### PR TITLE
Move Kafka TLS config to operator config

### DIFF
--- a/src/operator/api/v1alpha1/kafkaserverconfig_types.go
+++ b/src/operator/api/v1alpha1/kafkaserverconfig_types.go
@@ -23,9 +23,12 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type TLSSource struct {
-	CertFile   string `json:"certFile,omitempty" yaml:"certFile,omitempty"`
-	KeyFile    string `json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
-	RootCAFile string `json:"rootCAFile,omitempty" yaml:"rootCAFile,omitempty"`
+	// +kubebuilder:validation:Required
+	CertFile string `json:"certFile" yaml:"certFile"`
+	// +kubebuilder:validation:Required
+	KeyFile string `json:"keyFile" yaml:"keyFile"`
+	// +kubebuilder:validation:Required
+	RootCAFile string `json:"rootCAFile" yaml:"rootCAFile"`
 }
 
 type ResourcePatternType string
@@ -50,10 +53,11 @@ type KafkaServerConfigSpec struct {
 	Service Service `json:"service,omitempty" yaml:"service,omitempty"`
 	// If Intents for network policies are enabled, and there are other Intents to this Kafka server,
 	// will automatically create an Intent so that the Intents Operator can connect. Set to true to disable.
-	NoAutoCreateIntentsForOperator bool          `json:"noAutoCreateIntentsForOperator,omitempty" yaml:"noAutoCreateIntentsForOperator,omitempty"`
-	Addr                           string        `json:"addr,omitempty" yaml:"addr,omitempty"`
-	TLS                            TLSSource     `json:"tls" yaml:"tls"`
-	Topics                         []TopicConfig `json:"topics,omitempty" yaml:"topics,omitempty"`
+	NoAutoCreateIntentsForOperator bool   `json:"noAutoCreateIntentsForOperator,omitempty" yaml:"noAutoCreateIntentsForOperator,omitempty"`
+	Addr                           string `json:"addr,omitempty" yaml:"addr,omitempty"`
+	// +kubebuilder:validation:Optional
+	TLS    TLSSource     `json:"tls,omitempty" yaml:"tls,omitempty"`
+	Topics []TopicConfig `json:"topics,omitempty" yaml:"topics,omitempty"`
 }
 
 // KafkaServerConfigStatus defines the observed state of KafkaServerConfig

--- a/src/operator/config/crd/bases/k8s.otterize.com_kafkaserverconfigs.yaml
+++ b/src/operator/config/crd/bases/k8s.otterize.com_kafkaserverconfigs.yaml
@@ -58,6 +58,10 @@ spec:
                     type: string
                   rootCAFile:
                     type: string
+                required:
+                - certFile
+                - keyFile
+                - rootCAFile
                 type: object
               topics:
                 items:
@@ -77,8 +81,6 @@ spec:
                   - topic
                   type: object
                 type: array
-            required:
-            - tls
             type: object
           status:
             description: KafkaServerConfigStatus defines the observed state of KafkaServerConfig

--- a/src/operator/config/manager/manager.yaml
+++ b/src/operator/config/manager/manager.yaml
@@ -32,6 +32,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --kafka-server-tls-cert=/etc/tls/svid.pem
+        - --kafka-server-tls-key=/etc/tls/key.pem
+        - --kafka-server-tls-ca=/etc/tls/bundle.pem
         image: controller:latest
         name: manager
         imagePullPolicy: Always

--- a/src/operator/config/samples/otterize_v1alpha1_kafkaserverconfig.yaml
+++ b/src/operator/config/samples/otterize_v1alpha1_kafkaserverconfig.yaml
@@ -6,10 +6,6 @@ spec:
   service:
     name: kafka
   addr: kafka-tls-0.kafka-tls-headless.default.svc.cluster.local:9092
-  tls:
-    certFile: /etc/tls/svid.pem
-    keyFile: /etc/tls/key.pem
-    rootCAFile: /etc/tls/bundle.pem
   topics:
     - topic: "orders"
       pattern: literal

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -60,8 +60,8 @@ func getIntentsByServer(defaultNamespace string, intents []otterizev1alpha1.Inte
 func (r *KafkaACLReconciler) applyACLs(intents *otterizev1alpha1.ClientIntents) (serverCount int, err error) {
 	intentsByServer := getIntentsByServer(intents.Namespace, intents.Spec.Calls)
 
-	if err := r.KafkaServersStore.MapErr(func(serverName types.NamespacedName, config *otterizev1alpha1.KafkaServerConfig) error {
-		kafkaIntentsAdmin, err := kafkaacls.NewKafkaIntentsAdmin(*config, r.enableKafkaACLCreation)
+	if err := r.KafkaServersStore.MapErr(func(serverName types.NamespacedName, config *otterizev1alpha1.KafkaServerConfig, tls otterizev1alpha1.TLSSource) error {
+		kafkaIntentsAdmin, err := kafkaacls.NewKafkaIntentsAdmin(*config, tls, r.enableKafkaACLCreation)
 		if err != nil {
 			err = fmt.Errorf("failed to connect to Kafka server %s: %w", serverName, err)
 			r.RecordWarningEventf(intents, ReasonCouldNotConnectToKafkaServer, "Kafka ACL reconcile failed: %s", err.Error())
@@ -94,8 +94,8 @@ func (r *KafkaACLReconciler) applyACLs(intents *otterizev1alpha1.ClientIntents) 
 }
 
 func (r *KafkaACLReconciler) RemoveACLs(intents *otterizev1alpha1.ClientIntents) error {
-	return r.KafkaServersStore.MapErr(func(serverName types.NamespacedName, config *otterizev1alpha1.KafkaServerConfig) error {
-		kafkaIntentsAdmin, err := kafkaacls.NewKafkaIntentsAdmin(*config, r.enableKafkaACLCreation)
+	return r.KafkaServersStore.MapErr(func(serverName types.NamespacedName, config *otterizev1alpha1.KafkaServerConfig, tls otterizev1alpha1.TLSSource) error {
+		kafkaIntentsAdmin, err := kafkaacls.NewKafkaIntentsAdmin(*config, tls, r.enableKafkaACLCreation)
 		if err != nil {
 			return err
 		}

--- a/src/operator/controllers/kafkaacls/serversStore.go
+++ b/src/operator/controllers/kafkaacls/serversStore.go
@@ -13,12 +13,14 @@ var (
 type ServersStore struct {
 	serversByName          map[types.NamespacedName]*otterizev1alpha1.KafkaServerConfig
 	enableKafkaACLCreation bool
+	tlsSourceFiles         otterizev1alpha1.TLSSource
 }
 
-func NewServersStore(enableKafkaACLCreation bool) *ServersStore {
+func NewServersStore(tlsSourceFiles otterizev1alpha1.TLSSource, enableKafkaACLCreation bool) *ServersStore {
 	return &ServersStore{
 		serversByName:          map[types.NamespacedName]*otterizev1alpha1.KafkaServerConfig{},
 		enableKafkaACLCreation: enableKafkaACLCreation,
+		tlsSourceFiles:         tlsSourceFiles,
 	}
 }
 func (s *ServersStore) Add(config *otterizev1alpha1.KafkaServerConfig) {
@@ -46,12 +48,12 @@ func (s *ServersStore) Get(serverName string, namespace string) (*KafkaIntentsAd
 		return nil, ServerSpecNotFound
 	}
 
-	return NewKafkaIntentsAdmin(*config, s.enableKafkaACLCreation)
+	return NewKafkaIntentsAdmin(*config, s.tlsSourceFiles, s.enableKafkaACLCreation)
 }
 
-func (s *ServersStore) MapErr(f func(types.NamespacedName, *otterizev1alpha1.KafkaServerConfig) error) error {
+func (s *ServersStore) MapErr(f func(types.NamespacedName, *otterizev1alpha1.KafkaServerConfig, otterizev1alpha1.TLSSource) error) error {
 	for serverName, config := range s.serversByName {
-		if err := f(serverName, config); err != nil {
+		if err := f(serverName, config, s.tlsSourceFiles); err != nil {
 			return err
 		}
 	}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -71,9 +71,13 @@ func main() {
 	var enableNetworkPolicyCreation bool
 	var enableKafkaACLCreation bool
 	var disableWebhookServer bool
+	var tlsSource otterizev1alpha1.TLSSource
 
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	pflag.StringVar(&tlsSource.CertFile, "kafka-server-tls-cert", "", "name of tls certificate file")
+	pflag.StringVar(&tlsSource.KeyFile, "kafka-server-tls-key", "", "name of tls private key file")
+	pflag.StringVar(&tlsSource.RootCAFile, "kafka-server-tls-ca", "", "name of tls ca file")
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -130,7 +134,7 @@ func main() {
 		logrus.WithError(err).Fatal(err, "unable to start manager")
 	}
 
-	kafkaServersStore := kafkaacls.NewServersStore(enableKafkaACLCreation)
+	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enableKafkaACLCreation)
 
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), mgr.GetScheme(), autoCreateNetworkPoliciesForExternalTraffic)
 


### PR DESCRIPTION
## Description
TLS files configuration is unique per every instance of intents operator, so no reason for it to be duplicated per each instance of KfakaServerConfig.

Therfore this commit move tls config from kafka server config to the operator configuration.

## Link to Dev Task
[Simplify KafkaServerConfig default config](https://www.notion.so/otterize/Simplify-KafkaServerConfig-default-config-8433c1aded0e4e8da116efa008a5998d)