### PR TITLE
Added enable-enforcement=false flag that disables enforcement globally

### DIFF
--- a/src/operator/controllers/external_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/external_traffic/endpoints_reconciler.go
@@ -32,11 +32,11 @@ func (r *EndpointsReconciler) formatPolicyName(serviceName string) string {
 	return fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 }
 
-func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool) *EndpointsReconciler {
+func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool, globalEnforceSetting bool) *EndpointsReconciler {
 	return &EndpointsReconciler{
 		Client:        client,
 		Scheme:        scheme,
-		netpolCreator: NewNetworkPolicyCreator(client, scheme, enabled),
+		netpolCreator: NewNetworkPolicyCreator(client, scheme, enabled, globalEnforceSetting),
 	}
 }
 

--- a/src/operator/controllers/external_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/external_traffic/endpoints_reconciler.go
@@ -32,11 +32,11 @@ func (r *EndpointsReconciler) formatPolicyName(serviceName string) string {
 	return fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 }
 
-func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool, globalEnforceSetting bool) *EndpointsReconciler {
+func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool, enforcementEnabledGlobally bool) *EndpointsReconciler {
 	return &EndpointsReconciler{
 		Client:        client,
 		Scheme:        scheme,
-		netpolCreator: NewNetworkPolicyCreator(client, scheme, enabled, globalEnforceSetting),
+		netpolCreator: NewNetworkPolicyCreator(client, scheme, enabled, enforcementEnabledGlobally),
 	}
 }
 

--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	ReasonEnforcementGloballyDisabled         = "EnforcementGloballyDisabled"
 	ReasonCreatingExternalTrafficPolicyFailed = "CreatingExternalTrafficPolicyFailed"
 	ReasonCreatedExternalTrafficPolicy        = "CreatedExternalTrafficPolicy"
 	ReasonGettingExternalTrafficPolicyFailed  = "GettingExternalTrafficPolicyFailed"
@@ -53,7 +54,9 @@ func (r *NetworkPolicyCreator) handleNetworkPolicyCreationOrUpdate(
 
 	// No matching network policy found, create one
 	if k8serrors.IsNotFound(errGetExistingPolicy) {
-		if r.enforcementEnabledGlobally && r.enabled {
+		if !r.enforcementEnabledGlobally {
+			r.RecordNormalEventf(eventsObject, ReasonEnforcementGloballyDisabled, "Skipping created external traffic network policy for service '%s' because enforcement is globally disabled", endpoints.GetName())
+		} else if r.enabled {
 			logrus.Infof(
 				"Creating network policy to allow external traffic to %s (ns %s)", endpoints.GetName(), endpoints.GetNamespace())
 			err := r.client.Create(ctx, newPolicy)

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -41,13 +41,14 @@ func NewIntentsReconciler(
 	kafkaServerStore kafkaacls.ServersStore,
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
+	globalEnforceSetting bool,
 	enableNetworkPolicyCreation, enableKafkaACLCreation bool,
 	otterizeClient otterizecloud.CloudClient) *IntentsReconciler {
 	intentsReconciler := &IntentsReconciler{
 		group: reconcilergroup.NewGroup("intents-reconciler", client, scheme,
 			intents_reconcilers.NewPodLabelReconciler(client, scheme),
-			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enableNetworkPolicyCreation),
-			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin),
+			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enableNetworkPolicyCreation, globalEnforceSetting),
+			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, globalEnforceSetting),
 		)}
 
 	if otterizeClient != nil {

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -41,14 +41,14 @@ func NewIntentsReconciler(
 	kafkaServerStore kafkaacls.ServersStore,
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
-	globalEnforceSetting bool,
+	enforcementEnabledGlobally bool,
 	enableNetworkPolicyCreation, enableKafkaACLCreation bool,
 	otterizeClient otterizecloud.CloudClient) *IntentsReconciler {
 	intentsReconciler := &IntentsReconciler{
 		group: reconcilergroup.NewGroup("intents-reconciler", client, scheme,
 			intents_reconcilers.NewPodLabelReconciler(client, scheme),
-			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enableNetworkPolicyCreation, globalEnforceSetting),
-			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, globalEnforceSetting),
+			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enableNetworkPolicyCreation, enforcementEnabledGlobally),
+			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, enforcementEnabledGlobally),
 		)}
 
 	if otterizeClient != nil {

--- a/src/operator/controllers/intents_reconcilers/external_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_network_policy_test.go
@@ -48,10 +48,10 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.NetworkPolicyReconciler = NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true)
+	s.NetworkPolicyReconciler = NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true)
 	s.NetworkPolicyReconciler.InjectRecorder(recorder)
 
