### PR TITLE
Fixed bug where external traffic policies would be erroneously removed when intents from multiple namespaces were deleted

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -195,8 +195,7 @@ func (in *Intent) GetServerNamespace(intentsObjNamespace string) string {
 	return nameWithNamespace[1]
 }
 
-// GetServerNamespace returns target namespace for intent if exists
-// or the entire resource's namespace if the specific intent has no target namespace, as it's optional
+// GetServerName returns server's service name, without namespace
 func (in *Intent) GetServerName() string {
 	nameWithNamespace := strings.Split(in.Name, ".")
 	if len(nameWithNamespace) == 1 {
@@ -204,6 +203,10 @@ func (in *Intent) GetServerName() string {
 	}
 
 	return nameWithNamespace[0]
+}
+
+func (in *Intent) GetServerFullyQualifiedName(intentsObjNamespace string) string {
+	return fmt.Sprintf("%s.%s", in.GetServerName(), in.GetServerNamespace(intentsObjNamespace))
 }
 
 func (in *Intent) typeAsGQLType() graphqlclient.IntentType {

--- a/src/operator/controllers/external_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/external_traffic/endpoints_reconciler.go
@@ -32,10 +32,6 @@ type EndpointsReconciler struct {
 	injectablerecorder.InjectableRecorder
 }
 
-type EndpointsReconcilerInterface interface {
-	Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
-}
-
 func (r *EndpointsReconciler) formatPolicyName(serviceName string) string {
 	return fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 }

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -52,6 +52,7 @@ func NewIntentsReconciler(
 	endpointsReconciler *external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
 	enforcementConfig EnforcementConfig,
+	externalNetworkPoliciesCreatedEvenIfNoIntents bool,
 	otterizeClient otterizecloud.CloudClient,
 	operatorPodName string,
 	operatorPodNamespace string) *IntentsReconciler {
@@ -59,7 +60,7 @@ func NewIntentsReconciler(
 		group: reconcilergroup.NewGroup("intents-reconciler", client, scheme,
 			intents_reconcilers.NewCRDValidatorReconciler(client, scheme),
 			intents_reconcilers.NewPodLabelReconciler(client, scheme),
-			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementEnabledGlobally),
+			intents_reconcilers.NewNetworkPolicyReconciler(client, scheme, endpointsReconciler, restrictToNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementEnabledGlobally, externalNetworkPoliciesCreatedEvenIfNoIntents),
 			intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementEnabledGlobally, operatorPodName, operatorPodNamespace, serviceidresolver.NewResolver(client)),
 			intents_reconcilers.NewIstioPolicyReconciler(client, scheme, restrictToNamespaces, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementEnabledGlobally),
 		)}

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -116,7 +116,7 @@ func (r *IntentsReconciler) InitIntentsServerIndices(mgr ctrl.Manager) error {
 			}
 
 			for _, intent := range intents.GetCallsList() {
-				res = append(res, intent.Name)
+				res = append(res, intent.GetServerFullyQualifiedName(intents.Namespace))
 			}
 
 			return res

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -58,11 +58,12 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.NetworkPolicyReconciler = intents_reconcilers.NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true)
+	createEvenIfNoIntentsFound := false
+	s.NetworkPolicyReconciler = intents_reconcilers.NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true, createEvenIfNoIntentsFound)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
 	s.NetworkPolicyReconciler.InjectRecorder(recorder)
 
-	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, false, true)
+	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, createEvenIfNoIntentsFound, true)
 	s.endpointReconciler.InjectRecorder(recorder)
 	err := s.endpointReconciler.InitIngressReferencedServicesIndex(s.Mgr)
 	s.Require().NoError(err)

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -57,11 +57,12 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.NetworkPolicyReconciler = intents_reconcilers.NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true)
+	createEvenIfNoIntentsFound := true
+	s.NetworkPolicyReconciler = intents_reconcilers.NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, nil, []string{}, true, true, createEvenIfNoIntentsFound)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
 	s.NetworkPolicyReconciler.InjectRecorder(recorder)
 
-	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, true, true)
+	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, true, createEvenIfNoIntentsFound, true)
 	s.endpointReconciler.InjectRecorder(recorder)
 	err := s.endpointReconciler.InitIngressReferencedServicesIndex(s.Mgr)
 	s.Require().NoError(err)
