### PR TITLE
Handle Kafka intents with no topics as if they allow all topics

### DIFF
--- a/src/operator/api/v1alpha1/intents_types.go
+++ b/src/operator/api/v1alpha1/intents_types.go
@@ -117,7 +117,8 @@ type HTTPResource struct {
 }
 
 type KafkaTopic struct {
-	Name       string           `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name"`
+	//+optional
 	Operations []KafkaOperation `json:"operations" yaml:"operations"`
 }
 

--- a/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
@@ -88,7 +88,6 @@ spec:
                             type: array
                         required:
                         - name
-                        - operations
                         type: object
                       type: array
                     type:

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -202,6 +202,54 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLGetCreatedAndUpdatedBasedOnInt
 	s.reconcile(namespacedName)
 }
 
+func (s *KafkaACLReconcilerTestSuite) TestKafkaACLCreateByIntentWithNoResourcesCreatesACLForAllTopics() {
+	// Expected Acl for consume operation
+	resource := sarama.Resource{
+		ResourceType:        sarama.AclResourceTopic,
+		ResourceName:        "*",
+		ResourcePatternType: sarama.AclPatternLiteral,
+	}
+
+	createAclOperation := sarama.Acl{
+		Principal:      s.principal(),
+		Host:           "*",
+		Operation:      sarama.AclOperationAll,
+		PermissionType: sarama.AclPermissionAllow,
+	}
+
+	createACL := sarama.ResourceAcls{
+		Resource: resource,
+		Acls:     []*sarama.Acl{&createAclOperation},
+	}
+
+	aclForAll := []*sarama.ResourceAcls{&createACL}
+
+	s.mockKafkaAdmin.EXPECT().ListAcls(gomock.Any()).Return([]sarama.ResourceAcls{}, nil).Times(1)
+	s.mockKafkaAdmin.EXPECT().CreateACLs(MatchSaramaResource(aclForAll)).Return(nil)
+	s.mockKafkaAdmin.EXPECT().ListAcls(gomock.Any()).Return([]sarama.ResourceAcls{createACL}, nil).Times(1)
+	s.mockKafkaAdmin.EXPECT().Close().Times(1)
+
+	// Create intents object with Consume operation
+	intents := []otterizev1alpha1.Intent{{
+		Name:      kafkaServiceName,
+		Type:      otterizev1alpha1.IntentTypeKafka,
+		Namespace: s.TestNamespace,
+	},
+	}
+
+	clientIntents, err := s.AddIntents(intentsObjectName, clientName, intents)
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	namespacedName := types.NamespacedName{
+		Namespace: s.TestNamespace,
+		Name:      clientIntents.Name,
+	}
+
+	s.reconcile(namespacedName)
+
+}
+
 func (s *KafkaACLReconcilerTestSuite) TestKafkaACLDeletedAfterIntentsRemoved() {
 	// Expected Acl for consume operation
 	resource := sarama.Resource{

--- a/src/operator/controllers/kafkaacls/intentsAdmin.go
+++ b/src/operator/controllers/kafkaacls/intentsAdmin.go
@@ -314,6 +314,12 @@ func (a *KafkaIntentsAdminImpl) ApplyClientIntents(clientName string, clientName
 	appliedIntentKafkaAcls, err := a.collectTopicsToACLList(principal, appliedIntentKafkaTopics)
 	expectedIntentKafkaTopics := lo.Flatten(
 		lo.Map(intents, func(intent otterizev1alpha1.Intent, _ int) []otterizev1alpha1.KafkaTopic {
+			// If no topics, then consider intent to apply to all topics.
+			if len(intent.Topics) == 0 {
+				return []otterizev1alpha1.KafkaTopic{
+					{Name: "*", Operations: []otterizev1alpha1.KafkaOperation{otterizev1alpha1.KafkaOperationAll}},
+				}
+			}
 			return intent.Topics
 		}),
 	)

--- a/src/operator/controllers/kafkaacls/intentsAdmin.go
+++ b/src/operator/controllers/kafkaacls/intentsAdmin.go
@@ -218,6 +218,9 @@ func (a *KafkaIntentsAdminImpl) collectTopicsToACLList(principal string, topics 
 			ResourcePatternType: sarama.AclPatternLiteral,
 		}
 		acls := make([]sarama.Acl, 0)
+		if len(topic.Operations) == 0 {
+			topic.Operations = append(topic.Operations, otterizev1alpha1.KafkaOperationAll)
+		}
 		for _, operation := range topic.Operations {
 			operation, ok := KafkaOperationToAclOperationBMap.Get(operation)
 			if !ok {

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -29,6 +29,7 @@ import (
 const waitForCreationInterval = 20 * time.Millisecond
 const waitForCreationTimeout = 10 * time.Second
 const waitForDeletionTSTimeout = 3 * time.Second
+const maxNamespaceLength = 63
 
 type ControllerManagerTestSuiteBase struct {
 	suite.Suite
@@ -61,7 +62,7 @@ func (s *ControllerManagerTestSuiteBase) BeforeTest(_, testName string) {
 		s.Require().NoError(err)
 	}()
 
-	s.TestNamespace = strings.ToLower(fmt.Sprintf("%s-%s", testName, time.Now().Format("20060102150405")))
+	s.TestNamespace = strings.ToLower(fmt.Sprintf("%s-%s", testName, time.Now().Format("20060102150405")))[:maxNamespaceLength]
 	testNamespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: s.TestNamespace},
 	}


### PR DESCRIPTION
Previously, Kafka intents with no topics would simply not allow any access. Intents that are not specific about which resources are allowed should allow all access of the kind that isn't specified. For example, a HTTP intent with no HTTP method or path specified just means that you can access using HTTP, to any path and any method.

Similarly, a Kafka intent with no topics or operations specified should create an ACL that allows access to all topics and operations, and a Kafka intent with only the topic name specified should create an ACL that allows all operations for that topic.