### PR TITLE
Decouple reconcilers run results from each other

### DIFF
--- a/src/shared/reconcilergroup/reconcilergroup_test.go
+++ b/src/shared/reconcilergroup/reconcilergroup_test.go
@@ -1,0 +1,95 @@
+package reconcilergroup
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+type ReconcilerGroupTestSuite struct {
+	suite.Suite
+	group *Group
+}
+
+func (s *ReconcilerGroupTestSuite) SetupTest() {
+}
+
+type TestReconciler struct {
+	Reconciled bool
+	Err        error
+	Result     reconcile.Result
+}
+
+func (t *TestReconciler) Reconcile(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	t.Reconciled = true
+	return t.Result, t.Err
+}
+
+func (t *TestReconciler) InjectRecorder(recorder record.EventRecorder) {
+	// Just to implement the interface
+}
+
+func (s *ReconcilerGroupTestSuite) TestGroupError() {
+	reconcilerWithError := &TestReconciler{Err: fmt.Errorf("test error"), Result: reconcile.Result{}}
+	reconcilerWithResult := &TestReconciler{Err: nil, Result: reconcile.Result{Requeue: true}}
+	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
+	s.group = NewGroup("test", nil, nil, reconcilerWithError, reconcilerWithResult, happyReconciler)
+	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	s.Require().Equal(reconcilerWithError.Err, err)
+	s.Require().Equal(reconcilerWithResult.Result, res)
+	s.Require().True(reconcilerWithError.Reconciled)
+	s.Require().True(reconcilerWithResult.Reconciled)
+	s.Require().True(happyReconciler.Reconciled)
+}
+
+func (s *ReconcilerGroupTestSuite) TestAddToGroup() {
+	happyReconciler := &TestReconciler{}
+	addedReconciler := &TestReconciler{}
+	s.group = NewGroup("test", nil, nil, happyReconciler)
+	s.group.AddToGroup(addedReconciler)
+	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	s.Require().NoError(err)
+	s.Require().True(res.IsZero())
+	s.Require().True(happyReconciler.Reconciled)
+	s.Require().True(addedReconciler.Reconciled)
+}
+
+func (s *ReconcilerGroupTestSuite) TestGroupSuccess() {
+	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
+	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
+	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
+	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	s.Require().NoError(err)
+	s.Require().Equal(reconcile.Result{}, res)
+	s.Require().True(anotherHappyReconciler.Reconciled)
+	s.Require().True(happyReconciler.Reconciled)
+}
+
+func (s *ReconcilerGroupTestSuite) TestResultIsTheShortestRequeueTime() {
+	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 10}}
+	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 5}}
+	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
+	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	s.Require().NoError(err)
+	s.Require().Equal(reconcile.Result{RequeueAfter: 5}, res)
+	s.Require().True(anotherHappyReconciler.Reconciled)
+	s.Require().True(happyReconciler.Reconciled)
+}
+
+func (s *ReconcilerGroupTestSuite) TestResultIsTheEmptyRequeueAfter() {
+	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 10}}
+	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{Requeue: true}}
+	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
+	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	s.Require().NoError(err)
+	s.Require().Equal(reconcile.Result{Requeue: true}, res)
+	s.Require().True(anotherHappyReconciler.Reconciled)
+	s.Require().True(happyReconciler.Reconciled)
+}
+
+func TestReconcilerGroup(t *testing.T) {
+	suite.Run(t, new(ReconcilerGroupTestSuite))
+}

--- a/src/shared/reconcilergroup/reconcilergroup_test.go
+++ b/src/shared/reconcilergroup/reconcilergroup_test.go
@@ -37,7 +37,7 @@ func (s *ReconcilerGroupTestSuite) TestGroupError() {
 	reconcilerWithResult := &TestReconciler{Err: nil, Result: reconcile.Result{Requeue: true}}
 	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
 	s.group = NewGroup("test", nil, nil, reconcilerWithError, reconcilerWithResult, happyReconciler)
-	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	res, err := s.group.Reconcile(context.Background(), reconcile.Request{})
 	s.Require().Equal(reconcilerWithError.Err, err)
 	s.Require().Equal(reconcilerWithResult.Result, res)
 	s.Require().True(reconcilerWithError.Reconciled)
@@ -50,7 +50,7 @@ func (s *ReconcilerGroupTestSuite) TestAddToGroup() {
 	addedReconciler := &TestReconciler{}
 	s.group = NewGroup("test", nil, nil, happyReconciler)
 	s.group.AddToGroup(addedReconciler)
-	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	res, err := s.group.Reconcile(context.Background(), reconcile.Request{})
 	s.Require().NoError(err)
 	s.Require().True(res.IsZero())
 	s.Require().True(happyReconciler.Reconciled)
@@ -61,7 +61,7 @@ func (s *ReconcilerGroupTestSuite) TestGroupSuccess() {
 	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
 	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{}}
 	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
-	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	res, err := s.group.Reconcile(context.Background(), reconcile.Request{})
 	s.Require().NoError(err)
 	s.Require().Equal(reconcile.Result{}, res)
 	s.Require().True(anotherHappyReconciler.Reconciled)
@@ -72,7 +72,7 @@ func (s *ReconcilerGroupTestSuite) TestResultIsTheShortestRequeueTime() {
 	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 10}}
 	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 5}}
 	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
-	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	res, err := s.group.Reconcile(context.Background(), reconcile.Request{})
 	s.Require().NoError(err)
 	s.Require().Equal(reconcile.Result{RequeueAfter: 5}, res)
 	s.Require().True(anotherHappyReconciler.Reconciled)
@@ -83,7 +83,7 @@ func (s *ReconcilerGroupTestSuite) TestResultIsTheEmptyRequeueAfter() {
 	happyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{RequeueAfter: 10}}
 	anotherHappyReconciler := &TestReconciler{Err: nil, Result: reconcile.Result{Requeue: true}}
 	s.group = NewGroup("test", nil, nil, happyReconciler, anotherHappyReconciler)
-	res, err := s.group.Reconcile(nil, reconcile.Request{})
+	res, err := s.group.Reconcile(context.Background(), reconcile.Request{})
 	s.Require().NoError(err)
 	s.Require().Equal(reconcile.Result{Requeue: true}, res)
 	s.Require().True(anotherHappyReconciler.Reconciled)


### PR DESCRIPTION
### Description
## Problem description
The intents operator manager combines multiple reconcilers with a large group of them who watch the resource `ClientIntents`. Those are gathered under the `intents reconciler` using a reconciler group mechanism. 

The current state is that failure in one of them will re-queue the request immediately without handling the rest of the reconcilers. Depending on the random order of reconcilers' registration to the group, there may be reconcilers who won't run in at all if the error in one of the reconciler repeats. For example, a bug in Cloud reconciler may result in not creating NetworkPolicies.

## Solution

Here is the current list of reconcilers:
* NetworkPolicy
* PodLabel
* CRD validator
* Cloud 
* Kafka ACL 
* Istio policy

It's pretty clear that most of this list is independent of each other. There are only the Network Policy and Pod labels that have a strong connection, but the activity of the pod label is also handled in the pod watcher which is totally isolated from those reconcilers and may fail independently. The other reconcilers who handle other resources who are related to NetPol watch other resources and are therefore fully independent, too.

It seems that allowing every reconciler to run after an error occurred isn't a big change compared to current state of things. The first error will be returned to K8s runtime SDK and the shortest request to re-queue will be saved. Every error will be logged since K8s runtime will log only the first one.

### Testing

- [x] This change adds test coverage for new functionality
