### PR TITLE
Replace dots with underscore in discovered service name

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -198,12 +198,16 @@ func (in *Intent) GetServerNamespace(intentsObjNamespace string) string {
 // GetServerNamespace returns target namespace for intent if exists
 // or the entire resource's namespace if the specific intent has no target namespace, as it's optional
 func (in *Intent) GetServerName() string {
+	var name string
 	nameWithNamespace := strings.Split(in.Name, ".")
 	if len(nameWithNamespace) == 1 {
-		return in.Name
+		name = in.Name
+	} else {
+		name = nameWithNamespace[0]
 	}
 
-	return nameWithNamespace[0]
+	name = strings.ReplaceAll(name, "_", ".")
+	return name
 }
 
 func (in *Intent) typeAsGQLType() graphqlclient.IntentType {


### PR DESCRIPTION
The name of the Otterize service is derived from the K8s resource that owns a pod we want to secure. The name of the resource that owns the pod doesn't necessarily have to be a valid DNS name, but it must follow the [RFC 1123 subdomain naming convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).

This means that '.' is a valid character in the deployment name, which poses a challenge when parsing server names and namespaces in client intents format. The dot is used as a separator between the name and the namespace. For example, if the deployment name is `my-application.4.5.0` in the `infra` namespace, we won't be able to tell if `my-application.4.5.0.infra` is a namespaced name or just the name of the deployment without any namespace.

To address this issue, this PR replaces every dot discovered in the owner resource name with an underscore. In the above example, we would expect the Otterize service name of the mentioned pod to be `my-application_4_5_0.infra`, while `my-application_4_5_0_infra` would be another service name without a namespace.