### PR TITLE
Will skip kafka finalizer for intents if no rule of type 'Kafka' exists

### DIFF
--- a/src/operator/api/v1alpha1/intents_types.go
+++ b/src/operator/api/v1alpha1/intents_types.go
@@ -195,3 +195,12 @@ func (in *ClientIntents) BuildPodLabelSelector() (labels.Selector, error) {
 
 	return labelSelector, nil
 }
+
+func (in *ClientIntents) HasKafkaTypeInCallList() bool {
+	for _, intent := range in.GetCallsList() {
+		if intent.Type == IntentTypeKafka {
+			return true
+		}
+	}
+	return false
+}

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -114,7 +114,7 @@ func (r *KafkaACLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if intents.ObjectMeta.DeletionTimestamp.IsZero() {
-		if !controllerutil.ContainsFinalizer(intents, KafkaACLsFinalizerName) {
+		if !controllerutil.ContainsFinalizer(intents, KafkaACLsFinalizerName) && intents.HasKafkaTypeInCallList() {
 			logger.Infof("Adding finalizer %s", KafkaACLsFinalizerName)
 			controllerutil.AddFinalizer(intents, KafkaACLsFinalizerName)
 			if err := r.client.Update(ctx, intents); err != nil {


### PR DESCRIPTION
## Description
Will skip kafka finalizer for intents if no rule of type 'Kafka' exists



## Link to Dev Task
[Related issue ](https://www.notion.so/otterize/Cannot-remove-intents-when-intents-operator-is-unable-to-connect-to-a-Kafka-server-to-reconcile-ACLs-413597e8b9ce4a1ea9e49311372295a6)