@@ -232,7 +233,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 	}
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedDespiteLastIntentDeleted() {
+func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedDespiteLastIntentDeleted() {
 	serviceName := "test-server-load-balancer-test"
 	intents, err := s.AddIntents("test-intents", "test-client", []otterizev1alpha2.Intent{{
 		Name: serviceName,

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Shopify/sarama"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	intentsreconcilersmocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
@@ -165,7 +166,7 @@ func (s *KafkaACLReconcilerTestSuite) TestNoACLCreatedForIntentsOperator() {
 }
 
 func (s *KafkaACLReconcilerTestSuite) initOperatorNamespace() {
-	s.operatorNamespace = operatorPodNamespacePrefix + "-" + s.TestNamespace
+	s.operatorNamespace = operatorPodNamespacePrefix + "-" + uuid.New().String()
 	s.CreateNamespace(s.operatorNamespace)
 	s.Reconciler.operatorPodNamespace = s.operatorNamespace
 }

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -224,7 +224,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLGetCreatedAndUpdatedBasedOnInt
 	intentsConsume := []otterizev1alpha2.Intent{intentsConfig}
 	_, err := s.AddIntents(intentsObjectName, clientName, intentsConsume)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 	namespacedName := types.NamespacedName{
 		Namespace: s.TestNamespace,
 		Name:      intentsObjectName,
@@ -253,7 +252,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLGetCreatedAndUpdatedBasedOnInt
 	// Update the intents object and reconcile
 	err = s.UpdateIntents(intentsObjectName, intentsWithConsumeAndProduce)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), namespacedName, intentsFromReconciler)
 		assert.Equal(len(intentsFromReconciler.Spec.Calls[0].Topics[0].Operations), 2)
@@ -295,7 +293,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLDeletedAfterIntentsRemoved() {
 
 	clientIntents, err := s.AddIntents(intentsObjectName, clientName, intents)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	namespacedName := types.NamespacedName{
 		Namespace: s.TestNamespace,
@@ -327,7 +324,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLDeletedAfterIntentsRemoved() {
 	// Remove the intents object
 	err = s.RemoveIntents(intentsObjectName)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	s.reconcile(namespacedName)
 }
@@ -346,7 +342,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLCreationDisabled() {
 
 	clientIntents, err := s.AddIntents(intentsObjectName, clientName, intents)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	namespacedName := types.NamespacedName{
 		Namespace: s.TestNamespace,
@@ -370,7 +365,6 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLEnforcementGloballyDisabled() 
 
 	clientIntents, err := s.AddIntents(intentsObjectName, clientName, intents)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	namespacedName := types.NamespacedName{
 		Namespace: s.TestNamespace,
@@ -399,7 +393,6 @@ func (s *KafkaACLReconcilerTestSuite) reconcile(namespacedName types.NamespacedN
 
 	s.Require().NoError(err)
 	s.Require().Empty(res)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 }
 
 func (s *KafkaACLReconcilerTestSuite) generateIntents(operation otterizev1alpha2.KafkaOperation) otterizev1alpha2.Intent {

--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
-	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
@@ -21,6 +20,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 type NetworkPolicyReconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
-	endpointsReconciler         external_traffic.EndpointsReconcilerInterface
+	endpointsReconciler         reconcile.Reconciler
 	RestrictToNamespaces        []string
 	enableNetworkPolicyCreation bool
 	enforcementEnabledGlobally  bool
@@ -46,7 +46,7 @@ type NetworkPolicyReconciler struct {
 func NewNetworkPolicyReconciler(
 	c client.Client,
 	s *runtime.Scheme,
-	endpointsReconciler external_traffic.EndpointsReconcilerInterface,
+	endpointsReconciler reconcile.Reconciler,
 	restrictToNamespaces []string,
 	enableNetworkPolicyCreation bool,
 	enforcementEnabledGlobally bool) *NetworkPolicyReconciler {
@@ -254,7 +254,7 @@ func (r *NetworkPolicyReconciler) handleNetworkPolicyRemoval(
 	var intentsList otterizev1alpha2.ClientIntentsList
 	err := r.List(
 		ctx, &intentsList,
-		&client.MatchingFields{otterizev1alpha2.OtterizeTargetServerIndexField: intent.Name},
+		&client.MatchingFields{otterizev1alpha2.OtterizeTargetServerIndexField: intent.GetServerFullyQualifiedName(intentsObjNamespace)},
 		&client.ListOptions{Namespace: intentsObjNamespace})
 
 	if err != nil {
@@ -289,20 +289,39 @@ func (r *NetworkPolicyReconciler) deleteNetworkPolicy(
 		return err
 	}
 
+	// Check if network policies from all namespaces are gone
+	// If so, check if intents required flag for external policies is disabled
+	// If so, delete.
+
 	// Remove network policies created by the external traffic reconcilers.
 	// Once no more Otterize network policies are present, there's no longer need for them.
-	externalPolicyList := &v1.NetworkPolicyList{}
-	serviceNameLabel := policy.Labels[otterizev1alpha2.OtterizeNetworkPolicy]
-	err = r.List(ctx, externalPolicyList, client.MatchingLabels{otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic: serviceNameLabel},
-		&client.ListOptions{Namespace: policy.Namespace})
+	// Before we do this, we must check there are no Otterize network policies in ANY namespace.
+	// This function is called once there are no more network policies from this namespace.
+
+	var intentsList otterizev1alpha2.ClientIntentsList
+	err = r.List(
+		ctx, &intentsList,
+		&client.MatchingFields{otterizev1alpha2.OtterizeTargetServerIndexField: intent.GetServerFullyQualifiedName(intentsObjNamespace)})
+
 	if err != nil {
 		return err
 	}
 
-	for _, externalPolicy := range externalPolicyList.Items {
-		err := r.Delete(ctx, externalPolicy.DeepCopy())
+	// This is the last intent out of all namespaces, so it's safe to delete the external traffic policy.
+	if len(intentsList.Items) == 1 {
+		externalPolicyList := &v1.NetworkPolicyList{}
+		serviceNameLabel := policy.Labels[otterizev1alpha2.OtterizeNetworkPolicy]
+		err = r.List(ctx, externalPolicyList, client.MatchingLabels{otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic: serviceNameLabel},
+			&client.ListOptions{Namespace: policy.Namespace})
 		if err != nil {
 			return err
+		}
+
+		for _, externalPolicy := range externalPolicyList.Items {
+			err := r.Delete(ctx, externalPolicy.DeepCopy())
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/src/operator/controllers/intents_reconcilers/network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy_test.go
@@ -228,6 +228,14 @@ func (s *NetworkPolicyReconcilerTestSuite) testCleanNetworkPolicy(clientIntentsN
 		},
 	}
 
+	s.Client.EXPECT().List(
+		gomock.Any(),
+		gomock.Eq(emptyIntentsList),
+		&client.MatchingFields{otterizev1alpha2.OtterizeTargetServerIndexField: serverName},
+	).DoAndReturn(func(ctx context.Context, list *otterizev1alpha2.ClientIntentsList, opts ...client.ListOption) error {
+		intentsList.DeepCopyInto(list)
+		return nil
+	})
 	s.Client.EXPECT().List(gomock.Any(), gomock.Eq(emptyExternalPolicyList), client.MatchingLabels{otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic: formattedTargetServer}, &client.ListOptions{Namespace: existingPolicy.Namespace}).DoAndReturn(
 		func(ctx context.Context, list *v1.NetworkPolicyList, opts ...client.ListOption) error {
 			externalPolicyList.DeepCopyInto(list)

--- a/src/operator/controllers/intents_reconcilers/network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy_test.go
@@ -40,6 +40,7 @@ func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
 		restrictToNamespaces,
 		true,
 		true,
+		false,
 	)
 
 	s.Reconciler.Recorder = s.Recorder

--- a/src/operator/controllers/kafkaserverconfig_controller_test.go
+++ b/src/operator/controllers/kafkaserverconfig_controller_test.go
@@ -169,7 +169,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) reconcile(namespacedName types.Na
 
 	s.Require().NoError(err)
 	s.Require().Empty(res)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 }
 
 func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigUpload() {

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -198,6 +198,7 @@ func main() {
 		endpointReconciler,
 		watchedNamespaces,
 		enforcementConfig,
+		autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement,
 		otterizeCloudClient,
 		podName,
 		podNamespace,

--- a/src/operator/webhooks/webhook_suite_test.go
+++ b/src/operator/webhooks/webhook_suite_test.go
@@ -16,7 +16,6 @@
 package webhooks
 
 import (
-	"context"
 	"fmt"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -105,7 +104,6 @@ func (s *ValidationWebhookTestSuite) TestNoTopicsForHTTPIntentsAfterUpdate() {
 	})
 	expectedErr := fmt.Sprintf("type %s cannot contain kafka topics", otterizev1alpha2.IntentTypeHTTP)
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	err = s.UpdateIntents("intents", []otterizev1alpha2.Intent{
 		{

--- a/src/watcher/reconcilers/pods.go
+++ b/src/watcher/reconcilers/pods.go
@@ -271,7 +271,7 @@ func (p *PodWatcher) InitIntentsServerIndices(mgr ctrl.Manager) error {
 			}
 
 			for _, intent := range intents.GetCallsList() {
-				res = append(res, intent.Name)
+				res = append(res, intent.GetServerFullyQualifiedName(intent.GetServerFullyQualifiedName(intents.Namespace)))
 			}
 
 			return res

--- a/src/watcher/reconcilers/pods.go
+++ b/src/watcher/reconcilers/pods.go
@@ -271,7 +271,8 @@ func (p *PodWatcher) InitIntentsServerIndices(mgr ctrl.Manager) error {
 			}
 
 			for _, intent := range intents.GetCallsList() {
-				res = append(res, intent.GetServerFullyQualifiedName(intent.GetServerFullyQualifiedName(intents.Namespace)))
+				fullName := intent.GetServerFullyQualifiedName(intents.Namespace)
+				res = append(res, fullName)
 			}
 
 			return res

--- a/src/watcher/reconcilers/pods_test.go
+++ b/src/watcher/reconcilers/pods_test.go
@@ -135,7 +135,6 @@ func (s *WatcherPodLabelReconcilerTestSuite) TestClientAccessLabelAdded() {
 	},
 	})
 	s.Require().NoError(err)
-	s.Require().True(s.Mgr.GetCache().WaitForCacheSync(context.Background()))
 
 	podName := fmt.Sprintf("%s-0", deploymentName)
 


### PR DESCRIPTION
1. Fixed bug where external traffic policies would be erroneously removed when intents from multiple namespaces existed and all intents in one namespace were deleted.
2. The experimental flag, `autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement`, was not taken into account during intent deletion flow, so even when it was enabled, removing all intents would result in external traffic network policies being removed.

- [x] This change adds test coverage for new/changed/fixed functionality