### PR TITLE
Add local docker image generation flow to Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Run the `make` command inside `src/operator` directory. Some useful commands are
 * `make build` to compile the go code.
 * `make deploy` to generate Kubernetes Deployment object which deploys the project to your local cluster.
 
+To create a local Docker image, execute `make docker-build-local`, and deploy it to your local cluster using `make deploy-local`.
+For utilizing the locally built Docker image on Minikube running on a VM like macOS arm64, use `make minikube-push`.
+
 ## Contributing
 1. Feel free to fork and open a pull request! Include tests and document your code in [Godoc style](https://go.dev/blog/godoc)
 2. In your pull request, please refer to an existing issue or open a new one.

--- a/src/operator/Makefile
+++ b/src/operator/Makefile
@@ -14,6 +14,11 @@ IMAGE_TAG_BASE ?= 353146681200.dkr.ecr.us-east-1.amazonaws.com/otterize
 
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):operator-$(VERSION)
+
+LOCAL_IMAGE_TAG ?= 255.255.255
+OPERATOR_DEBUG_IMAGE ?= otterize/intents-operator:$(LOCAL_IMAGE_TAG)
+WATCHER_DEBUG_IMAGE ?= otterize/intents-operator-pod-watcher:$(LOCAL_IMAGE_TAG)
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
@@ -90,9 +95,23 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} -f ../intents-operator.Dockerfile ../
 
+.PHONY: docker-build-local
+docker-build-local: test ## Build docker image with the manager.
+	docker build -t ${OPERATOR_DEBUG_IMAGE} -f ../intents-operator.Dockerfile ../
+	docker build -f ../watcher.Dockerfile -t ${WATCHER_DEBUG_IMAGE} ../
+
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+.PHONY: minikube-push
+minikube-push: ## For MacOS users: Push locally built docker images directly into minikube VM since it doesn't access local docker registry directly.
+	minikube ssh "docker rmi -f $(OPERATOR_DEBUG_IMAGE)"
+	minikube image load ${OPERATOR_DEBUG_IMAGE}
+	minikube ssh "docker rmi -f $(WATCHER_DEBUG_IMAGE)"
+	minikube image load ${WATCHER_DEBUG_IMAGE}
+
 
 ##@ Deployment
 
@@ -117,6 +136,14 @@ copy-manifests-to-helm: manifests
 .PHONY: deploy
 deploy: manifests copy-manifests-to-helm helm-dependency
 	helm upgrade --install -n otterize-system --create-namespace otterize $(OTTERIZE_HELM_CHART_DIR)
+
+.PHONY: deploy-local
+deploy-local: manifests copy-manifests-to-helm helm-dependency ## Deploy images built locally into the cluster.
+	helm upgrade --install -n otterize-system --create-namespace otterize $(OTTERIZE_HELM_CHART_DIR) \
+	--set intentsOperator.operator.tag=$(LOCAL_IMAGE_TAG) \
+	--set intentsOperator.operator.pullPolicy=Never \
+	--set intentsOperator.watcher.tag=$(LOCAL_IMAGE_TAG) \
+	--set intentsOperator.watcher.pullPolicy=Never
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
Allow developers to create a local image, push and deploy it to Minikube without using Otterize's official registry.