### PR TITLE
Unify service ID resolver logic - intents-operator

### DIFF
--- a/src/operator/api/v1alpha1/otterize_labels.go
+++ b/src/operator/api/v1alpha1/otterize_labels.go
@@ -34,9 +34,9 @@ func UpdateOtterizeAccessLabels(pod *v1.Pod, otterizeAccessLabels map[string]str
 	return pod
 }
 
-func HasOtterizeServerLabel(pod *v1.Pod) bool {
-	_, exists := pod.Labels[OtterizeServerLabelKey]
-	return exists
+func HasOtterizeServerLabel(pod *v1.Pod, labelValue string) bool {
+	value, exists := pod.Labels[OtterizeServerLabelKey]
+	return exists && value == labelValue
 }
 
 func cleanupOtterizeLabelsAndAnnotations(pod *v1.Pod) *v1.Pod {

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -1,0 +1,63 @@
+package serviceidresolver
+
+import (
+	"context"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ServiceNameAnnotation = "otterize/service-name"
+)
+
+type Resolver struct {
+	client.Client
+}
+
+func NewResolver(c client.Client) *Resolver {
+	return &Resolver{c}
+}
+
+// ResolvePodToServiceIdentity resolves a pod object to its otterize service ID, referenced in intents objects.
+// This is done by recursion over the pod's owner reference hierarchy until reaching a root owner reference.
+// In case the pod is annotated with an "otterize/service-name" annotation, that annotation's value will override
+// any owner reference name as the service name.
+func (r *Resolver) ResolvePodToServiceIdentity(ctx context.Context, pod *corev1.Pod) (string, error) {
+	log := logrus.WithFields(logrus.Fields{"pod": pod.Name, "namespace": pod.Namespace})
+
+	annotatedServiceName, ok := pod.Annotations[ServiceNameAnnotation]
+	if ok {
+		return annotatedServiceName, nil
+	}
+
+	var obj client.Object
+	obj = pod
+	for len(obj.GetOwnerReferences()) > 0 {
+		owner := obj.GetOwnerReferences()[0]
+		ownerObj := &unstructured.Unstructured{}
+		ownerObj.SetAPIVersion(owner.APIVersion)
+		ownerObj.SetKind(owner.Kind)
+		err := r.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: obj.GetNamespace()}, ownerObj)
+		if err != nil && errors.IsForbidden(err) {
+			// We don't have permissions for further resolving of the owner object,
+			// and so we treat it as the identity.
+			log.WithFields(logrus.Fields{"owner": owner.Name, "ownerKind": obj.GetObjectKind().GroupVersionKind()}).Warning(
+				"permission error resolving owner, will use owner object as service identifier",
+			)
+			return owner.Name, nil
+		} else if err != nil {
+			return "", fmt.Errorf("error querying owner reference: %w", err)
+		}
+
+		// recurse parent owner reference
+		obj = ownerObj
+	}
+
+	log.WithFields(logrus.Fields{"owner": obj.GetName(), "ownerKind": obj.GetObjectKind().GroupVersionKind()}).Info("pod resolved to owner name")
+	return obj.GetName(), nil
+}

--- a/src/watcher/deployment.yaml
+++ b/src/watcher/deployment.yaml
@@ -18,5 +18,5 @@ spec:
       serviceAccountName: otterize-pod-watcher
       containers:
         - name: otterize-pod-watcher
-          image: 353146681200.dkr.ecr.us-east-1.amazonaws.com/otterize:watcher-0.0.6
+          image: 353146681200.dkr.ecr.us-east-1.amazonaws.com/otterize:watcher-latest
           imagePullPolicy: Always

--- a/src/watcher/reconcilers/pods.go
+++ b/src/watcher/reconcilers/pods.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	otterizev1alpha1 "github.com/otterize/intents-operator/src/operator/api/v1alpha1"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -17,21 +16,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const (
-	OwnerTypeReplicaSet  = "ReplicaSet"
-	OwnerTypeStatefulSet = "StatefulSet"
-	OwnerTypeDaemonSet   = "DaemonSet"
-	OwnerTypeDeployment  = "Deployment"
-)
-
 const OtterizeClientNameIndexField = "spec.service.name"
 
 type PodWatcher struct {
 	client.Client
+	serviceIdResolver *serviceidresolver.Resolver
 }
 
 func NewPodWatcher(c client.Client) *PodWatcher {
-	return &PodWatcher{c}
+	return &PodWatcher{Client: c, serviceIdResolver: serviceidresolver.NewResolver(c)}
 }
 
 func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -47,17 +40,17 @@ func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	otterizeServiceIdentity, err := p.resolvePodToOtterizeIdentity(ctx, &pod)
