### PR TITLE
Removing report namespace route and logic from cloud reconciler

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
@@ -10,7 +10,6 @@ import (
 )
 
 type CloudClient interface {
-	ReportKubernetesNamespace(ctx context.Context, namespace string) error
 	ReportKafkaServerConfig(ctx context.Context, namespace string, source string, server graphqlclient.KafkaServerConfigInput) error
 	ReportAppliedIntents(ctx context.Context, namespace string, clientIntentsList otterizev1alpha1.ClientIntentsList) error
 }
@@ -28,18 +27,6 @@ func NewClient(ctx context.Context) (CloudClient, bool, error) {
 	}
 
 	return &CloudClientImpl{client: client}, true, nil
-}
-
-func (c *CloudClientImpl) ReportKubernetesNamespace(ctx context.Context, namespace string) error {
-	res, err := graphqlclient.ReportKubernetesNamespace(ctx, c.client, namespace)
-	if err != nil {
-		return err
-	}
-	// Return value is bool - returns true if anything was updated in the DB
-	if res.ReportKubernetesNamespace {
-		logrus.Infof("Successfully reported namespace # %s # to Otterize cloud", namespace)
-	}
-	return nil
 }
 
 func (c *CloudClientImpl) ReportKafkaServerConfig(ctx context.Context, namespace string, source string, server graphqlclient.KafkaServerConfigInput) error {

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -285,11 +285,6 @@ func (r *KafkaServerConfigReconciler) uploadKafkaServerConfig(ctx context.Contex
 		return nil
 	}
 
-	err := r.otterizeClient.ReportKubernetesNamespace(ctx, kafkaServerConfig.Namespace)
-	if err != nil {
-		return err
-	}
-
 	input := graphqlclient.KafkaServerConfigInput{
 		Name:    kafkaServerConfig.Spec.Service.Name,
 		Address: kafkaServerConfig.Spec.Addr,
@@ -303,7 +298,7 @@ func (r *KafkaServerConfigReconciler) uploadKafkaServerConfig(ctx context.Contex
 		}),
 	}
 
-	err = r.otterizeClient.ReportKafkaServerConfig(ctx, kafkaServerConfig.Namespace, IntentsOperatorSource, input)
+	err := r.otterizeClient.ReportKafkaServerConfig(ctx, kafkaServerConfig.Namespace, IntentsOperatorSource, input)
 	if err != nil {
 		return err
 	}

--- a/src/operator/controllers/kafkaserverconfig_controller_test.go
+++ b/src/operator/controllers/kafkaserverconfig_controller_test.go
@@ -147,7 +147,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigUpload() {
 	s.AddKafkaServerConfig(&kafkaServerConfig)
 
 	// Set go mock expectations
-	s.mockCloudClient.EXPECT().ReportKubernetesNamespace(gomock.Any(), s.TestNamespace).Return(nil)
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(nil)
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil)
 	s.mockIntentsAdmin.EXPECT().Close()
@@ -165,18 +164,15 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestReUploadKafkaServerConfigOnFa
 	s.AddKafkaServerConfig(&kafkaServerConfig)
 
 	// Set go mock expectations for failure
-	s.mockCloudClient.EXPECT().ReportKubernetesNamespace(gomock.Any(), s.TestNamespace).Return(errors.New("failed to report namespace")).Times(1)
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close()
 
 	// Set go mock expectations for failure
-	s.mockCloudClient.EXPECT().ReportKubernetesNamespace(gomock.Any(), s.TestNamespace).Return(nil)
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(errors.New("failed to upload kafka server config"))
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close()
 
 	// Set go mock expectations
