### PR TITLE
Add support for creating external traffic policies even if no intents point to the same service

### DIFF
--- a/src/operator/controllers/external_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/external_traffic/endpoints_reconciler.go
@@ -211,7 +211,7 @@ func (r *EndpointsReconciler) reconcileEndpoints(ctx context.Context, endpoints 
 
 	}
 
-	if !foundOtterizeNetpolsAffectingPods {
+	if !foundOtterizeNetpolsAffectingPods && !r.createEvenIfNoIntentsFound {
 		policyName := r.formatPolicyName(endpoints.Name)
 		result, err := r.handlePolicyDelete(ctx, policyName, endpoints.Namespace)
 		if err != nil {

--- a/src/operator/controllers/external_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/external_traffic/endpoints_reconciler.go
@@ -26,8 +26,9 @@ const OtterizeExternalNetworkPolicyNameTemplate = "external-access-to-%s"
 
 type EndpointsReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
-	netpolCreator *NetworkPolicyCreator
+	Scheme                     *runtime.Scheme
+	netpolCreator              *NetworkPolicyCreator
+	createEvenIfNoIntentsFound bool
 	injectablerecorder.InjectableRecorder
 }
 
@@ -35,11 +36,12 @@ func (r *EndpointsReconciler) formatPolicyName(serviceName string) string {
 	return fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 }
 
-func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool, enforcementEnabledGlobally bool) *EndpointsReconciler {
+func NewEndpointsReconciler(client client.Client, scheme *runtime.Scheme, enabled bool, createEvenIfNoIntentsFound bool, enforcementEnabledGlobally bool) *EndpointsReconciler {
 	return &EndpointsReconciler{
-		Client:        client,
-		Scheme:        scheme,
-		netpolCreator: NewNetworkPolicyCreator(client, scheme, enabled, enforcementEnabledGlobally),
+		Client:                     client,
+		Scheme:                     scheme,
+		createEvenIfNoIntentsFound: createEvenIfNoIntentsFound,
+		netpolCreator:              NewNetworkPolicyCreator(client, scheme, enabled, createEvenIfNoIntentsFound, enforcementEnabledGlobally),
 	}
 }
 
@@ -186,6 +188,15 @@ func (r *EndpointsReconciler) reconcileEndpoints(ctx context.Context, endpoints 
 		}
 
 		if len(netpolList.Items) == 0 {
+			if r.createEvenIfNoIntentsFound {
+				result, err := r.ReconcileServiceForServiceWithoutIntents(ctx, endpoints, serverLabel, ingressList)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				if !result.IsZero() {
+					return result, nil
+				}
+			}
 			continue
 		}
 
@@ -241,7 +252,24 @@ func (r *EndpointsReconciler) ReconcileServiceForOtterizeNetpol(ctx context.Cont
 		return ctrl.Result{}, err
 	}
 
-	err = r.netpolCreator.handleNetworkPolicyCreationOrUpdate(ctx, endpoints, svc, otterizeServiceName, svc, netpol, ingressList, r.formatPolicyName(endpoints.Name))
+	err = r.netpolCreator.handleNetworkPolicyCreationOrUpdateForNetpol(ctx, endpoints, svc, otterizeServiceName, svc, netpol, ingressList, r.formatPolicyName(endpoints.Name))
+	if err != nil {
+		if k8serrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *EndpointsReconciler) ReconcileServiceForServiceWithoutIntents(ctx context.Context, endpoints *corev1.Endpoints, otterizeServiceName string, ingressList *v1.IngressList) (ctrl.Result, error) {
+	svc := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, svc)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.netpolCreator.handleNetworkPolicyCreationOrUpdateForServiceWithoutIntents(ctx, endpoints, svc, otterizeServiceName, svc, svc, ingressList, r.formatPolicyName(endpoints.Name))
 	if err != nil {
 		if k8serrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil

--- a/src/operator/controllers/intents_reconcilers/external_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_network_policy_with_no_intents_test.go
@@ -77,16 +77,12 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the network policy was created between the two services based on the intents
 	np := &v1.NetworkPolicy{}
-	policyName := fmt.Sprintf(otterizev1alpha2.OtterizeNetworkPolicyNameTemplate, serviceName, s.TestNamespace)
-	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: policyName}, np)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(np)
 
 	s.AddDeploymentWithService(serviceName, []string{"1.1.1.1"}, map[string]string{"app": "test"}, nil)
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	// the ingress reconciler expect the pod watcher labels in order to work
-	_, err = s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
 	s.Require().NoError(err)
 
 	// make sure the ingress network policy doesn't exist yet
@@ -120,10 +116,6 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the network policy was created between the two services based on the intents
 	np := &v1.NetworkPolicy{}
-	policyName := fmt.Sprintf(otterizev1alpha2.OtterizeNetworkPolicyNameTemplate, serviceName, s.TestNamespace)
-	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: policyName}, np)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(np)
 
 	podIps := []string{"1.1.2.1"}
 	podLabels := map[string]string{"app": "test-load-balancer"}
