### PR TITLE
Remove redundant call to k8s api

### DIFF
--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -115,6 +115,7 @@ func (r *KafkaServerConfigReconciler) removeKafkaServerFromStore(kafkaServerConf
 }
 
 func (r *KafkaServerConfigReconciler) ensureFinalizerRunForOperatorIntents(ctx context.Context, config *otterizev1alpha2.KafkaServerConfig) error {
+	// Get the operator pod just to verify that we have the right name and namespace
 	operatorPod := &v1.Pod{}
 	err := r.Get(ctx, types.NamespacedName{Name: r.operatorPodName, Namespace: r.operatorPodNamespace}, operatorPod)
 	if err != nil {


### PR DESCRIPTION
The code removed call client.Get for operator pod, but nothing is done we the pod read. The only use was accessing `pod.Namespace` which is already known to us, that's how we got the pod in the first place.
