### PR TITLE
Fix bug where pod-watcher would fail to reconcile pods due to missing schema registration

### DIFF
--- a/.github/workflows/netpol-e2e-test.yaml
+++ b/.github/workflows/netpol-e2e-test.yaml
@@ -23,7 +23,7 @@ env:
 
 
 jobs:
-  e2e-test:
+  e2e-test-intents-last:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -116,3 +116,88 @@ jobs:
       
 
       
+  e2e-test-intents-first:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: ${{ secrets.OTTERIZEBOT_GITHUB_TOKEN }} # required for checking out submodules
+
+      - name: Login to GCR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: _json_key_base64
+          password: ${{ secrets.B64_GCLOUD_SERVICE_ACCOUNT_JSON}}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          start-args: "--network-plugin=cni --cni=calico"
+
+      - name: Wait for Calico startup
+        run: |-
+          kubectl wait pods -n kube-system -l k8s-app=calico-kube-controllers --for condition=Ready --timeout=90s
+          kubectl wait pods -n kube-system -l k8s-app=calico-node --for condition=Ready --timeout=90s
+          kubectl wait pods -n kube-system -l k8s-app=calico-kube-controllers --for condition=Ready --timeout=90s
+
+      - name: Install Otterize
+        run: |-
+          docker pull ${{ env.REGISTRY }}/intents-operator:${{ inputs.operator-tag }}
+          minikube image load ${{ env.REGISTRY }}/intents-operator:${{ inputs.operator-tag }}
+          docker pull ${{ env.REGISTRY }}/watcher:${{ inputs.watcher-tag }}
+          minikube image load  ${{ env.REGISTRY }}/watcher:${{ inputs.watcher-tag }}
+          
+          OPERATOR_FLAGS="--set-string intentsOperator.operator.repository=${{ env.REGISTRY }} --set-string intentsOperator.operator.image=intents-operator --set-string intentsOperator.operator.tag=${{ inputs.operator-tag }} --set-string intentsOperator.operator.pullPolicy=Never"
+          WATCHER_FLAGS="--set-string intentsOperator.watcher.repository=${{ env.REGISTRY }} --set-string intentsOperator.watcher.image=watcher --set-string intentsOperator.watcher.tag=${{ inputs.watcher-tag }} --set-string intentsOperator.watcher.pullPolicy=Never"
+          helm dep up ./helm-charts/otterize-kubernetes
+          helm install otterize ./helm-charts/otterize-kubernetes -n otterize-system --create-namespace $OPERATOR_FLAGS $WATCHER_FLAGS
+
+
+      - name: Wait for Otterize
+        run: |-
+          kubectl wait pods -n otterize-system -l app=intents-operator --for condition=Ready --timeout=360s
+          kubectl wait pods -n otterize-system -l app=otterize-watcher --for condition=Ready --timeout=360s
+
+
+      - name: Apply intents
+        run: |-
+          kubectl apply -f https://docs.otterize.com/code-examples/automate-network-policies/intents.yaml
+
+      - name: Deploy Tutorial services
+        run: |-
+          kubectl apply -f https://docs.otterize.com/code-examples/automate-network-policies/all.yaml
+
+      - name: Wait for Tutorial services
+        run: |-
+          kubectl wait pods -n otterize-tutorial-npol -l app=client --for condition=Ready --timeout=180s
+          kubectl wait pods -n otterize-tutorial-npol -l app=client-other --for condition=Ready --timeout=180s
+          kubectl wait pods -n otterize-tutorial-npol -l app=server --for condition=Ready --timeout=180s
+
+      - name: Test connectivity
+        run: |-
+          CLI1_POD=`kubectl get pod --selector app=client -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`
+          CLI2_POD=`kubectl get pod --selector app=client-other -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`          
+          echo Client: $CLI1_POD      client_other: $CLI2_POD
+          
+          # should work because there is an applied intent
+          echo check client log
+          kubectl logs --tail 14 -n otterize-tutorial-npol $CLI1_POD | grep "Hi, I am the server, you called, may I help you?"
+          
+          # should be blocked (using 3 because the log should repeat itself every 3 lines)
+          echo check client other log
+          kubectl logs --tail 3 -n otterize-tutorial-npol $CLI2_POD | grep "curl timed out"
+          
+      
+
+
+  e2e-test:
+    needs:
+      - e2e-test-intents-last
+      - e2e-test-intents-first


### PR DESCRIPTION
Pod watcher, which is responsible for labeling pods when they change, failed to reconcile pods because it required the v1.CustomResourceDefinition resource to be registered in its schema and it was not.

Added e2e test to catch this problem.