-	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true)
+	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, true)
 	s.endpointReconciler.InjectRecorder(recorder)
 	err := s.endpointReconciler.InitIngressReferencedServicesIndex(s.Mgr)
 	s.Require().NoError(err)

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -20,7 +20,6 @@ const (
 	KafkaACLsFinalizerName                  = "intents.otterize.com/kafka-finalizer"
 	ReasonCouldNotConnectToKafkaServer      = "CouldNotConnectToKafkaServer"
 	ReasonCouldNotApplyIntentsOnKafkaServer = "CouldNotApplyIntentsOnKafkaServer"
-	ReasonEnforcementDisabledGlobally       = "EnforcementDisabledGlobally"
 	ReasonKafkaACLCreationDisabled          = "KafkaACLCreationDisabled"
 	ReasonKafkaServerNotConfigured          = "KafkaServerNotConfigured"
 	ReasonRemovingKafkaACLsFailed           = "RemovingKafkaACLsFailed"

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -104,8 +104,8 @@ func (s *KafkaACLReconcilerTestSuite) principal() string {
 }
 
 func getMockIntentsAdminFactory(clusterAdmin sarama.ClusterAdmin, usernameMapping string) kafkaacls.IntentsAdminFactoryFunction {
-	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, globalEnforceSetting bool) (kafkaacls.KafkaIntentsAdmin, error) {
-		return kafkaacls.NewKafkaIntentsAdminImpl(kafkaServer, clusterAdmin, usernameMapping, enableKafkaACLCreation, globalEnforceSetting), nil
+	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, enforcementEnabledGlobally bool) (kafkaacls.KafkaIntentsAdmin, error) {
+		return kafkaacls.NewKafkaIntentsAdminImpl(kafkaServer, clusterAdmin, usernameMapping, enableKafkaACLCreation, enforcementEnabledGlobally), nil
 	}
 }
 

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -74,7 +74,7 @@ func (s *KafkaACLReconcilerTestSuite) setupServerStore(serviceName string) *kafk
 
 	serverConfig.SetNamespace(s.TestNamespace)
 	emptyTls := otterizev1alpha1.TLSSource{}
-	kafkaServersStore := kafkaacls.NewServersStore(emptyTls, true, kafkaacls.NewKafkaIntentsAdmin)
+	kafkaServersStore := kafkaacls.NewServersStore(emptyTls, true, kafkaacls.NewKafkaIntentsAdmin, true)
 	kafkaServersStore.Add(serverConfig)
 	return kafkaServersStore
 }
@@ -95,7 +95,7 @@ func (s *KafkaACLReconcilerTestSuite) BeforeTest(_, testName string) {
 func (s *KafkaACLReconcilerTestSuite) initKafkaIntentsAdmin(enableAclCreation bool) {
 	kafkaServersStore := s.setupServerStore(kafkaServiceName)
 	newTestKafkaIntentsAdmin := getMockIntentsAdminFactory(s.mockKafkaAdmin, usernameMapping)
-	s.Reconciler = NewKafkaACLReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, kafkaServersStore, enableAclCreation, newTestKafkaIntentsAdmin)
+	s.Reconciler = NewKafkaACLReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, kafkaServersStore, enableAclCreation, newTestKafkaIntentsAdmin, true)
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	s.Reconciler.InjectRecorder(recorder)
 }
