### PR TITLE
Fix Istio CRD name and add log message

### DIFF
--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -53,12 +53,13 @@ func NewIstioPolicyReconciler(
 }
 
 func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	isIstioInstalled, err := istiopolicy.IsIstioInstalled(ctx, r.Client)
+	isIstioInstalled, err := istiopolicy.IsIstioAuthorizationPoliciesInstalled(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	if !isIstioInstalled {
+		logrus.Warning("authorization policies CRD is not installed, Istio policy creation skipped")
 		return ctrl.Result{}, nil
 	}
 

--- a/src/operator/controllers/istiopolicy/tools.go
+++ b/src/operator/controllers/istiopolicy/tools.go
@@ -9,10 +9,10 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 const (
+	IstioCRDName            = "authorizationpolicies.security.istio.io"
 	IstioProxyContainerName = "istio-proxy"
 )
 
@@ -25,12 +25,13 @@ func IsPodPartOfIstioMesh(pod corev1.Pod) bool {
 	return false
 }
 
-func IsIstioInstalled(ctx context.Context, client client.Client) (bool, error) {
-	gvks, _, err := client.Scheme().ObjectKinds(&v1beta1.AuthorizationPolicy{})
+func IsIstioAuthorizationPoliciesInstalled(ctx context.Context, client client.Client) (bool, error) {
+	groupVersionKinds, _, err := client.Scheme().ObjectKinds(&v1beta1.AuthorizationPolicy{})
 	if err != nil {
 		return false, err
 	}
-	istioCRDName := fmt.Sprintf("%s.%s", strings.ToLower(gvks[0].Kind), gvks[0].Group)
+
+	istioCRDName := fmt.Sprintf("authorizationpolicies.%s", groupVersionKinds[0].Group)
 	crd := apiextensionsv1.CustomResourceDefinition{}
 	err = client.Get(ctx, types.NamespacedName{Name: istioCRDName}, &crd)
 	if err != nil && !k8serrors.IsNotFound(err) {

--- a/src/watcher/reconcilers/pods.go
+++ b/src/watcher/reconcilers/pods.go
@@ -80,12 +80,13 @@ func (p *PodWatcher) handleIstioPolicy(ctx context.Context, pod v1.Pod, serviceI
 		return nil
 	}
 
-	isIstioInstalled, err := istiopolicy.IsIstioInstalled(ctx, p.Client)
+	isIstioInstalled, err := istiopolicy.IsIstioAuthorizationPoliciesInstalled(ctx, p.Client)
 	if err != nil {
 		return err
 	}
 
 	if !isIstioInstalled {
+		logrus.Warning("authorization policies CRD is not installed, Istio policy creation skipped")
 		return nil
 	}
 


### PR DESCRIPTION
Fix Istio Authorization Policy name. Until this PR the resource got dynamically from AuthorizationPolicy object, which is in single, while the resource definition name is in the plural. The result - istio policies never created.

This commit changes the name of the search target to plural and adds a warning to the logs