### PR TITLE
uncomment tls secret + add default empty secret

### DIFF
--- a/src/operator/config/default/manager_config_patch.yaml
+++ b/src/operator/config/default/manager_config_patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        otterize/tls-secret-name: tls-controller-manager
+        otterize/tls-secret-name: intents-operator-tls-controller-manager
     spec:
       containers:
       - name: manager

--- a/src/operator/config/manager/manager.yaml
+++ b/src/operator/config/manager/manager.yaml
@@ -68,13 +68,20 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-#        volumeMounts:
-#          - name: tls
-#            mountPath: /etc/tls
-#            readOnly: true
+        volumeMounts:
+          - name: tls
+            mountPath: /etc/tls
+            readOnly: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
-#      volumes:
-#        - name: tls
-#          secret:
-#            secretName: tls-controller-manager
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-controller-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: tls-controller-manager


### PR DESCRIPTION
## Description
Uncomment tls-controller-manager secret and create it as a default empty secret. This secret will be filled with certs if spire-integration-operator is deployed. Otherwise it will remain empty (and won't harm the controller unless tls certs are actually required). 


## Link to Dev Task
-