@@ -105,8 +105,8 @@ func (s *KafkaACLReconcilerTestSuite) principal() string {
 }
 
 func getMockIntentsAdminFactory(clusterAdmin sarama.ClusterAdmin, usernameMapping string) kafkaacls.IntentsAdminFactoryFunction {
-	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool) (kafkaacls.KafkaIntentsAdmin, error) {
-		return kafkaacls.NewKafkaIntentsAdminImpl(kafkaServer, clusterAdmin, usernameMapping, enableKafkaACLCreation), nil
+	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, globalEnforceSetting bool) (kafkaacls.KafkaIntentsAdmin, error) {
+		return kafkaacls.NewKafkaIntentsAdminImpl(kafkaServer, clusterAdmin, usernameMapping, enableKafkaACLCreation, globalEnforceSetting), nil
 	}
 }
 

--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	ReasonEnforcementGloballyDisabled   = "EnforcementGloballyDisabled"
 	ReasonNetworkPolicyCreationDisabled = "NetworkPolicyCreationDisabled"
 	ReasonGettingNetworkPolicyFailed    = "GettingNetworkPolicyFailed"
 	ReasonRemovingNetworkPolicyFailed   = "RemovingNetworkPolicyFailed"
@@ -36,6 +37,7 @@ type NetworkPolicyReconciler struct {
 	endpointsReconciler         *external_traffic.EndpointsReconciler
 	RestrictToNamespaces        []string
 	enableNetworkPolicyCreation bool
+	globalEnforceSetting        bool
 	injectablerecorder.InjectableRecorder
 }
 
@@ -44,13 +46,15 @@ func NewNetworkPolicyReconciler(
 	s *runtime.Scheme,
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
-	enableNetworkPolicyCreation bool) *NetworkPolicyReconciler {
+	enableNetworkPolicyCreation bool,
+	globalEnforceSetting bool) *NetworkPolicyReconciler {
 	return &NetworkPolicyReconciler{
 		Client:                      c,
 		Scheme:                      s,
 		endpointsReconciler:         endpointsReconciler,
 		RestrictToNamespaces:        restrictToNamespaces,
 		enableNetworkPolicyCreation: enableNetworkPolicyCreation,
+		globalEnforceSetting:        globalEnforceSetting,
 	}
 }
 
