### PR TITLE
Adding owner object function

### DIFF
--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -29,7 +29,7 @@ func ResolvePodToServiceIdentityUsingAnnotationOnly(pod *corev1.Pod) (string, bo
 }
 
 // ResolvePodToServiceIdentity resolves a pod object to its otterize service ID, referenced in intents objects.
-// This is done by recursion over the pod's owner reference hierarchy until reaching a root owner reference.
+// It calls getOwnerObject to recursively iterates over the pod's owner reference hierarchy until reaching a root owner reference.
 // In case the pod is annotated with an "intents.otterize.com/service-name" annotation, that annotation's value will override
 // any owner reference name as the service name.
 func (r *Resolver) ResolvePodToServiceIdentity(ctx context.Context, pod *corev1.Pod) (string, error) {
@@ -45,6 +45,8 @@ func (r *Resolver) ResolvePodToServiceIdentity(ctx context.Context, pod *corev1.
 	return ownerObj.GetName(), nil
 }
 
+// getOwnerObject recursively iterates over the pod's owner reference hierarchy until reaching a root owner reference
+// and returns it.
 func (r *Resolver) getOwnerObject(ctx context.Context, pod *corev1.Pod) (client.Object, error) {
 	log := logrus.WithFields(logrus.Fields{"pod": pod.Name, "namespace": pod.Namespace})
 	var obj client.Object


### PR DESCRIPTION
### Description
Refactoring the `ResolvePodToServiceIdentity` function to call another function that returns the owner object (instead of just the name). This adds flexibility if other dependent projects require the owner's kind as well as the name.
