### PR TITLE
Netanelb/create istio reconciler

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -55,6 +55,7 @@ func NewIntentsReconciler(
 			intents_reconcilers.NewPodLabelReconciler(client, scheme),
 			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementEnabledGlobally),
 			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementEnabledGlobally),
+			intents_reconcilers.NewIstioPolicyReconciler(client, scheme, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementEnabledGlobally),
 		)}
 
 	if otterizeClient != nil {

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -30,6 +30,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type EnforcementConfig struct {
+	EnforcementEnabledGlobally bool
+	EnableNetworkPolicy        bool
+	EnableKafkaACL             bool
+	EnableIstioPolicy          bool
+}
+
 // IntentsReconciler reconciles a Intents object
 type IntentsReconciler struct {
 	group *reconcilergroup.Group
@@ -41,14 +48,13 @@ func NewIntentsReconciler(
 	kafkaServerStore kafkaacls.ServersStore,
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
-	enforcementEnabledGlobally bool,
-	enableNetworkPolicyCreation, enableKafkaACLCreation bool,
+	enforcementConfig EnforcementConfig,
 	otterizeClient otterizecloud.CloudClient) *IntentsReconciler {
 	intentsReconciler := &IntentsReconciler{
 		group: reconcilergroup.NewGroup("intents-reconciler", client, scheme,
 			intents_reconcilers.NewPodLabelReconciler(client, scheme),
-			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enableNetworkPolicyCreation, enforcementEnabledGlobally),
-			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enableKafkaACLCreation, kafkaacls.NewKafkaIntentsAdmin, enforcementEnabledGlobally),
+			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementEnabledGlobally),
+			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementEnabledGlobally),
 		)}
 
 	if otterizeClient != nil {

--- a/src/operator/controllers/intents_reconcilers/istio_poicy_test.go
+++ b/src/operator/controllers/intents_reconcilers/istio_poicy_test.go
@@ -1,0 +1,177 @@
+package intents_reconcilers
+
+import (
+	"context"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"testing"
+)
+
+type IstioPolicyReconcilerTestSuite struct {
+	testbase.ControllerManagerTestSuiteBase
+	Reconciler *IstioPolicyReconciler
+}
+
+func (s *IstioPolicyReconcilerTestSuite) SetupSuite() {
+	s.TestEnv = &envtest.Environment{}
+	var err error
+	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "config", "crd")}
+
+	s.RestConfig, err = s.TestEnv.Start()
+	s.Require().NoError(err)
+	s.Require().NotNil(s.RestConfig)
+
+	s.K8sDirectClient, err = kubernetes.NewForConfig(s.RestConfig)
+	s.Require().NoError(err)
+	s.Require().NotNil(s.K8sDirectClient)
+
+	err = otterizev1alpha2.AddToScheme(s.TestEnv.Scheme)
+	s.Require().NoError(err)
+}
+
+func (s *IstioPolicyReconcilerTestSuite) BeforeTest(_, testName string) {
+	s.ControllerManagerTestSuiteBase.BeforeTest("", testName)
+	s.Reconciler = NewIstioPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, true)
+}
+
+func (s *IstioPolicyReconcilerTestSuite) SetupTest() {
+	s.ControllerManagerTestSuiteBase.SetupTest()
+}
+
+func (s *IstioPolicyReconcilerTestSuite) TestGlobalEnforcementDisabled() {
+	intents, err := s.AddIntents("test-intents", "test-client", []otterizev1alpha2.Intent{{
+		Type: otterizev1alpha2.IntentTypeHTTP, Name: "test-server",
+	},
+	})
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	reconciler := NewIstioPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, false)
+	recorder := record.NewFakeRecorder(100)
+	reconciler.InjectRecorder(recorder)
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: s.TestNamespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	select {
+	case event := <-recorder.Events:
+		s.Require().Contains(event, ReasonEnforcementGloballyDisabled)
+	default:
+		s.Fail("event not raised")
+	}
+}
+
+func (s *IstioPolicyReconcilerTestSuite) TestIstioPolicyEnforcementDisabled() {
+	intents, err := s.AddIntents("test-intents", "test-client", []otterizev1alpha2.Intent{{
+		Type: otterizev1alpha2.IntentTypeHTTP, Name: "test-server",
+	},
+	})
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	reconciler := NewIstioPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, false, true)
+	recorder := record.NewFakeRecorder(100)
+	reconciler.InjectRecorder(recorder)
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: s.TestNamespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	select {
+	case event := <-recorder.Events:
+		s.Require().Contains(event, ReasonIstioPolicyCreationDisabled)
+	default:
+		s.Fail("event not raised")
+	}
+}
+
+func (s *IstioPolicyReconcilerTestSuite) TestIstioPolicyFinalizerAddedAndRemove() {
+	intentObjectName := "finalizer-intents"
+	intents, err := s.AddIntents(intentObjectName, "test-client", []otterizev1alpha2.Intent{{
+		Type: otterizev1alpha2.IntentTypeHTTP, Name: "test-server",
+	},
+	})
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	res, err := s.Reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: s.TestNamespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	intents = &otterizev1alpha2.ClientIntents{}
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{
+			Namespace: s.TestNamespace,
+			Name:      intentObjectName,
+		}, intents)
+		assert.NoError(err)
+		assert.NotEmpty(intents.Finalizers)
+	})
+	s.Require().Contains(intents.Finalizers, IstioPolicyFinalizerName)
+
+	additionalFinalizerIntents := intents.DeepCopy()
+	// We have to add another finalizer so the object won't actually be deleted after the reconciler finishes
+	additionalFinalizerIntents.Finalizers = append(additionalFinalizerIntents.Finalizers, "finalizer-to-prevent-obj-deletion")
+	err = s.Mgr.GetClient().Patch(context.Background(), additionalFinalizerIntents, client.MergeFrom(intents))
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	err = s.Mgr.GetClient().Delete(context.Background(), intents, &client.DeleteOptions{GracePeriodSeconds: lo.ToPtr(int64(0))})
+	s.Require().NoError(err)
+	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+
+	s.WaitForDeletionToBeMarked(intents)
+
+	res = ctrl.Result{Requeue: true}
+	for res.Requeue {
+		res, err = s.Reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: s.TestNamespace,
+				Name:      intents.Name,
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
+	}
+
+	intents = &otterizev1alpha2.ClientIntents{}
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err = s.Mgr.GetCache().Get(context.Background(), types.NamespacedName{
+			Namespace: s.TestNamespace, Name: "finalizer-intents",
+		}, intents)
+		assert.True(len(intents.Finalizers) == 1 && intents.Finalizers[0] != otterizev1alpha2.NetworkPolicyFinalizerName)
+	})
+	s.Require().NotContains(intents.Finalizers, IstioPolicyFinalizerName)
+}
+
+func TestIstioPolicyReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(IstioPolicyReconcilerTestSuite))
+}

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -62,7 +62,7 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
-			r.RecordWarningEventf(intents, ReasonRemovingIstioPolicyFailed, "could not remove network policies: %s", err.Error())
+			r.RecordWarningEventf(intents, ReasonRemovingIstioPolicyFailed, "could not remove istio policies: %s", err.Error())
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -1,0 +1,105 @@
+package intents_reconcilers
+
+import (
+	"context"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	IstioPolicyFinalizerName          = "intents.otterize.com/istio-policy-finalizer"
+	ReasonIstioPolicyCreationDisabled = "IstioPolicyCreationDisabled"
+	ReasonRemovingIstioPolicyFailed   = "RemovingIstioPolicyFailed"
+)
+
+type IstioPolicyReconciler struct {
+	client.Client
+	Scheme                     *runtime.Scheme
+	enableIstioPolicyCreation  bool
+	enforcementEnabledGlobally bool
+	injectablerecorder.InjectableRecorder
+}
+
+func NewIstioPolicyReconciler(
+	c client.Client,
+	s *runtime.Scheme,
+	enableIstioPolicyCreation bool,
+	enforcementEnabledGlobally bool) *IstioPolicyReconciler {
+	return &IstioPolicyReconciler{
+		Client:                     c,
+		Scheme:                     s,
+		enableIstioPolicyCreation:  enableIstioPolicyCreation,
+		enforcementEnabledGlobally: enforcementEnabledGlobally,
+	}
+}
+
+func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	intents := &otterizev1alpha2.ClientIntents{}
+	err := r.Get(ctx, req.NamespacedName, intents)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if intents.Spec == nil {
+		return ctrl.Result{}, nil
+	}
+
+	logrus.Infof("Reconciling Istio authorization policies for service %s in namespace %s",
+		intents.Spec.Service.Name, req.Namespace)
+
+	if !intents.DeletionTimestamp.IsZero() {
+		err := r.cleanFinalizerAndPolicies(ctx, intents)
+		if err != nil {
+			if k8serrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			r.RecordWarningEventf(intents, ReasonRemovingIstioPolicyFailed, "could not remove network policies: %s", err.Error())
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(intents, IstioPolicyFinalizerName) {
+		logrus.WithField("namespacedName", req.String()).Infof("Adding finalizer %s", IstioPolicyFinalizerName)
+		controllerutil.AddFinalizer(intents, IstioPolicyFinalizerName)
+		if err := r.Update(ctx, intents); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if !r.enforcementEnabledGlobally {
+		r.RecordNormalEvent(intents, ReasonEnforcementGloballyDisabled, "Enforcement is disabled globally, istio policy creation skipped")
+		return ctrl.Result{}, nil
+	}
+
+	if !r.enableIstioPolicyCreation {
+		r.RecordNormalEvent(intents, ReasonIstioPolicyCreationDisabled, "Istio policy creation is disabled, creation skipped")
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: handle authorization policies creation
+
+	return ctrl.Result{}, nil
+}
+
+func (r *IstioPolicyReconciler) cleanFinalizerAndPolicies(ctx context.Context, intents *otterizev1alpha2.ClientIntents) error {
+	if !controllerutil.ContainsFinalizer(intents, IstioPolicyFinalizerName) {
+		return nil
+	}
+
+	logrus.Infof("Removing Istio policies for deleted intents for service: %s", intents.Spec.Service.Name)
+
+	// TODO: remove authorization policies
+
+	controllerutil.RemoveFinalizer(intents, IstioPolicyFinalizerName)
+	return r.Update(ctx, intents)
+}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -99,6 +99,8 @@ func main() {
 		"Whether to enable istio authorization policy creation")
 	pflag.BoolVar(&enforcementConfig.EnableKafkaACL, "enable-kafka-acl-creation", true,
 		"Whether to disable Intents Kafka ACL creation")
+	pflag.BoolVar(&enforcementConfig.IstioFeatureFlagEnabled, "istio-feature-enabled", false,
+		"Whether to enable istio feature flag")
 
 	pflag.Parse()
 

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -86,15 +86,20 @@ type CertificateInformation {
 	ttl: Int
 }
 
+type Client {
+	id: ID!
+	secret: String!
+}
+
 type Cluster {
 	id: ID!
-	integration: Integration
-	defaultEnvironment: Environment
 	name: String!
-	components: IntegrationComponents!
 	configuration: ClusterConfiguration
 	namespaces: [Namespace!]!
 	serviceCount: Int!
+	integration: Integration
+	defaultEnvironment: Environment
+	components: IntegrationComponents!
 }
 
 type ClusterConfiguration {
@@ -170,11 +175,11 @@ enum EdgeAccessStatusVerdict {
 
 type Environment {
 	id: ID!
-	appliedIntentsCount: Int!
 	name: String!
 	labels: [Label!]
 	namespaces: [Namespace!]!
 	serviceCount: Int!
+	appliedIntentsCount: Int!
 }
 
 type HTTPConfig {
@@ -218,7 +223,6 @@ type Integration {
 }
 
 type IntegrationComponents {
-	clusterId: ID!
 	intentsOperator: IntentsOperatorComponent!
 	credentialsOperator: CredentialsOperatorComponent!
 	networkMapper: NetworkMapperComponent!
@@ -385,6 +389,26 @@ type MeMutation {
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
+"""Create client"""
+	createClient: Client!
+"""Delete client"""
+	deleteClient(
+		id: ID!
+	): ID!
+"""Create user invite"""
+	createInvite(
+		email: String!
+	): Invite!
+"""Delete user invite"""
+	deleteInvite(
+		id: ID!
+	): ID!
+"""Accept user invite"""
+	acceptInvite(
+		id: ID!
+	): Invite!
+"""Operate on the current logged-in user"""
+	me: MeMutation!
 """Create a new organization"""
 	createOrganization: Organization!
 """Update organization"""
@@ -398,23 +422,57 @@ type Mutation {
 		id: ID!
 		userId: ID!
 	): ID!
-"""Operate on the current logged-in user"""
-	me: MeMutation!
-"""Create user invite"""
-	createInvite(
-		email: String!
-	): Invite!
-"""Delete user invite"""
-	deleteInvite(
+	initializeOrganizationCAs(
+		organizationId: ID!
+	): Boolean!
+"""Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
+	registerKubernetesPodOwnerCertificateRequest(
+		podOwner: NamespacedPodOwner!
+		certificateCustomization: CertificateCustomization
+	): Service!
+"""Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners """
+	reportActiveCertificateRequesters(
+		activePodOwners: [NamespacedPodOwner!]!
+	): Boolean!
+"""Create cluster"""
+	createCluster(
+		name: String!
+	): Cluster!
+"""Delete cluster"""
+	deleteCluster(
 		id: ID!
 	): ID!
-"""Accept user invite"""
-	acceptInvite(
+"""Update cluster"""
+	updateCluster(
 		id: ID!
-	): Invite!
-	reportIntentsOperatorConfiguration(
-		configuration: IntentsOperatorConfigurationInput!
-	): Boolean!
+		name: String
+		configuration: ClusterConfigurationInput
+	): Cluster!
+"""Create a new environment"""
+	createEnvironment(
+		name: String!
+		labels: [LabelInput!]
+	): Environment!
+"""Update environment"""
+	updateEnvironment(
+		id: ID!
+		name: String
+		labels: [LabelInput!]
+	): Environment!
+"""Delete environment"""
+	deleteEnvironment(
+		id: ID!
+	): ID!
+"""Add label to environment"""
+	addEnvironmentLabel(
+		id: ID!
+		label: LabelInput!
+	): Environment!
+"""Remove label from environment"""
+	deleteEnvironmentLabel(
+		id: ID!
+		key: String!
+	): Environment!
 """Create a new generic integration"""
 	createGenericIntegration(
 		name: String!
@@ -442,8 +500,8 @@ type Mutation {
 	reportIntegrationComponentStatus(
 		component: ComponentType!
 	): Boolean!
-	createEnvIntCA(
-		environmentId: ID!
+	reportIntentsOperatorConfiguration(
+		configuration: IntentsOperatorConfigurationInput!
 	): Boolean!
 	reportDiscoveredIntents(
 		intents: [DiscoveredIntentInput!]!
@@ -456,58 +514,11 @@ type Mutation {
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
 	): Boolean!
-"""Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
-	registerKubernetesPodOwnerCertificateRequest(
-		podOwner: NamespacedPodOwner!
-		certificateCustomization: CertificateCustomization
-	): Service!
-"""Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners """
-	reportActiveCertificateRequesters(
-		activePodOwners: [NamespacedPodOwner!]!
-	): Boolean!
-"""Create a new environment"""
-	createEnvironment(
-		name: String!
-		labels: [LabelInput!]
-	): Environment!
-"""Update environment"""
-	updateEnvironment(
-		id: ID!
-		name: String
-		labels: [LabelInput!]
-	): Environment!
-"""Delete environment"""
-	deleteEnvironment(
-		id: ID!
-	): ID!
-"""Add label to environment"""
-	addEnvironmentLabel(
-		id: ID!
-		label: LabelInput!
-	): Environment!
-"""Remove label from environment"""
-	deleteEnvironmentLabel(
-		id: ID!
-		key: String!
-	): Environment!
 """Associate namespace to environment"""
 	associateNamespaceToEnv(
 		id: ID!
 		environmentId: ID
 	): Namespace!
-"""Create cluster"""
-	createCluster(
-		name: String!
-	): Cluster!
-"""Delete cluster"""
-	deleteCluster(
-		id: ID!
-	): ID!
-"""Update cluster"""
-	updateCluster(
-		id: ID!
-		configuration: ClusterConfigurationInput
-	): Cluster!
 }
 
 type Namespace {
@@ -538,20 +549,10 @@ type Organization {
 type Query {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""List organizations"""
-	organizations: [Organization!]!
-"""Get organization"""
-	organization(
+"""Get client"""
+	client(
 		id: ID!
-	): Organization!
-"""List users"""
-	users: [User!]!
-"""Get user"""
-	user(
-		id: ID!
-	): User!
-"""Get information regarding the current logged-in user"""
-	me: Me!
+	): Client!
 """List user invites"""
 	invites(
 		email: String
@@ -566,6 +567,49 @@ type Query {
 		email: String
 		status: InviteStatus
 	): Invite!
+"""Get information regarding the current logged-in user"""
+	me: Me!
+"""List organizations"""
+	organizations: [Organization!]!
+"""Get organization"""
+	organization(
+		id: ID!
+	): Organization!
+"""List users"""
+	users: [User!]!
+"""Get user"""
+	user(
+		id: ID!
+	): User!
+"""Get access graph"""
+	accessGraph(
+		filter: InputAccessGraphFilter
+	): AccessGraph!
+"""Get cluster"""
+	cluster(
+		id: ID!
+	): Cluster!
+"""List clusters"""
+	clusters(
+		name: String
+	): [Cluster!]!
+"""Get cluster by filters"""
+	oneCluster(
+		name: String!
+	): Cluster
+"""Get environment"""
+	environment(
+		id: ID!
+	): Environment!
+"""List environments"""
+	environments(
+		name: String
+		labels: [LabelInput!]
+	): [Environment!]!
+"""Get environment by filters"""
+	oneEnvironment(
+		name: String!
+	): Environment!
 """List integrations"""
 	integrations(
 		name: String
@@ -594,39 +638,6 @@ type Query {
 		clientId: ID
 		serverId: ID
 	): [Intent!]!
-"""Get service"""
-	service(
-		id: ID!
-	): Service!
-"""List services"""
-	services(
-		environmentId: ID
-		namespaceId: ID
-		name: String
-	): [Service!]!
-"""Get service by filters"""
-	oneService(
-		environmentId: ID
-		namespaceId: ID
-		name: String
-	): Service
-"""Get access graph"""
-	accessGraph(
-		filter: InputAccessGraphFilter
-	): AccessGraph!
-"""Get environment"""
-	environment(
-		id: ID!
-	): Environment!
-"""List environments"""
-	environments(
-		name: String
-		labels: [LabelInput!]
-	): [Environment!]!
-"""Get environment by filters"""
-	oneEnvironment(
-		name: String!
-	): Environment!
 """Get namespace"""
 	namespace(
 		id: ID!
@@ -643,18 +654,22 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
-"""Get cluster"""
-	cluster(
+"""Get service"""
+	service(
 		id: ID!
-	): Cluster!
-"""List clusters"""
-	clusters(
+	): Service!
+"""List services"""
+	services(
+		environmentId: ID
+		namespaceId: ID
 		name: String
-	): [Cluster!]!
-"""Get cluster by filters"""
-	oneCluster(
-		name: String!
-	): Cluster
+	): [Service!]!
+"""Get service by filters"""
+	oneService(
+		environmentId: ID
+		namespaceId: ID
+		name: String
+	): Service
 }
 
 type ServerBlockingStatus {
@@ -699,13 +714,13 @@ enum ServerProtectionStatusVerdict {
 
 type Service {
 	id: ID!
+	certificateInformation: CertificateInformation
 	tlsKeyPair: KeyPair!
 	name: String!
 	namespace: Namespace
 	environment: Environment!
 """If service is Kafka, its KafkaServerConfig."""
 	kafkaServerConfig: KafkaServerConfig
-	certificateInformation: CertificateInformation
 }
 
 type ServiceAccessGraph {


### PR DESCRIPTION
This is the initial step of generating Istio `AuthorizationPolicy` with the operator.
This PR is meant to support the new reconciler who will create those policies. Currently, it only adds finalizers to intents objects, record basic events and print log when creating is disabled.

The TODO comments this PR adds are all meant to mark the location where the next PRs will add logic. The feature flag will be removed or changed in the future, until the feature is ready the reconciler will be added only if explicitly asked.