### PR TITLE
Fix small timeout in token acquisition

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
@@ -5,6 +5,7 @@ import (
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,8 +44,11 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 	}
 
 	if err = r.otterizeClient.ReportAppliedIntents(ctx, lo.ToPtr(req.Namespace), intentsInput); err != nil {
+		logrus.WithError(err).Error("failed to report applied intents")
 		return ctrl.Result{}, err
 	}
+
+	logrus.Infof("successfully reported applied intents %d", len(clientIntentsList.Items))
 
 	return ctrl.Result{}, nil
 }

--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
@@ -48,7 +48,7 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 		return ctrl.Result{}, err
 	}
 
-	logrus.Infof("successfully reported applied intents %d", len(clientIntentsList.Items))
+	logrus.Infof("successfully reported %d applied intents", len(clientIntentsList.Items))
 
 	return ctrl.Result{}, nil
 }

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"github.com/bombsimon/logrusr/v3"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/otterize/intents-operator/src/operator/controllers"
 	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/otterizecloud"
@@ -29,9 +30,6 @@ import (
 	"github.com/spf13/pflag"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"time"
-
-	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -161,14 +159,12 @@ func main() {
 	}
 
 	signalHandlerCtx := ctrl.SetupSignalHandler()
-	timeoutCtx, cancelFunc := context.WithTimeout(signalHandlerCtx, 10*time.Second)
-	defer cancelFunc()
-	otterizeCloudClient, connectedToCloud, err := otterizecloud.NewClient(timeoutCtx)
+	otterizeCloudClient, connectedToCloud, err := otterizecloud.NewClient(signalHandlerCtx)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to initialize Otterize Cloud client")
 	}
 	if connectedToCloud {
-		err := otterizeCloudClient.ReportIntentsOperatorConfiguration(timeoutCtx, graphqlclient.IntentsOperatorConfigurationInput{
+		err := otterizeCloudClient.ReportIntentsOperatorConfiguration(signalHandlerCtx, graphqlclient.IntentsOperatorConfigurationInput{
 			GlobalEnforcementEnabled:        enforcementEnabledGlobally,
 			NetworkPolicyEnforcementEnabled: enforcementEnabledGlobally && enableNetworkPolicyCreation,
 			KafkaACLEnforcementEnabled:      enforcementEnabledGlobally && enableKafkaACLCreation,

--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -8,12 +8,14 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+	"net/http"
 )
 
 func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 	clientID := viper.GetString(ApiClientIdKey)
 	secret := viper.GetString(ApiClientSecretKey)
 	apiAddress := viper.GetString(OtterizeAPIAddressKey)
+	clientTimeout := viper.GetDuration(CloudClientTimeoutKey)
 	if clientID == "" && secret == "" {
 		return nil, false, nil
 	}
@@ -31,9 +33,13 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 		AuthStyle:    oauth2.AuthStyleInParams,
 	}
 
-	tokenSrc := cfg.TokenSource(ctx)
-	graphqlUrl := fmt.Sprintf("%s/graphql/v1beta", apiAddress)
-	httpClient := oauth2.NewClient(ctx, tokenSrc)
+	// Timeout for oauth token acquisition is set using the http client passed to the token source context
+	clientWithTimeout := &http.Client{Timeout: clientTimeout}
+	ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, clientWithTimeout)
 
+	tokenSrc := cfg.TokenSource(ctxWithClient)
+	graphqlUrl := fmt.Sprintf("%s/graphql/v1beta", apiAddress)
+	httpClient := oauth2.NewClient(ctxWithClient, tokenSrc)
+	httpClient.Timeout = clientTimeout
 	return graphql.NewClient(graphqlUrl, httpClient), true, nil
 }

--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -33,13 +33,22 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 		AuthStyle:    oauth2.AuthStyleInParams,
 	}
 
