### PR TITLE
Turn telemetry off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Otterize intents operator
+# Otterize intents operator 
 
 <img title="Otter Manning Helm" src="./otterhelm.png" width=200 />
 

--- a/src/shared/telemetries/telemetrysender/config.go
+++ b/src/shared/telemetries/telemetrysender/config.go
@@ -10,7 +10,7 @@ const (
 	TimeoutKey                   = "telemetry-client-timeout"
 	CloudClientTimeoutDefault    = "30s"
 	TelemetryEnabledKey          = "telemetry-enabled"
-	TelemetryEnabledDefault      = true
+	TelemetryEnabledDefault      = false
 	TelemetryMaxBatchSizeKey     = "telemetry-max-batch-size"
 	TelemetryMaxBatchSizeDefault = 100
 	TelemetryIntervalKey         = "telemetry-interval-seconds"


### PR DESCRIPTION

### Description

Because helm charts with latest tagged images are still out there, we will disable telemetry by default on the operator and keep it on from the helm-chart. By doing so, only new users will send telemetries while the old ones won't.  

