### PR TITLE
Fixed bug where cross namespace intents repeated the namespace name

### DIFF
--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -55,7 +55,7 @@ func getIntentsByServer(defaultNamespace string, intents []otterizev1alpha2.Inte
 		}
 
 		serverName := types.NamespacedName{
-			Name:      intent.Name,
+			Name:      intent.GetServerName(),
 			Namespace: intent.GetServerNamespace(defaultNamespace),
 		}
 

--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -301,7 +301,7 @@ func (r *NetworkPolicyReconciler) buildNetworkPolicyObjectForIntent(
 	intent otterizev1alpha2.Intent, policyName, intentsObjNamespace string) *v1.NetworkPolicy {
 	targetNamespace := intent.GetServerNamespace(intentsObjNamespace)
 	// The intent's target server made of name + namespace + hash
-	formattedTargetServer := otterizev1alpha2.GetFormattedOtterizeIdentity(intent.Name, targetNamespace)
+	formattedTargetServer := otterizev1alpha2.GetFormattedOtterizeIdentity(intent.GetServerName(), targetNamespace)
 
 	return &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Description

Since the change in #90 , cross-namespace intents would generate a malformed label. Added test to prevent regression.