### PR TITLE
Properly close kafka server connections in attempt to solve errors after inactivity

### DIFF
--- a/src/operator/config/default/manager_config_patch.yaml
+++ b/src/operator/config/default/manager_config_patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        otterize/tls-secret-name: spifferize-tls-controller-manager
+        otterize/tls-secret-name: tls-controller-manager
     spec:
       containers:
       - name: manager

--- a/src/operator/config/samples/otterize_v1alpha1_kafkaserverconfig.yaml
+++ b/src/operator/config/samples/otterize_v1alpha1_kafkaserverconfig.yaml
@@ -6,9 +6,9 @@ spec:
   serverName: kafka
   addr: kafka-tls-0.kafka-tls-headless.default.svc.cluster.local:9092
   tls:
-    certFile: /etc/spifferize/svid.pem
-    keyFile: /etc/spifferize/key.pem
-    rootCAFile: /etc/spifferize/bundle.pem
+    certFile: /etc/tls/svid.pem
+    keyFile: /etc/tls/key.pem
+    rootCAFile: /etc/tls/bundle.pem
   topics:
     - topic: "orders"
       pattern: literal

--- a/src/operator/controllers/kafkaacls/intentsAdmin.go
+++ b/src/operator/controllers/kafkaacls/intentsAdmin.go
@@ -94,6 +94,12 @@ func NewKafkaIntentsAdmin(kafkaServer otterizev1alpha1.KafkaServerConfig) (*Kafk
 	return &KafkaIntentsAdmin{kafkaServer: kafkaServer, kafkaAdminClient: a}, nil
 }
 
+func (a *KafkaIntentsAdmin) Close() {
+	if err := a.kafkaAdminClient.Close(); err != nil {
+		logrus.WithError(err).Error("Error closing kafka admin client")
+	}
+}
+
 func (a *KafkaIntentsAdmin) formatPrincipal(clientName string, clientNamespace string) string {
 	return fmt.Sprintf("User:CN=%s.%s,O=SPIRE,C=US", clientName, clientNamespace)
 }

--- a/src/operator/controllers/kafkaacls/serversStore.go
+++ b/src/operator/controllers/kafkaacls/serversStore.go
@@ -47,13 +47,9 @@ func (s *ServersStore) Get(serverName string, namespace string) (*KafkaIntentsAd
 	return NewKafkaIntentsAdmin(*config)
 }
 
-func (s *ServersStore) MapErr(f func(types.NamespacedName, *KafkaIntentsAdmin) error) error {
+func (s *ServersStore) MapErr(f func(types.NamespacedName, *v1alpha1.KafkaServerConfig) error) error {
 	for serverName, config := range s.serversByName {
-		a, err := NewKafkaIntentsAdmin(*config)
-		if err != nil {
-			return err
-		}
-		if err := f(serverName, a); err != nil {
+		if err := f(serverName, config); err != nil {
 			return err
 		}
 	}

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -45,7 +45,7 @@ type KafkaServerConfigReconciler struct {
 //+kubebuilder:rbac:groups=otterize.com,resources=kafkaserverconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=otterize.com,resources=kafkaserverconfigs/finalizers,verbs=update
 
-func (r *KafkaServerConfigReconciler) ensureFinalizerRun(ctx context.Context, kafkaServerConfig *otterizev1alpha1.KafkaServerConfig) (ctrl.Result, error) {
+func (r *KafkaServerConfigReconciler) removeKafkaServerFromStore(kafkaServerConfig *otterizev1alpha1.KafkaServerConfig) error {
 	logger := logrus.WithFields(
 		logrus.Fields{
 			"name":      kafkaServerConfig.Name,
@@ -53,25 +53,33 @@ func (r *KafkaServerConfigReconciler) ensureFinalizerRun(ctx context.Context, ka
 		},
 	)
 
+	intentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.ServerName, kafkaServerConfig.Namespace)
+	if err != nil && errors.Is(err, kafkaacls.ServerSpecNotFound) {
+		logger.Info("Kafka server not registered to servers store")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	defer intentsAdmin.Close()
+
+	logger.Info("Removing associated ACLs")
+	if err := intentsAdmin.RemoveAllIntents(); err != nil {
+		return err
+	}
+
+	logger.Info("Removing Kafka server from store")
+	r.ServersStore.Remove(kafkaServerConfig.Spec.ServerName, kafkaServerConfig.Namespace)
+	return nil
+}
+
+func (r *KafkaServerConfigReconciler) ensureFinalizerRun(ctx context.Context, kafkaServerConfig *otterizev1alpha1.KafkaServerConfig) (ctrl.Result, error) {
 	if !controllerutil.ContainsFinalizer(kafkaServerConfig, finalizerName) {
 		return ctrl.Result{}, nil
 	}
 
-	intentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.ServerName, kafkaServerConfig.Namespace)
-	if err != nil {
-		if !errors.Is(err, kafkaacls.ServerSpecNotFound) {
-			return ctrl.Result{}, err
-		} else {
-			logger.Info("Kafka server not registered to servers store")
-		}
-	} else {
-		logger.Info("Removing associated ACLs")
-		if err := intentsAdmin.RemoveAllIntents(); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		logger.Info("Removing Kafka server from store")
-		r.ServersStore.Remove(kafkaServerConfig.Spec.ServerName, kafkaServerConfig.Namespace)
+	if err := r.removeKafkaServerFromStore(kafkaServerConfig); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	controllerutil.RemoveFinalizer(kafkaServerConfig, finalizerName)
@@ -131,6 +139,7 @@ func (r *KafkaServerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	defer kafkaIntentsAdmin.Close()
 
 	if err := kafkaIntentsAdmin.ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics); err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
## Description
Properly close kafka server connections in attempt to solve errors after long periods of inactivity. 
This also fixes a few deployment issues following this PR: https://github.com/otterize/intents-operator/pull/8  (CC @orishoshan ) 


## Link to Dev Task
https://www.notion.so/otterize/intents-operator-Sarama-kafka-client-disconnects-without-recovery-after-a-period-of-inactivity-264662884e284747935753a5336082df
