### PR TITLE
Fix panic on client intents delete for pods that has no annotations

### DIFF
--- a/src/operator/controllers/intents_reconcilers/pods.go
+++ b/src/operator/controllers/intents_reconcilers/pods.go
@@ -126,6 +126,9 @@ func (r *PodLabelReconciler) cleanFinalizerAndUnlabelPods(
 	// Remove the access label for each intent, for every pod in the list
 	for _, pod := range podList.Items {
 		updatedPod := pod.DeepCopy()
+		if updatedPod.Annotations == nil {
+			updatedPod.Annotations = make(map[string]string)
+		}
 		updatedPod.Annotations[otterizev1alpha2.AllIntentsRemovedAnnotation] = "true"
 		for _, intent := range intents.GetCallsList() {
 			targetServerIdentity := otterizev1alpha2.GetFormattedOtterizeIdentity(

--- a/src/operator/controllers/intents_reconcilers/pods_test.go
+++ b/src/operator/controllers/intents_reconcilers/pods_test.go
@@ -88,7 +88,7 @@ func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelAdded() {
 	})
 }
 
-func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelRemoved() {
+func (s *PodLabelReconcilerTestSuite) testClientAccessLabelRemovedWithParams(podAnnotations map[string]string) {
 	// Tests for removal of intents for client + marking annotations of "All intents removed"
 	deploymentName := "whocares"
 	intentTargetServerName := "test-server"
@@ -105,7 +105,7 @@ func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelRemoved() {
 	s.AddDeployment(deploymentName, []string{"1.1.1.1"}, map[string]string{
 		otterizev1alpha2.OtterizeServerLabelKey: otterizeSvcIdentity,
 		accessLabel:                             "true"},
-		map[string]string{"a": "b"},
+		podAnnotations,
 	)
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
@@ -139,6 +139,14 @@ func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelRemoved() {
 	s.Require().NotEmpty(pod)
 	s.Require().NotContains(pod.Labels, accessLabel)
 	s.Require().Contains(pod.Annotations, otterizev1alpha2.AllIntentsRemovedAnnotation)
+}
+
+func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelRemoved() {
+	s.testClientAccessLabelRemovedWithParams(map[string]string{"a": "b"})
+}
+
+func (s *PodLabelReconcilerTestSuite) TestClientAccessLabelRemovedNoPodAnnotations() {
+	s.testClientAccessLabelRemovedWithParams(nil)
 }
 
 func (s *PodLabelReconcilerTestSuite) TestAccessLabelChangedOnIntentsEdit() {


### PR DESCRIPTION
This is a fix for the following panic, caused by access to nil annotations map:
```
name=cartservice namespace=otterize-ecom-demo reconcileID="\"72de7012-fbf6-4bb8-93c8-3d796198f06e\""
2023-01-18T13:46:30.010885750Z manager panic: assignment to entry in nil map [recovered]
2023-01-18T13:46:30.010898166Z manager     panic: assignment to entry in nil map
2023-01-18T13:46:30.010900250Z manager 
2023-01-18T13:46:30.010901791Z manager goroutine 289 [running]:
2023-01-18T13:46:30.010905875Z manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
2023-01-18T13:46:30.010908666Z manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:118 +0x1f4
2023-01-18T13:46:30.010910333Z manager panic({0x168b360, 0x1adf9f0})
2023-01-18T13:46:30.010911833Z manager     /usr/local/go/src/runtime/panic.go:838 +0x207
2023-01-18T13:46:30.010913500Z manager github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers.(*PodLabelReconciler).cleanFinalizerAndUnlabelPods(0xc000589860, {0x1af7bb8, 0xc0009b4ff0}, 0xc0009b23c0)
2023-01-18T13:46:30.010927875Z manager     /workspace/operator/controllers/intents_reconcilers/pods.go:129 +0x455
2023-01-18T13:46:30.010930875Z manager github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers.(*PodLabelReconciler).Reconcile(0xc000589860, {0x1af7bb8, 0xc0009b4ff0}, {{{0xc0005a08e8?, 0xc000697c60?}, {0xc00054aea0?, 0x1?}}})
2023-01-18T13:46:30.010932916Z manager     /workspace/operator/controllers/intents_reconcilers/pods.go:53 +0x19a
2023-01-18T13:46:30.010934500Z manager github.com/otterize/intents-operator/src/shared/reconcilergroup.(*Group).Reconcile(0xc0003c09b0, {0x1af7bb8, 0xc0009b4ff0}, {{{0xc0005a08e8?, 0xd?}, {0xc00054aea0?, 0x40278027d8?}}})
2023-01-18T13:46:30.010936250Z manager     /workspace/shared/reconcilergroup/reconcilergroup.go:38 +0x1b8
2023-01-18T13:46:30.010937750Z manager github.com/otterize/intents-operator/src/operator/controllers.(*IntentsReconciler).Reconcile(0x30?, {0x1af7bb8?, 0xc0009b4ff0?}, {{{0xc0005a08e8?, 0x10?}, {0xc00054aea0?, 0x40d787?}}})
2023-01-18T13:46:30.010939416Z manager     /workspace/operator/controllers/intents_controller.go:72 +0x30
2023-01-18T13:46:30.010940958Z manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1af7b10?, {0x1af7bb8?, 0xc0009b4ff0?}, {{{0xc0005a08e8?, 0x17c0740?}, {0xc00054aea0?, 0x4041f4?}}})
2023-01-18T13:46:30.010942583Z manager     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:121 +0xc8
2023-01-18T13:46:30.010944208Z manager sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00040c640, {0x1af7b10, 0xc000151880}, {0x16e9920?, 0xc000414ba0?})
```