+	serviceID, err := p.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &pod)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if !otterizev1alpha1.HasOtterizeServerLabel(&pod) {
+	otterizeServerLabelValue := otterizev1alpha1.GetFormattedOtterizeIdentity(serviceID, pod.Namespace)
+	if !otterizev1alpha1.HasOtterizeServerLabel(&pod, otterizeServerLabelValue) {
 		// Label pods as destination servers
-		logrus.Infof("Labeling pod %s with server identity %s", pod.Name, otterizeServiceIdentity.Name)
+		logrus.Infof("Labeling pod %s with server identity %s", pod.Name, serviceID)
 		updatedPod := pod.DeepCopy()
-		updatedPod.Labels[otterizev1alpha1.OtterizeServerLabelKey] =
-			otterizev1alpha1.GetFormattedOtterizeIdentity(otterizeServiceIdentity.Name, otterizeServiceIdentity.Namespace)
+		updatedPod.Labels[otterizev1alpha1.OtterizeServerLabelKey] = otterizeServerLabelValue
 
 		err := p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
 		if err != nil {
@@ -77,12 +70,12 @@ func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	var intents otterizev1alpha1.IntentsList
 	err = p.List(
 		ctx, &intents,
-		&client.MatchingFields{OtterizeClientNameIndexField: otterizeServiceIdentity.Name},
-		&client.ListOptions{Namespace: otterizeServiceIdentity.Namespace})
+		&client.MatchingFields{OtterizeClientNameIndexField: serviceID},
+		&client.ListOptions{Namespace: pod.Namespace})
 
 	if err != nil {
 		logrus.Errorln("Failed listing intents", "Service name",
-			otterizeServiceIdentity.Name, "Namespace", otterizeServiceIdentity.Namespace)
+			serviceID, "Namespace", pod.Namespace)
 		return ctrl.Result{}, err
 	}
 
@@ -92,13 +85,13 @@ func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	otterizeAccessLabels := map[string]string{}
 	for _, intent := range intents.Items {
-		currIntentLabels := intent.GetIntentsLabelMapping(otterizeServiceIdentity.Namespace)
+		currIntentLabels := intent.GetIntentsLabelMapping(pod.Namespace)
 		for k, v := range currIntentLabels {
 			otterizeAccessLabels[k] = v
 		}
 	}
 	if otterizev1alpha1.IsMissingOtterizeAccessLabels(&pod, otterizeAccessLabels) {
-		logrus.Infof("Updating Otterize access labels for %s", otterizeServiceIdentity.Name)
+		logrus.Infof("Updating Otterize access labels for %s", serviceID)
 		updatedPod := otterizev1alpha1.UpdateOtterizeAccessLabels(pod.DeepCopy(), otterizeAccessLabels)
 		err := p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
 		if err != nil {
@@ -128,42 +121,6 @@ func (p *PodWatcher) InitIntentsClientIndices(mgr manager.Manager) error {
 	}
 
 	return nil
-}
-
-func (p *PodWatcher) resolvePodToOtterizeIdentity(ctx context.Context, pod *v1.Pod) (*types.NamespacedName, error) {
-	var otterizeIdentity string
-	var ownerKind client.Object
-	for _, owner := range pod.OwnerReferences {
-		namespacedName := types.NamespacedName{Name: owner.Name, Namespace: pod.Namespace}
-		switch owner.Kind {
-		case OwnerTypeReplicaSet:
-			ownerKind = &appsv1.ReplicaSet{}
-		case OwnerTypeDaemonSet:
-			ownerKind = &appsv1.DaemonSet{}
-		case OwnerTypeStatefulSet:
-			ownerKind = &appsv1.StatefulSet{}
-		case OwnerTypeDeployment:
-			ownerKind = &appsv1.Deployment{}
-		default:
-			logrus.Infof("Unknown owner kind %s for pod %s", owner.Kind, pod.Name)
-		}
-		err := p.Get(ctx, namespacedName, ownerKind)
-		if err != nil {
-			return nil, err
-		}
-		otterizeIdentity = p.getOtterizeIdentityFromObject(ownerKind)
-		return &types.NamespacedName{Name: otterizeIdentity, Namespace: pod.Namespace}, nil
-	}
-
-	return nil, fmt.Errorf("pod %s has no owner", pod.Name)
-}
-
-func (p *PodWatcher) getOtterizeIdentityFromObject(obj client.Object) string {
-	owners := obj.GetOwnerReferences()
-	if len(owners) != 0 {
-		return owners[0].Name
-	}
-	return obj.GetName()
 }
 
 func (w *PodWatcher) Register(mgr manager.Manager) error {


### PR DESCRIPTION
## Description
Implement the service ID resolving logic once in the intents-operator. 
This implementation will be referred to by intents-observer and spire-integration-operator (PRs coming up after this is merged). 


## Link to Dev Task
https://www.notion.so/otterize/Make-algorithm-for-resolving-service-name-the-same-in-SPIRE-operator-intents-operator-and-k8s-sniff-75ef5834eab2401da4a3538c896aaab8