@@ -131,7 +123,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	// the ingress reconciler expect the pod watcher labels in order to work
-	_, err = s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
 	s.Require().NoError(err)
 
 	// make sure the load balancer network policy doesn't exist yet
@@ -165,10 +157,6 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the network policy was created between the two services based on the intents
 	np := &v1.NetworkPolicy{}
-	policyName := fmt.Sprintf(otterizev1alpha2.OtterizeNetworkPolicyNameTemplate, serviceName, s.TestNamespace)
-	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: policyName}, np)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(np)
 
 	podIps := []string{"1.1.2.1"}
 	podLabels := map[string]string{"app": "test-load-balancer"}
@@ -176,7 +164,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	// the ingress reconciler expect the pod watcher labels in order to work
-	_, err = s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
 	s.Require().NoError(err)
 
 	// make sure the load balancer network policy doesn't exist yet
@@ -209,10 +197,6 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 
 	// make sure the network policy was created between the two services based on the intents
 	np := &v1.NetworkPolicy{}
-	policyName := fmt.Sprintf(otterizev1alpha2.OtterizeNetworkPolicyNameTemplate, serviceName, s.TestNamespace)
-	err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: policyName}, np)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(np)
 
 	podIps := []string{"1.1.2.1"}
 	podLabels := map[string]string{"app": "test-load-balancer"}