-	// Timeout for oauth token acquisition is set using the http client passed to the token source context
+	// Timeout for oauth token acquisition is set by http client passed to the token source context
+	// See example 'Example (CustomHTTP)' in https://pkg.go.dev/golang.org/x/oauth2
 	clientWithTimeout := &http.Client{Timeout: clientTimeout}
 	ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, clientWithTimeout)
 
 	tokenSrc := cfg.TokenSource(ctxWithClient)
 	graphqlUrl := fmt.Sprintf("%s/graphql/v1beta", apiAddress)
 	httpClient := oauth2.NewClient(ctxWithClient, tokenSrc)
+
+	// Timeout in context isn't used in the client itself
+	// as mentioned in https://pkg.go.dev/golang.org/x/oauth2#NewClient:
+	//
+	// 		"Note that if a custom *http.Client is provided via the
+	//		Context it is used only for token acquisition and is not
+	//		used to configure the *http.Client returned from NewClient"
 	httpClient.Timeout = clientTimeout
+
 	return graphql.NewClient(graphqlUrl, httpClient), true, nil
 }

--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client_test.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client_test.go
@@ -1,0 +1,64 @@
+package otterizecloudclient
+
+import (
+	"context"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type CloudClientTestSuite struct {
+	suite.Suite
+}
+
+func (s *CloudClientTestSuite) SetupTest() {
+	viper.Reset()
+}
+
+func (s *CloudClientTestSuite) TearDownTest() {
+	viper.Reset()
+}
+
+func (s *CloudClientTestSuite) TestNewClientSuccess() {
+	viper.Set(ApiClientIdKey, "cli_id1234")
+	viper.Set(ApiClientSecretKey, "secret1234")
+	viper.Set(OtterizeAPIAddressKey, "https://testapp.otterize.com/api")
+	viper.Set(CloudClientTimeoutKey, "30s")
+
+	ctx := context.Background()
+	client, ok, err := NewClient(ctx)
+	s.Nil(err)
+	s.True(ok)
+	s.NotNil(client)
+}
+
+func (s *CloudClientTestSuite) TestNoCredentialsNoClient() {
+	viper.Set(ApiClientIdKey, "")
+	viper.Set(ApiClientSecretKey, "")
+
+	ctx := context.Background()
+	client, ok, err := NewClient(ctx)
+	s.Nil(err)
+	s.False(ok)
+	s.Nil(client)
+}
+
+func (s *CloudClientTestSuite) TestPartialCredentialsReturnError() {
+	viper.Set(ApiClientIdKey, "cli_id1234")
+	viper.Set(ApiClientSecretKey, "")
+
+	ctx := context.Background()
+	_, _, err := NewClient(ctx)
+	s.NotNil(err)
+
+	viper.Set(ApiClientIdKey, "")
+	viper.Set(ApiClientSecretKey, "secret1234")
+
+	ctx = context.Background()
+	_, _, err = NewClient(ctx)
+	s.NotNil(err)
+}
+
+func TestNewClientTestSuite(t *testing.T) {
+	suite.Run(t, &CloudClientTestSuite{})
+}

--- a/src/shared/otterizecloud/otterizecloudclient/config.go
+++ b/src/shared/otterizecloud/otterizecloudclient/config.go
@@ -9,6 +9,8 @@ const (
 	ApiClientIdKey                 = "client-id"
 	ApiClientSecretKey             = "client-secret"
 	OtterizeAPIAddressKey          = "api-address"
+	CloudClientTimeoutKey          = "cloud-client-timeout"
+	CloudClientTimeoutDefault      = "30s"
 	OtterizeAPIAddressDefault      = "https://app.otterize.com/api"
 	ComponentReportIntervalKey     = "component-report-interval"
 	ComponentReportIntervalDefault = 60
@@ -18,6 +20,7 @@ const (
 func init() {
 	viper.SetDefault(OtterizeAPIAddressKey, OtterizeAPIAddressDefault)
 	viper.SetDefault(ComponentReportIntervalKey, ComponentReportIntervalDefault)
+	viper.SetDefault(CloudClientTimeoutKey, CloudClientTimeoutDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
### Description

Until this PR token source timeout received context with timeout of 10sec from application start.
Since token acquisition happen after 24 hours, it immediately gets a timeout and exit.

This PR create token source with timeout on httpclient, like the package expects the user to do
