### PR TITLE
Report network policy & Kafka ACL enforcement state in addition to global enforcement state

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
@@ -11,7 +11,7 @@ import (
 type CloudClient interface {
 	ReportKafkaServerConfig(ctx context.Context, namespace string, servers []graphqlclient.KafkaServerConfigInput) error
 	ReportAppliedIntents(ctx context.Context, namespace *string, intents []*graphqlclient.IntentInput) error
-	ReportIntentsOperatorConfiguration(ctx context.Context, enableEnforcement bool) error
+	ReportIntentsOperatorConfiguration(ctx context.Context, globalEnforcementEnabled bool, networkPolicyEnforcementEnabled bool, kafkaACLEnforcementEnabled bool) error
 	ReportComponentStatus(ctx context.Context, component graphqlclient.ComponentType)
 }
 
@@ -57,9 +57,13 @@ func (c *CloudClientImpl) ReportAppliedIntents(
 
 func (c *CloudClientImpl) ReportIntentsOperatorConfiguration(
 	ctx context.Context,
-	enableEnforcement bool) error {
+	globalEnforcementEnabled bool,
+	networkPolicyEnforcementEnabled bool,
+	kafkaACLEnforcementEnabled bool) error {
 	_, err := graphqlclient.ReportIntentsOperatorConfiguration(ctx, c.client, graphqlclient.IntentsOperatorConfigurationInput{
-		EnableEnforcement: enableEnforcement,
+		GlobalEnforcementEnabled:        globalEnforcementEnabled,
+		NetworkPolicyEnforcementEnabled: networkPolicyEnforcementEnabled,
+		KafkaACLEnforcementEnabled:      kafkaACLEnforcementEnabled,
 	})
 	if err != nil {
 		return err

--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_api.go
@@ -11,9 +11,11 @@ import (
 type CloudClient interface {
 	ReportKafkaServerConfig(ctx context.Context, namespace string, servers []graphqlclient.KafkaServerConfigInput) error
 	ReportAppliedIntents(ctx context.Context, namespace *string, intents []*graphqlclient.IntentInput) error
-	ReportIntentsOperatorConfiguration(ctx context.Context, globalEnforcementEnabled bool, networkPolicyEnforcementEnabled bool, kafkaACLEnforcementEnabled bool) error
+	ReportIntentsOperatorConfiguration(ctx context.Context, config IntentsOperatorConfigurationInput) error
 	ReportComponentStatus(ctx context.Context, component graphqlclient.ComponentType)
 }
+
+type IntentsOperatorConfigurationInput graphqlclient.IntentsOperatorConfigurationInput
 
 type CloudClientImpl struct {
 	client graphql.Client
@@ -57,14 +59,8 @@ func (c *CloudClientImpl) ReportAppliedIntents(
 
 func (c *CloudClientImpl) ReportIntentsOperatorConfiguration(
 	ctx context.Context,
-	globalEnforcementEnabled bool,
-	networkPolicyEnforcementEnabled bool,
-	kafkaACLEnforcementEnabled bool) error {
-	_, err := graphqlclient.ReportIntentsOperatorConfiguration(ctx, c.client, graphqlclient.IntentsOperatorConfigurationInput{
-		GlobalEnforcementEnabled:        globalEnforcementEnabled,
-		NetworkPolicyEnforcementEnabled: networkPolicyEnforcementEnabled,
-		KafkaACLEnforcementEnabled:      kafkaACLEnforcementEnabled,
-	})
+	config IntentsOperatorConfigurationInput) error {
+	_, err := graphqlclient.ReportIntentsOperatorConfiguration(ctx, c.client, graphqlclient.IntentsOperatorConfigurationInput(config))
 	if err != nil {
 		return err
 	}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -47,8 +47,6 @@ var (
 	scheme = runtime.NewScheme()
 )
 
-const enableEnforcementKey = "enable-enforcement"
-
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -91,7 +89,7 @@ func main() {
 		"Whether to generate and use a self signed cert as the CA for webhooks")
 	pflag.BoolVar(&disableWebhookServer, "disable-webhook-server", false,
 		"Disable webhook validator server")
-	pflag.BoolVar(&enforcementEnabledGlobally, enableEnforcementKey, true,
+	pflag.BoolVar(&enforcementEnabledGlobally, "enable-enforcement", true,
 		"If set to false disables the enforcement globally, superior to the other flags")
 	pflag.BoolVar(&autoCreateNetworkPoliciesForExternalTraffic, "auto-create-network-policies-for-external-traffic", true,
 		"Whether to automatically create network policies for external traffic")
@@ -234,16 +232,16 @@ func main() {
 	defer cancelFunc()
 	cloudClient, connectedToCloud, err := otterizecloud.NewClient(ctx)
 	if err != nil {
-		logrus.WithError(err).Warning("Failed to connect to Otterize cloud")
+		logrus.WithError(err).Fatal("Failed to connect to Otterize cloud")
 	}
 	if connectedToCloud {
-		err := cloudClient.ReportIntentsOperatorConfiguration(ctx, enforcementEnabledGlobally)
+		err := cloudClient.ReportIntentsOperatorConfiguration(ctx, enforcementEnabledGlobally, enableNetworkPolicyCreation, enableKafkaACLCreation)
 		if err != nil {
-			logrus.WithError(err).Warning("Failed to report configuration to the cloud")
+			logrus.WithError(err).Fatal("Failed to report configuration to the cloud")
 		}
 	}
 	if !enforcementEnabledGlobally {
-		logrus.Infof("Running with %s=false, won't perform any enforcement", enableEnforcementKey)
+		logrus.Infof("Running with enforcement disabled globally, won't perform any enforcement")
 	}
 
 	logrus.Info("starting manager")

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -222,12 +222,16 @@ func main() {
 	defer cancelFunc()
 	otterizeCloudClient, connectedToCloud, err := otterizecloud.NewClient(timeoutCtx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to initialize Otterize Cloud client")
+		logrus.WithError(err).Error("Failed to initialize Otterize Cloud client")
 	}
 	if connectedToCloud {
-		err := otterizeCloudClient.ReportIntentsOperatorConfiguration(timeoutCtx, enforcementEnabledGlobally, enableNetworkPolicyCreation, enableKafkaACLCreation)
+		err := otterizeCloudClient.ReportIntentsOperatorConfiguration(timeoutCtx, otterizecloud.IntentsOperatorConfigurationInput{
+			GlobalEnforcementEnabled:        enforcementEnabledGlobally,
+			NetworkPolicyEnforcementEnabled: enableNetworkPolicyCreation,
+			KafkaACLEnforcementEnabled:      enableKafkaACLCreation,
+		})
 		if err != nil {
-			logrus.WithError(err).Fatal("Failed to report configuration to the cloud")
+			logrus.WithError(err).Error("Failed to report configuration to the cloud")
 		}
 		otterizecloud.StartPeriodicallyReportConnectionToCloud(otterizeCloudClient, signalHandlerCtx)
 	} else {

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -79,11 +79,25 @@ const (
 )
 
 type IntentsOperatorConfigurationInput struct {
-	EnableEnforcement bool `json:"enableEnforcement"`
+	GlobalEnforcementEnabled        bool `json:"globalEnforcementEnabled"`
+	NetworkPolicyEnforcementEnabled bool `json:"networkPolicyEnforcementEnabled"`
+	KafkaACLEnforcementEnabled      bool `json:"kafkaACLEnforcementEnabled"`
 }
 
-// GetEnableEnforcement returns IntentsOperatorConfigurationInput.EnableEnforcement, and is useful for accessing the field via an interface.
-func (v *IntentsOperatorConfigurationInput) GetEnableEnforcement() bool { return v.EnableEnforcement }
+// GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetGlobalEnforcementEnabled() bool {
+	return v.GlobalEnforcementEnabled
+}
+
+// GetNetworkPolicyEnforcementEnabled returns IntentsOperatorConfigurationInput.NetworkPolicyEnforcementEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetNetworkPolicyEnforcementEnabled() bool {
+	return v.NetworkPolicyEnforcementEnabled
+}
+
+// GetKafkaACLEnforcementEnabled returns IntentsOperatorConfigurationInput.KafkaACLEnforcementEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetKafkaACLEnforcementEnabled() bool {
+	return v.KafkaACLEnforcementEnabled
+}
 
 type KafkaConfigInput struct {
 	Name       *string           `json:"name"`

--- a/src/shared/otterizecloud/mocks/mock_cloud_api.go
+++ b/src/shared/otterizecloud/mocks/mock_cloud_api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	otterizecloud "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/otterizecloud"
 	graphqlclient "github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
 )
 
@@ -62,17 +63,17 @@ func (mr *MockCloudClientMockRecorder) ReportComponentStatus(ctx, component inte
 }
 
 // ReportIntentsOperatorConfiguration mocks base method.
-func (m *MockCloudClient) ReportIntentsOperatorConfiguration(ctx context.Context, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled bool) error {
+func (m *MockCloudClient) ReportIntentsOperatorConfiguration(ctx context.Context, config otterizecloud.IntentsOperatorConfigurationInput) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportIntentsOperatorConfiguration", ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled)
+	ret := m.ctrl.Call(m, "ReportIntentsOperatorConfiguration", ctx, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportIntentsOperatorConfiguration indicates an expected call of ReportIntentsOperatorConfiguration.
-func (mr *MockCloudClientMockRecorder) ReportIntentsOperatorConfiguration(ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportIntentsOperatorConfiguration(ctx, config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIntentsOperatorConfiguration", reflect.TypeOf((*MockCloudClient)(nil).ReportIntentsOperatorConfiguration), ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIntentsOperatorConfiguration", reflect.TypeOf((*MockCloudClient)(nil).ReportIntentsOperatorConfiguration), ctx, config)
 }
 
 // ReportKafkaServerConfig mocks base method.

--- a/src/shared/otterizecloud/mocks/mock_cloud_api.go
+++ b/src/shared/otterizecloud/mocks/mock_cloud_api.go
@@ -62,17 +62,17 @@ func (mr *MockCloudClientMockRecorder) ReportComponentStatus(ctx, component inte
 }
 
 // ReportIntentsOperatorConfiguration mocks base method.
-func (m *MockCloudClient) ReportIntentsOperatorConfiguration(ctx context.Context, enableEnforcement bool) error {
+func (m *MockCloudClient) ReportIntentsOperatorConfiguration(ctx context.Context, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReportIntentsOperatorConfiguration", ctx, enableEnforcement)
+	ret := m.ctrl.Call(m, "ReportIntentsOperatorConfiguration", ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReportIntentsOperatorConfiguration indicates an expected call of ReportIntentsOperatorConfiguration.
-func (mr *MockCloudClientMockRecorder) ReportIntentsOperatorConfiguration(ctx, enableEnforcement interface{}) *gomock.Call {
+func (mr *MockCloudClientMockRecorder) ReportIntentsOperatorConfiguration(ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIntentsOperatorConfiguration", reflect.TypeOf((*MockCloudClient)(nil).ReportIntentsOperatorConfiguration), ctx, enableEnforcement)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIntentsOperatorConfiguration", reflect.TypeOf((*MockCloudClient)(nil).ReportIntentsOperatorConfiguration), ctx, globalEnforcementEnabled, networkPolicyEnforcementEnabled, kafkaACLEnforcementEnabled)
 }
 
 // ReportKafkaServerConfig mocks base method.


### PR DESCRIPTION
### Description

A previous change #104 added the ability to report global enforcement state to Otterize Cloud - this PR adds the ability to report network policy and Kafka ACL enforcement state individually, in addition to the global state.