### PR TITLE
Fixed orphaned netpol when editing target server in intents

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -36,7 +36,7 @@ func NewIntentsReconciler(client client.Client, scheme *runtime.Scheme, kafkaSer
 	return &IntentsReconciler{
 		group: reconcilergroup.NewGroup("intents-reconciler", client, scheme,
 			&intents_reconcilers.PodLabelReconciler{Client: client, Scheme: scheme},
-			&intents_reconcilers.NetworkPolicyReconciler{Client: client, Scheme: scheme, RestrictToNamespaces: restrictToNamespaces},
+			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, restrictToNamespaces),
 			&intents_reconcilers.KafkaACLsReconciler{Client: client, Scheme: scheme, KafkaServersStore: kafkaServerStore},
 		)}
 }

--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -29,6 +29,14 @@ type NetworkPolicyReconciler struct {
 	injectablerecorder.InjectableRecorder
 }
 
+func NewNetworkPolicyReconciler(c client.Client, s *runtime.Scheme, restrictToNamespaces []string) *NetworkPolicyReconciler {
+	return &NetworkPolicyReconciler{
+		Client:               c,
+		Scheme:               s,
+		RestrictToNamespaces: restrictToNamespaces,
+	}
+}
+
 func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	intents := &otterizev1alpha1.ClientIntents{}
 	err := r.Get(ctx, req.NamespacedName, intents)
@@ -114,16 +122,19 @@ func (r *NetworkPolicyReconciler) handleNetworkPolicyCreation(
 	}
 
 	// Found network policy, check for diff
-	if reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) {
-		return nil
-	}
+	if !reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) {
+		policyCopy := existingPolicy.DeepCopy()
+		policyCopy.Spec = newPolicy.Spec
 
-	policyCopy := existingPolicy.DeepCopy()
-	policyCopy.Spec = newPolicy.Spec
+		err = r.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
+		if err != nil {
+			return err
+		}
 
-	err = r.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
-	if err != nil {
-		return err
+		err = r.handleNetworkPolicyRemoval(ctx, intent, intentsObjNamespace)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -140,25 +151,9 @@ func (r *NetworkPolicyReconciler) cleanFinalizerAndPolicies(
 			intent.Namespace = intents.Namespace
 		}
 
-		var intentsList otterizev1alpha1.ClientIntentsList
-		err := r.List(
-			ctx, &intentsList,
-			&client.MatchingFields{otterizev1alpha1.OtterizeTargetServerIndexField: intent.Name},
-			&client.ListOptions{Namespace: intents.Namespace})
-
+		err := r.handleNetworkPolicyRemoval(ctx, intent, intents.Namespace)
 		if err != nil {
 			return err
-		}
-
-		if len(intentsList.Items) == 1 {
-			// We have only 1 intents resource that has this server as its target - and it's the current one
-			// We need to delete the network policy that allows access from this namespace, as there are no other
-			// clients in that namespace that need to access the target server
-			logrus.Infof("No other intents in the namespace reference target server: %s", intent.Name)
-			logrus.Infoln("Removing matching network policy for server")
-			if err = r.removeNetworkPolicy(ctx, intent, intents.Namespace); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -170,7 +165,35 @@ func (r *NetworkPolicyReconciler) cleanFinalizerAndPolicies(
 	return nil
 }
 
-func (r *NetworkPolicyReconciler) removeNetworkPolicy(
+func (r *NetworkPolicyReconciler) handleNetworkPolicyRemoval(
+	ctx context.Context,
+	intent otterizev1alpha1.Intent,
+	intentsObjNamespace string) error {
+
+	var intentsList otterizev1alpha1.ClientIntentsList
+	err := r.List(
+		ctx, &intentsList,
+		&client.MatchingFields{otterizev1alpha1.OtterizeTargetServerIndexField: intent.Name},
+		&client.ListOptions{Namespace: intentsObjNamespace})
+
+	if err != nil {
+		return err
+	}
+
+	if len(intentsList.Items) == 1 {
+		// We have only 1 intents resource that has this server as its target - and it's the current one
+		// We need to delete the network policy that allows access from this namespace, as there are no other
+		// clients in that namespace that need to access the target server
+		logrus.Infof("No other intents in the namespace reference target server: %s", intent.Name)
+		logrus.Infoln("Removing matching network policy for server")
+		if err = r.deleteNetworkPolicy(ctx, intent, intentsObjNamespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *NetworkPolicyReconciler) deleteNetworkPolicy(
 	ctx context.Context,
 	intent otterizev1alpha1.Intent,
 	intentsObjNamespace string) error {


### PR DESCRIPTION
## Description
Fixed orphaned netpol when editing target server in intents


## Link to Dev Task
[Related issue](https://www.notion.so/otterize/When-applying-an-intents-file-with-client-server-and-then-changing-the-intent-to-client-server2-the--15340616c9234162968d7a55a8bfa6ef) 
