### PR TITLE
Ignore deleted pod in Istio policy creator

### DIFF
--- a/src/watcher/reconcilers/pods.go
+++ b/src/watcher/reconcilers/pods.go
@@ -119,7 +119,7 @@ func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if p.istioEnforcementEnabled() {
+	if p.istioEnforcementEnabled() && pod.DeletionTimestamp == nil {
 		for _, clientIntents := range intents.Items {
 			err = p.createIstioPolicies(ctx, clientIntents, pod)
 			if err != nil {


### PR DESCRIPTION
Don't update Istio policies in pod watcher. Service account name is read when the pod is created and there is no need to delete the policy when the pod is down. 