### PR TITLE
Validate new object on update

### DIFF
--- a/src/operator/webhooks/clientintents_webhook.go
+++ b/src/operator/webhooks/clientintents_webhook.go
@@ -80,7 +80,7 @@ func (v *IntentsValidator) ValidateCreate(ctx context.Context, obj runtime.Objec
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *IntentsValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
 	var allErrs field.ErrorList
-	intentsObj := oldObj.(*otterizev1alpha2.ClientIntents)
+	intentsObj := newObj.(*otterizev1alpha2.ClientIntents)
 	intentsList := &otterizev1alpha2.ClientIntentsList{}
 	if err := v.List(ctx, intentsList, &client.ListOptions{Namespace: intentsObj.Namespace}); err != nil {
 		return err

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -417,10 +417,7 @@ func (s *ControllerManagerTestSuiteBase) UpdateIntents(
 
 	intents.Spec.Calls = callList
 
-	err = s.Mgr.GetClient().Update(context.Background(), intents)
-	s.Require().NoError(err)
-
-	return nil
+	return s.Mgr.GetClient().Update(context.Background(), intents)
 }
 
 func (s *ControllerManagerTestSuiteBase) RemoveIntents(


### PR DESCRIPTION
### Description

Until this PR when applying patch to existing `ClientIntent` the validator checked the old object instead of the new one. It didn't return error when invalid combination of type and topic \ resource where applied, and instead we get failure when applying fix with the correct object. This PR change it to check the new as necessary, the old one is ignored just like we do on delete

### Testing

Add test that reproduce the bug and make sure we get error
- [x] This change adds test coverage for new/changed/fixed functionality
