### PR TITLE
Fix signal handler context

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
@@ -1,23 +1,22 @@
 package otterizecloud
 
 import (
+	"context"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"time"
 )
 
-func StartPeriodicallyReportConnectionToCloud(client CloudClient) {
+func StartPeriodicallyReportConnectionToCloud(client CloudClient, ctx context.Context) {
 	interval := viper.GetInt(otterizecloudclient.ComponentReportIntervalKey)
 	go func() {
-		runPeriodicReportConnection(interval, client)
+		runPeriodicReportConnection(interval, client, ctx)
 	}()
 }
 
-func runPeriodicReportConnection(interval int, client CloudClient) {
-	ctx := ctrl.SetupSignalHandler()
+func runPeriodicReportConnection(interval int, client CloudClient, ctx context.Context) {
 	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(interval))
 
 	logrus.Info("Starting cloud connection ticker")

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -162,6 +162,7 @@ func main() {
 		logrus.WithError(err).Fatal("unable to init index for ingress")
 	}
 
+	signalHandlerCtx := ctrl.SetupSignalHandler()
 	otterizeCloudClient, ok, err := otterizecloud.NewClient(context.Background())
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create otterize cloud client")
@@ -169,7 +170,7 @@ func main() {
 	if !ok {
 		logrus.Info("missing configuration for cloud integration, disabling cloud communication")
 	} else {
-		otterizecloud.StartPeriodicallyReportConnectionToCloud(otterizeCloudClient)
+		otterizecloud.StartPeriodicallyReportConnectionToCloud(otterizeCloudClient, signalHandlerCtx)
 	}
 
 	intentsReconciler := controllers.NewIntentsReconciler(
@@ -246,7 +247,7 @@ func main() {
 	}
 
 	logrus.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(signalHandlerCtx); err != nil {
 		logrus.WithError(err).Fatal("problem running manager")
 	}
 }


### PR DESCRIPTION
### Description

Multiple calls to signal handlers may crush the operator, this PR reuse the context in main to fix it.
