### PR TITLE
Fix kafka config failed tests

### DIFF
--- a/src/operator/controllers/kafkaacls/intentsAdmin.go
+++ b/src/operator/controllers/kafkaacls/intentsAdmin.go
@@ -325,7 +325,7 @@ func (a *KafkaIntentsAdminImpl) ApplyClientIntents(clientName string, clientName
 	if err != nil {
 		return fmt.Errorf("failed collecting topics to ACL list %w", err)
 	}
-	
+
 	resourceAclsCreate, resourceAclsDelete := a.kafkaResourceAclsDiff(expectedIntentsKafkaTopicsAcls, appliedIntentKafkaAcls)
 
 	if len(resourceAclsCreate) == 0 {


### PR DESCRIPTION
### Description

Kafka server config tests failed due to bad merge, as result there are two EXPECT statements that are no longer needed, and fixing the reconcile function in tests to auto reconcile incase of bad sync between k8s operations.

- [x] This change adds test coverage for new/changed/fixed functionality