@@ -117,6 +121,10 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 func (r *NetworkPolicyReconciler) handleNetworkPolicyCreation(
 	ctx context.Context, intentsObj *otterizev1alpha1.ClientIntents, intent otterizev1alpha1.Intent, intentsObjNamespace string) error {
+	if !r.globalEnforceSetting {
+		r.RecordNormalEvent(intentsObj, ReasonEnforcementGloballyDisabled, "Enforcement is disabled globally, network policy creation skipped")
+		return nil
+	}
 	if !r.enableNetworkPolicyCreation {
 		r.RecordNormalEvent(intentsObj, ReasonNetworkPolicyCreationDisabled, "Network policy creation is disabled, creation skipped")
 		return nil

--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -37,7 +37,7 @@ type NetworkPolicyReconciler struct {
 	endpointsReconciler         *external_traffic.EndpointsReconciler
 	RestrictToNamespaces        []string
 	enableNetworkPolicyCreation bool
-	globalEnforceSetting        bool
+	enforcementEnabledGlobally  bool
 	injectablerecorder.InjectableRecorder
 }
 
@@ -47,14 +47,14 @@ func NewNetworkPolicyReconciler(
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
 	enableNetworkPolicyCreation bool,
-	globalEnforceSetting bool) *NetworkPolicyReconciler {
+	enforcementEnabledGlobally bool) *NetworkPolicyReconciler {
 	return &NetworkPolicyReconciler{
 		Client:                      c,
 		Scheme:                      s,
 		endpointsReconciler:         endpointsReconciler,
 		RestrictToNamespaces:        restrictToNamespaces,
 		enableNetworkPolicyCreation: enableNetworkPolicyCreation,
-		globalEnforceSetting:        globalEnforceSetting,
+		enforcementEnabledGlobally:  enforcementEnabledGlobally,
 	}
 }
 
@@ -121,7 +121,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 func (r *NetworkPolicyReconciler) handleNetworkPolicyCreation(
 	ctx context.Context, intentsObj *otterizev1alpha1.ClientIntents, intent otterizev1alpha1.Intent, intentsObjNamespace string) error {
-	if !r.globalEnforceSetting {
+	if !r.enforcementEnabledGlobally {
 		r.RecordNormalEvent(intentsObj, ReasonEnforcementGloballyDisabled, "Enforcement is disabled globally, network policy creation skipped")
 		return nil
 	}

--- a/src/operator/controllers/intents_reconcilers/network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy_test.go
@@ -50,7 +50,7 @@ func (s *NetworkPolicyReconcilerTestSuite) BeforeTest(_, testName string) {
 
 func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
-	s.Reconciler = NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true)
+	s.Reconciler = NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true)
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	s.Reconciler.InjectRecorder(recorder)
 }

--- a/src/operator/controllers/kafkaacls/intentsAdmin.go
+++ b/src/operator/controllers/kafkaacls/intentsAdmin.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 )
 
-type IntentsAdminFactoryFunction func(serverConfig otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, globalEnforceSetting bool) (KafkaIntentsAdmin, error)
+type IntentsAdminFactoryFunction func(serverConfig otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, enforcementEnabledGlobally bool) (KafkaIntentsAdmin, error)
 
 type TopicToACLList map[sarama.Resource][]sarama.Acl
 
@@ -40,11 +40,11 @@ type KafkaIntentsAdmin interface {
 }
 
 type KafkaIntentsAdminImpl struct {
-	kafkaServer            otterizev1alpha1.KafkaServerConfig
-	kafkaAdminClient       sarama.ClusterAdmin
-	userNameMapping        string
-	enableKafkaACLCreation bool
-	globalEnforceSetting   bool
+	kafkaServer                otterizev1alpha1.KafkaServerConfig
+	kafkaAdminClient           sarama.ClusterAdmin
+	userNameMapping            string
+	enableKafkaACLCreation     bool
+	enforcementEnabledGlobally bool
 }
 
 var (
@@ -121,7 +121,7 @@ func getUserPrincipalMapping(tlsCert tls.Certificate) (string, error) {
 
 }
 
-func NewKafkaIntentsAdmin(kafkaServer otterizev1alpha1.KafkaServerConfig, defaultTls otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, globalEnforceSetting bool) (KafkaIntentsAdmin, error) {
+func NewKafkaIntentsAdmin(kafkaServer otterizev1alpha1.KafkaServerConfig, defaultTls otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, enforcementEnabledGlobally bool) (KafkaIntentsAdmin, error) {
 	logger := logrus.WithField("addr", kafkaServer.Spec.Addr)
 	logger.Info("Connecting to kafka server")
 	addrs := []string{kafkaServer.Spec.Addr}
@@ -158,11 +158,11 @@ func NewKafkaIntentsAdmin(kafkaServer otterizev1alpha1.KafkaServerConfig, defaul
 		return nil, err
 	}
 
-	return NewKafkaIntentsAdminImpl(kafkaServer, a, usernameMapping, enableKafkaACLCreation, globalEnforceSetting), nil
+	return NewKafkaIntentsAdminImpl(kafkaServer, a, usernameMapping, enableKafkaACLCreation, enforcementEnabledGlobally), nil
 }
 
-func NewKafkaIntentsAdminImpl(kafkaServer otterizev1alpha1.KafkaServerConfig, a sarama.ClusterAdmin, usernameMapping string, enableKafkaACLCreation bool, globalEnforceSetting bool) KafkaIntentsAdmin {
-	return &KafkaIntentsAdminImpl{kafkaServer: kafkaServer, kafkaAdminClient: a, userNameMapping: usernameMapping, enableKafkaACLCreation: enableKafkaACLCreation, globalEnforceSetting: globalEnforceSetting}
+func NewKafkaIntentsAdminImpl(kafkaServer otterizev1alpha1.KafkaServerConfig, a sarama.ClusterAdmin, usernameMapping string, enableKafkaACLCreation bool, enforcementEnabledGlobally bool) KafkaIntentsAdmin {
+	return &KafkaIntentsAdminImpl{kafkaServer: kafkaServer, kafkaAdminClient: a, userNameMapping: usernameMapping, enableKafkaACLCreation: enableKafkaACLCreation, enforcementEnabledGlobally: enforcementEnabledGlobally}
 }
 
 func (a *KafkaIntentsAdminImpl) Close() {
@@ -326,20 +326,20 @@ func (a *KafkaIntentsAdminImpl) ApplyClientIntents(clientName string, clientName
 	if err != nil {
 		return fmt.Errorf("failed collecting topics to ACL list %w", err)
 	}
-	
+
 	resourceAclsCreate, resourceAclsDelete := a.kafkaResourceAclsDiff(expectedIntentsKafkaTopicsAcls, appliedIntentKafkaAcls)
 
 	if len(resourceAclsCreate) == 0 {
 		logger.Info("No new ACLs found to apply on server")
 	} else {
-		if a.globalEnforceSetting && a.enableKafkaACLCreation {
+		if a.enforcementEnabledGlobally && a.enableKafkaACLCreation {
 			logger.Infof("Creating %d new ACLs", len(resourceAclsCreate))
 			if err := a.kafkaAdminClient.CreateACLs(resourceAclsCreate); err != nil {
 				return fmt.Errorf("failed applying ACLs to server: %w", err)
 			}
 		} else if !a.enableKafkaACLCreation {
 			logger.Infof("Skipped creation of %d new ACLs because Kafka ACL Creation is disabled", len(resourceAclsCreate))
-		} else if !a.globalEnforceSetting {
+		} else if !a.enforcementEnabledGlobally {
 			logger.Infof("Skipped creation of %d new enforcement is globally disabled", len(resourceAclsCreate))
 		}
 	}

--- a/src/operator/controllers/kafkaacls/serversStore.go
+++ b/src/operator/controllers/kafkaacls/serversStore.go
@@ -23,16 +23,16 @@ type ServersStoreImpl struct {
 	enableKafkaACLCreation      bool
 	tlsSourceFiles              otterizev1alpha1.TLSSource
 	IntentsAdminFactoryFunction IntentsAdminFactoryFunction
-	globalEnforceSetting        bool
+	enforcementEnabledGlobally  bool
 }
 
-func NewServersStore(tlsSourceFiles otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, factoryFunc IntentsAdminFactoryFunction, globalEnforceSetting bool) *ServersStoreImpl {
+func NewServersStore(tlsSourceFiles otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, factoryFunc IntentsAdminFactoryFunction, enforcementEnabledGlobally bool) *ServersStoreImpl {
 	return &ServersStoreImpl{
 		serversByName:               map[types.NamespacedName]*otterizev1alpha1.KafkaServerConfig{},
 		enableKafkaACLCreation:      enableKafkaACLCreation,
 		tlsSourceFiles:              tlsSourceFiles,
 		IntentsAdminFactoryFunction: factoryFunc,
-		globalEnforceSetting:        globalEnforceSetting,
+		enforcementEnabledGlobally:  enforcementEnabledGlobally,
 	}
 }
 
@@ -59,7 +59,7 @@ func (s *ServersStoreImpl) Get(serverName string, namespace string) (KafkaIntent
 		return nil, ServerSpecNotFound
 	}
 
-	return s.IntentsAdminFactoryFunction(*config, s.tlsSourceFiles, s.enableKafkaACLCreation, s.globalEnforceSetting)
+	return s.IntentsAdminFactoryFunction(*config, s.tlsSourceFiles, s.enableKafkaACLCreation, s.enforcementEnabledGlobally)
 }
 
 func (s *ServersStoreImpl) MapErr(f func(types.NamespacedName, *otterizev1alpha1.KafkaServerConfig, otterizev1alpha1.TLSSource) error) error {

--- a/src/operator/controllers/kafkaacls/serversStore.go
+++ b/src/operator/controllers/kafkaacls/serversStore.go
@@ -23,14 +23,16 @@ type ServersStoreImpl struct {
 	enableKafkaACLCreation      bool
 	tlsSourceFiles              otterizev1alpha1.TLSSource
 	IntentsAdminFactoryFunction IntentsAdminFactoryFunction
+	globalEnforceSetting        bool
 }
 
-func NewServersStore(tlsSourceFiles otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, factoryFunc IntentsAdminFactoryFunction) *ServersStoreImpl {
+func NewServersStore(tlsSourceFiles otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, factoryFunc IntentsAdminFactoryFunction, globalEnforceSetting bool) *ServersStoreImpl {
 	return &ServersStoreImpl{
 		serversByName:               map[types.NamespacedName]*otterizev1alpha1.KafkaServerConfig{},
 		enableKafkaACLCreation:      enableKafkaACLCreation,
 		tlsSourceFiles:              tlsSourceFiles,
 		IntentsAdminFactoryFunction: factoryFunc,
+		globalEnforceSetting:        globalEnforceSetting,
 	}
 }
 
@@ -59,7 +61,7 @@ func (s *ServersStoreImpl) Get(serverName string, namespace string) (KafkaIntent
 		return nil, ServerSpecNotFound
 	}
 
-	return s.IntentsAdminFactoryFunction(*config, s.tlsSourceFiles, s.enableKafkaACLCreation)
+	return s.IntentsAdminFactoryFunction(*config, s.tlsSourceFiles, s.enableKafkaACLCreation, s.globalEnforceSetting)
 }
 
 func (s *ServersStoreImpl) MapErr(f func(types.NamespacedName, *otterizev1alpha1.KafkaServerConfig, otterizev1alpha1.TLSSource) error) error {

--- a/src/operator/controllers/kafkaserverconfig_controller_test.go
+++ b/src/operator/controllers/kafkaserverconfig_controller_test.go
@@ -99,7 +99,7 @@ func (s *KafkaServerConfigReconcilerTestSuite) BeforeTest(_, testName string) {
 }
 
 func getMockIntentsAdminFactory(mockIntentsAdmin *kafkaaclsmocks.MockKafkaIntentsAdmin) kafkaacls.IntentsAdminFactoryFunction {
-	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, globalEnforceSetting bool) (kafkaacls.KafkaIntentsAdmin, error) {
+	return func(kafkaServer otterizev1alpha1.KafkaServerConfig, _ otterizev1alpha1.TLSSource, enableKafkaACLCreation bool, enforcementEnabledGlobally bool) (kafkaacls.KafkaIntentsAdmin, error) {
 		return mockIntentsAdmin, nil
 	}
 }
@@ -167,16 +167,12 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestReUploadKafkaServerConfigOnFa
 	kafkaServerConfig.SetNamespace(s.TestNamespace)
 	s.AddKafkaServerConfig(&kafkaServerConfig)
 
-	// Set go mock expectations for failure
-	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
-	s.mockIntentsAdmin.EXPECT().Close()
-
-	// Set go mock expectations for failure
+	// Make the mock return error to the reconciler, so it thinks the report failed
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(errors.New("failed to upload kafka server config"))
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close()
 
-	// Set go mock expectations
+	// We expect the reconciler to retry to report, this time we don't return an error, simulating success
 	s.mockCloudClient.EXPECT().ReportKafkaServerConfig(gomock.Any(), s.TestNamespace, IntentsOperatorSource, gomock.Any()).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics).Return(nil).Times(1)
 	s.mockIntentsAdmin.EXPECT().Close().Times(1)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -227,7 +227,7 @@ func main() {
 	}
 
 	if !enforcementEnabledGlobally {
-		logrus.Info("Running with %s=false, won't perform any enforcement", enableEnforcementKey)
+		logrus.Infof("Running with %s=false, won't perform any enforcement", enableEnforcementKey)
 	}
 
 	logrus.Info("starting manager")

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -46,6 +46,8 @@ var (
 	scheme = runtime.NewScheme()
 )
 
+const enableEnforcementKey = "enable-enforcement"
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -88,7 +90,7 @@ func main() {
 		"Whether to generate and use a self signed cert as the CA for webhooks")
 	pflag.BoolVar(&disableWebhookServer, "disable-webhook-server", false,
 		"Disable webhook validator server")
-	pflag.BoolVar(&enforcementEnabledGlobally, "enable-enforcement", true,
+	pflag.BoolVar(&enforcementEnabledGlobally, enableEnforcementKey, true,
 		"If set to false disables the enforcement globally, superior to the other flags")
 	pflag.BoolVar(&autoCreateNetworkPoliciesForExternalTraffic, "auto-create-network-policies-for-external-traffic", true,
 		"Whether to automatically create network policies for external traffic")
@@ -222,6 +224,10 @@ func main() {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		logrus.WithError(err).Fatal("unable to set up ready check")
+	}
+
+	if !enforcementEnabledGlobally {
+		logrus.Info("Running with %s=false, won't perform any enforcement", enableEnforcementKey)
 	}
 
 	logrus.Info("starting manager")

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -67,7 +67,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var selfSignedCert bool
-	var globalEnforceSetting bool
+	var enforcementEnabledGlobally bool
 	var autoCreateNetworkPoliciesForExternalTraffic bool
 	var watchedNamespaces []string
 	var enableNetworkPolicyCreation bool
@@ -88,7 +88,7 @@ func main() {
 		"Whether to generate and use a self signed cert as the CA for webhooks")
 	pflag.BoolVar(&disableWebhookServer, "disable-webhook-server", false,
 		"Disable webhook validator server")
-	pflag.BoolVar(&globalEnforceSetting, "globalEnforceSetting", true,
+	pflag.BoolVar(&enforcementEnabledGlobally, "enable-enforcement", true,
 		"If set to false disables the enforcement globally, superior to the other flags")
 	pflag.BoolVar(&autoCreateNetworkPoliciesForExternalTraffic, "auto-create-network-policies-for-external-traffic", true,
 		"Whether to automatically create network policies for external traffic")
@@ -138,9 +138,9 @@ func main() {
 		logrus.WithError(err).Fatal(err, "unable to start manager")
 	}
 
-	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, globalEnforceSetting)
+	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, enforcementEnabledGlobally)
 
-	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), mgr.GetScheme(), autoCreateNetworkPoliciesForExternalTraffic, globalEnforceSetting)
+	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), mgr.GetScheme(), autoCreateNetworkPoliciesForExternalTraffic, enforcementEnabledGlobally)
 
 	if err = endpointReconciler.InitIngressReferencedServicesIndex(mgr); err != nil {
 		logrus.WithError(err).Fatal("unable to init index for ingress")
@@ -169,7 +169,7 @@ func main() {
 
 	intentsReconciler := controllers.NewIntentsReconciler(
 		mgr.GetClient(), mgr.GetScheme(), kafkaServersStore, endpointReconciler,
-		watchedNamespaces, globalEnforceSetting, enableNetworkPolicyCreation, enableKafkaACLCreation,
+		watchedNamespaces, enforcementEnabledGlobally, enableNetworkPolicyCreation, enableKafkaACLCreation,
 		otterizeCloudClient)
 
 	if err = intentsReconciler.InitIntentsServerIndices(mgr); err != nil {


### PR DESCRIPTION
This PR adds the --enable-enforcement=false flag, which can be used in order to disable all the enforcement abilities of the intents operator at once.
If enable-enforcement is true (which is the default), the other flags can be used in order to disable only specific enforcement types (e.g. disable only Kafka ACLs)

Tests:
Added unit tests to verify network policies and Kafka ACLs are not created when enable-enforcement=false