### PR TITLE
Support custom root CAs when initializing cloud client

### DIFF
--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -48,6 +48,7 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 		cert, err := os.ReadFile(path)
 		if err != nil {
 			logrus.Errorf("Error loading cert PEM file at '%s', trying to continue without it: %s", path, err)
+			continue
 		}
 
 		if ok := rootCAs.AppendCertsFromPEM(cert); !ok {

--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -2,13 +2,17 @@ package otterizecloudclient
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"github.com/Khan/genqlient/graphql"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 	"net/http"
+	"os"
 )
 
 func NewClient(ctx context.Context) (graphql.Client, bool, error) {
@@ -16,6 +20,7 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 	secret := viper.GetString(ApiClientSecretKey)
 	apiAddress := viper.GetString(OtterizeAPIAddressKey)
 	clientTimeout := viper.GetDuration(CloudClientTimeoutKey)
+	extraCAPEMPaths := viper.GetStringSlice(OtterizeAPIExtraCAPEMPathsKey)
 	if clientID == "" && secret == "" {
 		return nil, false, nil
 	}
@@ -33,9 +38,28 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 		AuthStyle:    oauth2.AuthStyleInParams,
 	}
 
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, false, fmt.Errorf("error loading root system cert pool: %w", err)
+	}
+
+	for _, path := range extraCAPEMPaths {
+		logrus.Infof("Loading root CA from cert PEM file at '%s'", path)
+		cert, err := os.ReadFile(path)
+		if err != nil {
+			logrus.Errorf("Error loading cert PEM file at '%s', trying to continue without it: %s", path, err)
+		}
+
+		if ok := rootCAs.AppendCertsFromPEM(cert); !ok {
+			logrus.Warnf("Failed appending cert PEM file at '%s', trying to continue without it", path)
+		}
+	}
+
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}}
+
 	// Timeout for oauth token acquisition is set by http client passed to the token source context
 	// See example 'Example (CustomHTTP)' in https://pkg.go.dev/golang.org/x/oauth2
-	clientWithTimeout := &http.Client{Timeout: clientTimeout}
+	clientWithTimeout := &http.Client{Timeout: clientTimeout, Transport: transport}
 	ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, clientWithTimeout)
 
 	tokenSrc := cfg.TokenSource(ctxWithClient)

--- a/src/shared/otterizecloud/otterizecloudclient/config.go
+++ b/src/shared/otterizecloud/otterizecloudclient/config.go
@@ -10,6 +10,7 @@ const (
 	ApiClientSecretKey             = "client-secret"
 	OtterizeAPIAddressKey          = "api-address"
 	CloudClientTimeoutKey          = "cloud-client-timeout"
+	OtterizeAPIExtraCAPEMPathsKey  = "api-extra-ca-pem"
 	CloudClientTimeoutDefault      = "30s"
 	OtterizeAPIAddressDefault      = "https://app.otterize.com/api"
 	ComponentReportIntervalKey     = "component-report-interval"
@@ -21,6 +22,7 @@ func init() {
 	viper.SetDefault(OtterizeAPIAddressKey, OtterizeAPIAddressDefault)
 	viper.SetDefault(ComponentReportIntervalKey, ComponentReportIntervalDefault)
 	viper.SetDefault(CloudClientTimeoutKey, CloudClientTimeoutDefault)
+	viper.SetDefault(OtterizeAPIExtraCAPEMPathsKey, []string{})
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
### Description
Support providing custom root CAs when initializing the otterize cloud client.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
