### PR TITLE
Use context timeout instead of HTTP client 

### DIFF
--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +45,10 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 		return ctrl.Result{}, err
 	}
 
-	if err = r.otterizeClient.ReportAppliedIntents(ctx, lo.ToPtr(req.Namespace), intentsInput); err != nil {
+	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutDefault))
+	defer cancel()
+
+	if err = r.otterizeClient.ReportAppliedIntents(timeoutCtx, lo.ToPtr(req.Namespace), intentsInput); err != nil {
 		logrus.WithError(err).Error("failed to report applied intents")
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/status_report.go
@@ -20,16 +20,23 @@ func runPeriodicReportConnection(interval int, client CloudClient, ctx context.C
 	cloudUploadTicker := time.NewTicker(time.Second * time.Duration(interval))
 
 	logrus.Info("Starting cloud connection ticker")
-	client.ReportComponentStatus(ctx, graphqlclient.ComponentTypeIntentsOperator)
+	reportStatus(ctx, client)
 
 	for {
 		select {
 		case <-cloudUploadTicker.C:
-			client.ReportComponentStatus(ctx, graphqlclient.ComponentTypeIntentsOperator)
+			reportStatus(ctx, client)
 
 		case <-ctx.Done():
 			logrus.Info("Periodic upload exit")
 			return
 		}
 	}
+}
+
+func reportStatus(ctx context.Context, client CloudClient) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutDefault))
+	defer cancel()
+
+	client.ReportComponentStatus(timeoutCtx, graphqlclient.ComponentTypeIntentsOperator)
 }

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -25,8 +25,10 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -311,7 +313,10 @@ func (r *KafkaServerConfigReconciler) uploadKafkaServerConfigs(ctx context.Conte
 		inputs = append(inputs, input)
 	}
 
-	return r.otterizeClient.ReportKafkaServerConfig(ctx, namespace, inputs)
+	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutDefault))
+	defer cancel()
+
+	return r.otterizeClient.ReportKafkaServerConfig(timeoutCtx, namespace, inputs)
 }
 
 func kafkaServerConfigCRDToCloudModel(kafkaServerConfig otterizev1alpha2.KafkaServerConfig) (graphqlclient.KafkaServerConfigInput, error) {

--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -42,13 +42,5 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 	graphqlUrl := fmt.Sprintf("%s/graphql/v1beta", apiAddress)
 	httpClient := oauth2.NewClient(ctxWithClient, tokenSrc)
 
-	// Timeout in context isn't used in the client itself
-	// as mentioned in https://pkg.go.dev/golang.org/x/oauth2#NewClient:
-	//
-	// 		"Note that if a custom *http.Client is provided via the
-	//		Context it is used only for token acquisition and is not
-	//		used to configure the *http.Client returned from NewClient"
-	httpClient.Timeout = clientTimeout
-
 	return graphql.NewClient(graphqlUrl, httpClient), true, nil
 }


### PR DESCRIPTION
### Description

This PR replace the default timeout in cloud http client with context timeout for every operation. 
This behavior is more explicit, allow adjusting the value per use case.