### PR TITLE
Adjusted declared module name to match actual path

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/otterize/intents-operator
+module github.com/otterize/intents-operator/src
 
 go 1.18
 


### PR DESCRIPTION
## Description
The module name in the go.mod did not match the actual path after past repo structure changes.

