### PR TITLE
fix webhook name

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -175,7 +175,7 @@ func main() {
 			logrus.WithError(err).Fatal("failed writing certs to file system")
 		}
 		err = webhooks.UpdateWebHookCA(context.Background(),
-			"intents-operator-validating-webhook-configuration", certBundle.CertPem)
+			"validating-webhook-configuration", certBundle.CertPem)
 		if err != nil {
 			logrus.WithError(err).Fatal("updating webhook certificate failed")
 		}


### PR DESCRIPTION
## Description
Fixed webhook name


## Link to Dev Task
[Issue](https://www.notion.so/otterize/Validating-webhook-cert-update-fails-on-wrong-target-name-4e8fd22a9fd944fe98f18a41a35c085f)