@@ -220,7 +204,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	// the ingress reconciler expect the pod watcher labels in order to work
-	_, err = s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
 	s.Require().NoError(err)
 
 	// make sure the load balancer network policy doesn't exist yet

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -82,6 +82,7 @@ func main() {
 	enableLeaderElection := viper.GetBool(operatorconfig.EnableLeaderElectionKey)
 	selfSignedCert := viper.GetBool(operatorconfig.SelfSignedCertKey)
 	autoCreateNetworkPoliciesForExternalTraffic := viper.GetBool(operatorconfig.AutoCreateNetworkPoliciesForExternalTrafficKey)
+	autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement := viper.GetBool(operatorconfig.AutoCreateNetworkPoliciesForExternalTrafficNoIntentsRequiredKey)
 	watchedNamespaces := viper.GetStringSlice(operatorconfig.WatchedNamespacesKey)
 	enforcementConfig := controllers.EnforcementConfig{
 		EnforcementEnabledGlobally: viper.GetBool(operatorconfig.EnforcementEnabledGloballyKey),
@@ -153,7 +154,7 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementEnabledGlobally)
 
-	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), mgr.GetScheme(), autoCreateNetworkPoliciesForExternalTraffic, enforcementConfig.EnforcementEnabledGlobally)
+	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), mgr.GetScheme(), autoCreateNetworkPoliciesForExternalTraffic, autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement, enforcementConfig.EnforcementEnabledGlobally)
 
 	if err = endpointReconciler.InitIngressReferencedServicesIndex(mgr); err != nil {
 		logrus.WithError(err).Fatal("unable to init index for ingress")

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -10,33 +10,35 @@ import (
 )
 
 const (
-	MetricsAddrKey                                     = "metrics-bind-address" // The address the metric endpoint binds to
-	MetricsAddrDefault                                 = ":8180"
-	ProbeAddrKey                                       = "health-probe-bind-address" // The address the probe endpoint binds to
-	ProbeAddrDefault                                   = ":8181"
-	EnableLeaderElectionKey                            = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
-	EnableLeaderElectionDefault                        = false
-	WatchedNamespacesKey                               = "watched-namespaces"    // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
-	KafkaServerTLSCertKey                              = "kafka-server-tls-cert" // name of tls certificate file
-	KafkaServerTLSKeyKey                               = "kafka-server-tls-key"  // name of tls private key file
-	KafkaServerTLSCAKey                                = "kafka-server-tls-ca"   // name of tls ca file
-	SelfSignedCertKey                                  = "self-signed-cert"      // Whether to generate and use a self signed cert as the CA for webhooks
-	SelfSignedCertDefault                              = true
-	DisableWebhookServerKey                            = "disable-webhook-server" // Disable webhook validator server
-	DisableWebhookServerDefault                        = false
-	EnforcementEnabledGloballyKey                      = "enable-enforcement" // If set to false disables the enforcement globally, superior to the other flags
-	EnforcementEnabledGloballyDefault                  = true
-	AutoCreateNetworkPoliciesForExternalTrafficKey     = "auto-create-network-policies-for-external-traffic" // Whether to automatically create network policies for external traffic
-	AutoCreateNetworkPoliciesForExternalTrafficDefault = true
-	EnableNetworkPolicyKey                             = "enable-network-policy-creation" // Whether to enable Intents network policy creation
-	EnableNetworkPolicyDefault                         = true
-	EnableIstioPolicyKey                               = "experimental-enable-istio-policy-creation" // Whether to enable istio authorization policy creation
-	EnableIstioPolicyDefault                           = false
-	EnableKafkaACLKey                                  = "enable-kafka-acl-creation" // Whether to disable Intents Kafka ACL creation
-	EnableKafkaACLDefault                              = true
-	IntentsOperatorPodNameKey                          = "pod-name"
-	IntentsOperatorPodNamespaceKey                     = "pod-namespace"
-	EnvPrefix                                          = "OTTERIZE"
+	MetricsAddrKey                                                      = "metrics-bind-address" // The address the metric endpoint binds to
+	MetricsAddrDefault                                                  = ":8180"
+	ProbeAddrKey                                                        = "health-probe-bind-address" // The address the probe endpoint binds to
+	ProbeAddrDefault                                                    = ":8181"
+	EnableLeaderElectionKey                                             = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
+	EnableLeaderElectionDefault                                         = false
+	WatchedNamespacesKey                                                = "watched-namespaces"    // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
+	KafkaServerTLSCertKey                                               = "kafka-server-tls-cert" // name of tls certificate file
+	KafkaServerTLSKeyKey                                                = "kafka-server-tls-key"  // name of tls private key file
+	KafkaServerTLSCAKey                                                 = "kafka-server-tls-ca"   // name of tls ca file
+	SelfSignedCertKey                                                   = "self-signed-cert"      // Whether to generate and use a self signed cert as the CA for webhooks
+	SelfSignedCertDefault                                               = true
+	DisableWebhookServerKey                                             = "disable-webhook-server" // Disable webhook validator server
+	DisableWebhookServerDefault                                         = false
+	EnforcementEnabledGloballyKey                                       = "enable-enforcement" // If set to false disables the enforcement globally, superior to the other flags
+	EnforcementEnabledGloballyDefault                                   = true
+	AutoCreateNetworkPoliciesForExternalTrafficKey                      = "auto-create-network-policies-for-external-traffic" // Whether to automatically create network policies for external traffic
+	AutoCreateNetworkPoliciesForExternalTrafficDefault                  = true
+	AutoCreateNetworkPoliciesForExternalTrafficNoIntentsRequiredKey     = "exp-auto-create-network-policies-for-external-traffic-disable-intents-requirement" // Whether to automatically create network policies for external traffic, even if no intents point to the relevant service
+	AutoCreateNetworkPoliciesForExternalTrafficNoIntentsRequiredDefault = false
+	EnableNetworkPolicyKey                                              = "enable-network-policy-creation" // Whether to enable Intents network policy creation
+	EnableNetworkPolicyDefault                                          = true
+	EnableIstioPolicyKey                                                = "experimental-enable-istio-policy-creation" // Whether to enable istio authorization policy creation
+	EnableIstioPolicyDefault                                            = false
+	EnableKafkaACLKey                                                   = "enable-kafka-acl-creation" // Whether to disable Intents Kafka ACL creation
+	EnableKafkaACLDefault                                               = true
+	IntentsOperatorPodNameKey                                           = "pod-name"
+	IntentsOperatorPodNamespaceKey                                      = "pod-namespace"
+	EnvPrefix                                                           = "OTTERIZE"
 )
 
 func init() {
@@ -64,6 +66,7 @@ func InitCLIFlags() {
 	pflag.Bool(DisableWebhookServerKey, DisableWebhookServerDefault, "Disable webhook validator server")
 	pflag.Bool(EnforcementEnabledGloballyKey, EnforcementEnabledGloballyDefault, "If set to false disables the enforcement globally, superior to the other flags")
 	pflag.Bool(AutoCreateNetworkPoliciesForExternalTrafficKey, AutoCreateNetworkPoliciesForExternalTrafficDefault, "Whether to automatically create network policies for external traffic")
+	pflag.Bool(AutoCreateNetworkPoliciesForExternalTrafficNoIntentsRequiredKey, AutoCreateNetworkPoliciesForExternalTrafficNoIntentsRequiredDefault, "Whether to create network policies for external traffic, even if no intents point to the relevant service")
 	pflag.Bool(EnableNetworkPolicyKey, EnableNetworkPolicyDefault, "Whether to enable Intents network policy creation")
 	pflag.Bool(EnableKafkaACLKey, EnableKafkaACLDefault, "Whether to disable Intents Kafka ACL creation")
 	pflag.String(MetricsAddrKey, MetricsAddrDefault, "The address the metric endpoint binds to.")


### PR DESCRIPTION
When applying a global default deny policy, all traffic to all pods will be blocked, even traffic from an Ingress or LoadBalancer, which is likely intended traffic.

The intents operator can automatically create network policies for external traffic when intents are pointing to a target service. The rationale is that specifying intents for intra-cluster traffic should not block external traffic. See more info here: https://docs.otterize.com/reference/access-controls/network-policies#auto-generating-network-policies-for-external-traffic

This PR adds a disabled-by-default, experimental flag for enabling this behavior _even if no intents point to the service_, which is suitable for use with a global default deny policy. This way, the operator will open up external traffic automatically for external services, even if no intents point to them. This is common as external services are often only exposed to the Internet, and not called directly by others in the cluster, so they would not be referred to by intents.