### PR TITLE
Fix client intents CRD - rename fail

### DIFF
--- a/src/operator/config/crd/kustomization.yaml
+++ b/src/operator/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/k8s.otterize.com_intents.yaml
+- bases/k8s.otterize.com_clientintents.yaml
 - bases/k8s.otterize.com_kafkaserverconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 

--- a/src/operator/config/crd/patches/cainjection_in_intents.yaml
+++ b/src/operator/config/crd/patches/cainjection_in_intents.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: intents.otterize.com
+  name: clientintents.k8s.otterize.com

--- a/src/operator/config/crd/patches/webhook_in_intents.yaml
+++ b/src/operator/config/crd/patches/webhook_in_intents.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: intents.otterize.com
+  name: clientintents.k8s.otterize.com
 spec:
   conversion:
     strategy: Webhook


### PR DESCRIPTION
## Description
Fix client intents CRD - rename fail


## Link to Dev Task
https://www.notion.so/otterize/Align-intents-format-between-network-mapper-intents-operator-d876042fd81a40f08e52ff47dd43e862