### PR TITLE
Add a step for buildx setup in release-tag.yaml

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -26,6 +26,12 @@ jobs:
           username: _json_key_base64
           password: ${{ secrets.B64_GCLOUD_SERVICE_ACCOUNT_JSON}}
 
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          driver-opts: network=host
+
       - name: Build operator release image with tag as version
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION

### Description

Fix release workflow by adding a step for buildx setup in release-tag.yaml

