### PR TITLE
Add 'update CRD' permission to intents operator

### DIFF
--- a/src/operator/Makefile
+++ b/src/operator/Makefile
@@ -54,7 +54,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=intents-operator-manager-role crd webhook paths="../..."
+	$(CONTROLLER_GEN) rbac:roleName=otterize-intents-operator-manager-role crd webhook paths="../..."
 
 
 .PHONY: generate

--- a/src/operator/config/rbac/role.yaml
+++ b/src/operator/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: intents-operator-manager-role
+  name: otterize-intents-operator-manager-role
 rules:
 - apiGroups:
   - ""
@@ -24,6 +24,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:
@@ -51,6 +57,15 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - k8s.otterize.com
   resources:

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -75,6 +75,7 @@ func NewIntentsReconciler(
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;update;patch;list;watch
 //+kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;update;patch;list;watch;delete;create
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;update;patch;list
+//+kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/src/watcher/reconcilers/namespace.go
+++ b/src/watcher/reconcilers/namespace.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+
 type NamespaceWatcher struct {
 	client.Client
 }


### PR DESCRIPTION
This change also ensures that Kubebuilder auto-generated manifests are aligned with the latest version of Helm charts.