-	s.mockCloudClient.EXPECT().ReportKubernetesNamespace(gomock.Any(), s.TestNamespace).Return(nil).Times(1)
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close().Times(1)
@@ -195,7 +191,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigDelete() {
 	s.AddKafkaServerConfig(&kafkaServerConfig)
 
 	// Set go mock expectations
-	s.mockCloudClient.EXPECT().ReportKubernetesNamespace(gomock.Any(), s.TestNamespace).Return(nil).Times(1)
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close().Times(1)

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -159,16 +159,6 @@ func (v *ReportKafkaServerConfigResponse) GetReportKafkaServerConfig() bool {
 	return v.ReportKafkaServerConfig
 }
 
-// ReportKubernetesNamespaceResponse is returned by ReportKubernetesNamespace on success.
-type ReportKubernetesNamespaceResponse struct {
-	ReportKubernetesNamespace bool `json:"reportKubernetesNamespace"`
-}
-
-// GetReportKubernetesNamespace returns ReportKubernetesNamespaceResponse.ReportKubernetesNamespace, and is useful for accessing the field via an interface.
-func (v *ReportKubernetesNamespaceResponse) GetReportKubernetesNamespace() bool {
-	return v.ReportKubernetesNamespace
-}
-
 // __ReportAppliedKubernetesIntentsInput is used internally by genqlient
 type __ReportAppliedKubernetesIntentsInput struct {
 	Namespace string        `json:"namespace"`
@@ -196,14 +186,6 @@ func (v *__ReportKafkaServerConfigInput) GetSource() string { return v.Source }
 
 // GetServer returns __ReportKafkaServerConfigInput.Server, and is useful for accessing the field via an interface.
 func (v *__ReportKafkaServerConfigInput) GetServer() KafkaServerConfigInput { return v.Server }
-
-// __ReportKubernetesNamespaceInput is used internally by genqlient
-type __ReportKubernetesNamespaceInput struct {
-	Namespace string `json:"namespace"`
-}
-
-// GetNamespace returns __ReportKubernetesNamespaceInput.Namespace, and is useful for accessing the field via an interface.
-func (v *__ReportKubernetesNamespaceInput) GetNamespace() string { return v.Namespace }
 
 func ReportAppliedKubernetesIntents(
 	ctx context.Context,
@@ -260,36 +242,6 @@ mutation ReportKafkaServerConfig ($namespace: String!, $source: String!, $server
 	var err error
 
 	var data ReportKafkaServerConfigResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
-func ReportKubernetesNamespace(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-) (*ReportKubernetesNamespaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportKubernetesNamespace",
-		Query: `
-mutation ReportKubernetesNamespace ($namespace: String!) {
-	reportKubernetesNamespace(namespace: $namespace)
-}
-`,
-		Variables: &__ReportKubernetesNamespaceInput{
-			Namespace: namespace,
-		},
-	}
-	var err error
-
-	var data ReportKubernetesNamespaceResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/src/shared/otterizecloud/graphqlclient/genqlient.graphql
+++ b/src/shared/otterizecloud/graphqlclient/genqlient.graphql
@@ -1,7 +1,3 @@
-mutation ReportKubernetesNamespace($namespace: String!) {
-    reportKubernetesNamespace(namespace: $namespace)
-}
-
 mutation ReportKafkaServerConfig($namespace: String!, $source: String!, $server: KafkaServerConfigInput!) {
     reportKafkaServerConfig(namespace: $namespace, source: $source, serverConfig: $server)
 }

--- a/src/shared/otterizecloud/graphqlclient/genqlient.yaml
+++ b/src/shared/otterizecloud/graphqlclient/genqlient.yaml
@@ -3,7 +3,8 @@
 schema:
   - ../../../../graphql/root.graphql
   - ../../../../graphql/kafkaserverconfig.graphql
-  - ../../../../graphql/kubernetes.graphql
+  - ../../../../graphql/namespaces.graphql
+  - ../../../../graphql/clusters.graphql
   - ../../../../graphql/intents.graphql
   - ../../../../graphql/federation/federation-directives.graphql
 operations:

--- a/src/shared/otterizecloud/mocks/mock_cloud_api.go
+++ b/src/shared/otterizecloud/mocks/mock_cloud_api.go
@@ -63,17 +63,3 @@ func (mr *MockCloudClientMockRecorder) ReportKafkaServerConfig(ctx, namespace, s
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportKafkaServerConfig", reflect.TypeOf((*MockCloudClient)(nil).ReportKafkaServerConfig), ctx, namespace, source, server)
 }
-
-// ReportKubernetesNamespace mocks base method.
-func (m *MockCloudClient) ReportKubernetesNamespace(ctx context.Context, namespace string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportKubernetesNamespace", ctx, namespace)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReportKubernetesNamespace indicates an expected call of ReportKubernetesNamespace.
-func (mr *MockCloudClientMockRecorder) ReportKubernetesNamespace(ctx, namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportKubernetesNamespace", reflect.TypeOf((*MockCloudClient)(nil).ReportKubernetesNamespace), ctx, namespace)
-}


### PR DESCRIPTION
### Description
Removed namespace reporting and all its related features (`sync.Map` cache) from cloud reconciler