### PR TITLE
Send component status on start up

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
@@ -20,6 +20,8 @@ func runPeriodicReportConnection(interval int, client CloudClient, ctx context.C
 	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(interval))
 
 	logrus.Info("Starting cloud connection ticker")
+	client.ReportComponentStatus(ctx, graphqlclient.ComponentTypeIntentsOperator)
+
 	for {
 		select {
 		case <-cloudUploadTicker.C:


### PR DESCRIPTION
### Description

Send connection status right on operator start up, so we won't wait until `component-report-interval`  time will end