### PR TITLE
Convert Kafka operation enum to cloud format

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -226,12 +226,42 @@ func toPtrOrNil(s string) *string {
 	return lo.ToPtr(s)
 }
 
+func kafkaOperationK8sToCloud(op KafkaOperation) graphqlclient.KafkaOperation {
+	switch op {
+	case KafkaOperationAll:
+		return graphqlclient.KafkaOperationAll
+	case KafkaOperationConsume:
+		return graphqlclient.KafkaOperationConsume
+	case KafkaOperationProduce:
+		return graphqlclient.KafkaOperationProduce
+	case KafkaOperationCreate:
+		return graphqlclient.KafkaOperationCreate
+	case KafkaOperationAlter:
+		return graphqlclient.KafkaOperationAlter
+	case KafkaOperationDelete:
+		return graphqlclient.KafkaOperationDelete
+	case KafkaOperationDescribe:
+		return graphqlclient.KafkaOperationDescribe
+	case KafkaOperationClusterAction:
+		return graphqlclient.KafkaOperationClusterAction
+	case KafkaOperationDescribeConfigs:
+		return graphqlclient.KafkaOperationDescribeConfigs
+	case KafkaOperationAlterConfigs:
+		return graphqlclient.KafkaOperationAlterConfigs
+	case KafkaOperationIdempotentWrite:
+		return graphqlclient.KafkaOperationIdempotentWrite
+	default:
+		panic(fmt.Sprintf("Unknown KafkaOperation: %s", op))
+	}
+}
+
 func (in *Intent) ConvertToCloudFormat(resourceNamespace string, clientName string) graphqlclient.IntentInput {
 	otterizeTopics := lo.Map(in.Topics, func(topic KafkaTopic, i int) *graphqlclient.KafkaConfigInput {
 		return lo.ToPtr(graphqlclient.KafkaConfigInput{
 			Name: lo.ToPtr(topic.Name),
 			Operations: lo.Map(topic.Operations, func(op KafkaOperation, i int) *graphqlclient.KafkaOperation {
-				return lo.ToPtr(graphqlclient.KafkaOperation(op))
+				operation := kafkaOperationK8sToCloud(op)
+				return &operation
 			}),
 		})
 	})

--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -252,7 +252,7 @@ func kafkaOperationK8sToCloud(op KafkaOperation) graphqlclient.KafkaOperation {
 	case KafkaOperationIdempotentWrite:
 		return graphqlclient.KafkaOperationIdempotentWrite
 	default:
-		logrus.Panic("Unknown KafkaOperation: %s", op)
+		logrus.Panic(fmt.Sprintf("Unknown KafkaOperation: %s", op))
 		return "" // We won't reach here
 	}
 }

--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"strings"
@@ -251,7 +252,8 @@ func kafkaOperationK8sToCloud(op KafkaOperation) graphqlclient.KafkaOperation {
 	case KafkaOperationIdempotentWrite:
 		return graphqlclient.KafkaOperationIdempotentWrite
 	default:
-		panic(fmt.Sprintf("Unknown KafkaOperation: %s", op))
+		logrus.Panic("Unknown KafkaOperation: %s", op)
+		return "" // We won't reach here
 	}
 }
 

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -99,6 +99,7 @@ func (v *KafkaConfigInput) GetOperations() []*KafkaOperation { return v.Operatio
 type KafkaOperation string
 
 const (
+	KafkaOperationAll             KafkaOperation = "ALL"
 	KafkaOperationConsume         KafkaOperation = "CONSUME"
 	KafkaOperationProduce         KafkaOperation = "PRODUCE"
 	KafkaOperationCreate          KafkaOperation = "CREATE"


### PR DESCRIPTION
The Kafka operation didn't have structured conversion from k8s format to cloud format, just pure string conversation. There was also an missing enum value for Kafka operation. This all caused error when uploading Kafka operation to cloud.
This PR implement the missing value.