### PR TITLE
Support deep comparison of intents cloud object for testing

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/intents_input_matcher.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/intents_input_matcher.go
@@ -2,7 +2,10 @@ package otterizecloud
 
 import (
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	"golang.org/x/exp/constraints"
+	"sort"
 )
 
 // IntentsMatcher Implement gomock.Matcher interface for []graphqlclient.IntentInput
@@ -10,15 +13,86 @@ type IntentsMatcher struct {
 	expected []graphqlclient.IntentInput
 }
 
-func NilCompare[T comparable](a *T, b *T) bool {
-	return (a == nil && b == nil) || (a != nil && b != nil && *a == *b)
+func NilCompare[T constraints.Ordered](a *T, b *T) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	if *a > *b {
+		return 1
+	}
+	if *a < *b {
+		return -1
+	}
+	return 0
 }
 
-func compareIntentInput(a graphqlclient.IntentInput, b graphqlclient.IntentInput) bool {
-	return NilCompare(a.ClientName, b.ClientName) &&
-		NilCompare(a.Namespace, b.Namespace) &&
-		NilCompare(a.ServerName, b.ServerName) &&
-		NilCompare(a.ServerNamespace, b.ServerNamespace)
+func intentInputSort(intents []graphqlclient.IntentInput) {
+	for _, intent := range intents {
+		if intent.Type == nil {
+			continue
+		}
+
+		switch *intent.Type {
+		case graphqlclient.IntentTypeKafka:
+			for _, topic := range intent.Topics {
+				sort.Slice(topic.Operations, func(i, j int) bool {
+					return NilCompare(topic.Operations[i], topic.Operations[j]) < 0
+				})
+			}
+			sort.Slice(intent.Topics, func(i, j int) bool {
+				res := NilCompare(intent.Topics[i].Name, intent.Topics[j].Name)
+				if res != 0 {
+					return res < 0
+				}
+
+				return len(intent.Topics[i].Operations) < len(intent.Topics[j].Operations)
+			})
+		case graphqlclient.IntentTypeHttp:
+			sort.Slice(intent.Resources, func(i, j int) bool {
+				res := NilCompare(intent.Resources[i].Path, intent.Resources[j].Path)
+				if res != 0 {
+					return res < 0
+				}
+				return NilCompare(intent.Resources[i].Method, intent.Resources[j].Method) < 0
+			})
+		}
+	}
+	sort.Slice(intents, func(i, j int) bool {
+		res := NilCompare(intents[i].Namespace, intents[j].Namespace)
+		if res != 0 {
+			return res < 0
+		}
+		res = NilCompare(intents[i].ClientName, intents[j].ClientName)
+		if res != 0 {
+			return res < 0
+		}
+		res = NilCompare(intents[i].ServerName, intents[j].ServerName)
+		if res != 0 {
+			return res < 0
+		}
+		res = NilCompare(intents[i].ServerNamespace, intents[j].ServerNamespace)
+		if res != 0 {
+			return res < 0
+		}
+		res = NilCompare(intents[i].Type, intents[j].Type)
+		if res != 0 {
+			return res < 0
+		}
+		switch *intents[i].Type {
+		case graphqlclient.IntentTypeKafka:
+			return len(intents[i].Topics) < len(intents[j].Topics)
+		case graphqlclient.IntentTypeHttp:
+			return len(intents[i].Resources) < len(intents[j].Resources)
+		default:
+			panic("Unimplemented intent type")
+		}
+	})
 }
 
 func (m IntentsMatcher) Matches(x interface{}) bool {
@@ -32,35 +106,53 @@ func (m IntentsMatcher) Matches(x interface{}) bool {
 	matched := getMatcherFromPtrArr(actualIntentsPtr)
 	actualIntents := matched.expected
 	expectedIntents := m.expected
-	if len(actualIntents) != len(expectedIntents) {
-		return false
-	}
 
-	for _, expected := range expectedIntents {
-		found := false
-		for _, actual := range actualIntents {
-			if compareIntentInput(actual, expected) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
+	intentInputSort(expectedIntents)
+	intentInputSort(actualIntents)
+
+	diff := cmp.Diff(expectedIntents, actualIntents)
+	if diff != "" {
+		fmt.Println(diff)
 	}
-	return true
+	return cmp.Equal(expectedIntents, actualIntents)
 }
 
 func (m IntentsMatcher) String() string {
 	return prettyPrint(m)
 }
 
+func printKafkaConfigInput(input []*graphqlclient.KafkaConfigInput) string {
+	var result string
+	for _, item := range input {
+		var name, operations string
+		if item == nil {
+			result += "nil"
+			continue
+		}
+		if item.Name != nil {
+			name = *item.Name
+		} else {
+			name = "nil"
+		}
+
+		for _, op := range item.Operations {
+			if op == nil {
+				operations += "nil,"
+				continue
+			}
+			operations += fmt.Sprintf("%s,", *op)
+		}
+		result += fmt.Sprintf("KafkaConfigInput{Name: %s, Operations: %v}", name, operations)
+	}
+	return result
+}
+
 func prettyPrint(m IntentsMatcher) string {
 	expected := m.expected
 	var result string
-	itemFormat := "IntentInput{ClientName: %s, ServerName: %s, Namespace: %s, ServerNamespace: %s, Type: %s},"
+	itemFormat := "IntentInput{ClientName: %s, ServerName: %s, Namespace: %s, ServerNamespace: %s, Type: %s, Resource: %s},"
 	for _, intent := range expected {
-		var clientName, namespace, serverName, serverNamespace, intentType string
+		var clientName, namespace, serverName, serverNamespace, intentType, resource string
 		if intent.ClientName != nil {
 			clientName = *intent.ClientName
 		}
@@ -75,8 +167,16 @@ func prettyPrint(m IntentsMatcher) string {
 		}
 		if intent.Type != nil {
 			intentType = *intent.ServerNamespace
+			switch *intent.Type {
+			case graphqlclient.IntentTypeKafka:
+				resource = printKafkaConfigInput(intent.Topics)
+			case graphqlclient.IntentTypeHttp:
+				// Fallthrough
+			default:
+				resource = "Unimplemented type"
+			}
 		}
-		result += fmt.Sprintf(itemFormat, clientName, serverName, namespace, serverNamespace, intentType)
+		result += fmt.Sprintf(itemFormat, clientName, serverName, namespace, serverNamespace, intentType, resource)
 	}
 
 	return result


### PR DESCRIPTION
### Description

This PR improve the testing infrastructure by extending the intents matcher to deep compare all fields of intent sent to cloud. This will enable to test that every field in the CRD object and will support future expanding of our tests.

- [x] This change adds test coverage for new/changed/fixed functionality
