### PR TITLE
Make endpoints reconciler an interface

### DIFF
--- a/src/operator/controllers/external_traffic/ingress_reconciler.go
+++ b/src/operator/controllers/external_traffic/ingress_reconciler.go
@@ -22,11 +22,11 @@ import (
 type IngressReconciler struct {
 	client.Client
 	Scheme              *runtime.Scheme
-	endpointsReconciler *EndpointsReconciler
+	endpointsReconciler EndpointsReconciler
 	injectablerecorder.InjectableRecorder
 }
 
-func NewIngressReconciler(client client.Client, scheme *runtime.Scheme, endpointsReconciler *EndpointsReconciler) *IngressReconciler {
+func NewIngressReconciler(client client.Client, scheme *runtime.Scheme, endpointsReconciler EndpointsReconciler) *IngressReconciler {
 	return &IngressReconciler{Client: client, Scheme: scheme, endpointsReconciler: endpointsReconciler}
 }
 

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -49,7 +49,7 @@ func NewIntentsReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	kafkaServerStore kafkaacls.ServersStore,
-	endpointsReconciler *external_traffic.EndpointsReconciler,
+	endpointsReconciler external_traffic.EndpointsReconciler,
 	restrictToNamespaces []string,
 	enforcementConfig EnforcementConfig,
 	externalNetworkPoliciesCreatedEvenIfNoIntents bool,

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -30,7 +30,7 @@ import (
 type ExternalNetworkPolicyReconcilerTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
 	IngressReconciler       *external_traffic.IngressReconciler
-	endpointReconciler      *external_traffic.EndpointsReconciler
+	endpointReconciler      external_traffic.EndpointsReconciler
 	NetworkPolicyReconciler *intents_reconcilers.NetworkPolicyReconciler
 	podWatcher              *reconcilers.PodWatcher
 }

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -29,7 +29,7 @@ import (
 type ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
 	IngressReconciler       *external_traffic.IngressReconciler
-	endpointReconciler      *external_traffic.EndpointsReconciler
+	endpointReconciler      external_traffic.EndpointsReconciler
 	NetworkPolicyReconciler *intents_reconcilers.NetworkPolicyReconciler
 	podWatcher              *reconcilers.PodWatcher
 }

--- a/src/operator/controllers/intents_reconcilers/mocks/mock_endpoints_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/mocks/mock_endpoints_reconciler.go
@@ -9,34 +9,61 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	record "k8s.io/client-go/tools/record"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
-// MockEndpointsReconcilerInterface is a mock of EndpointsReconcilerInterface interface.
-type MockEndpointsReconcilerInterface struct {
+// MockEndpointsReconciler is a mock of EndpointsReconciler interface.
+type MockEndpointsReconciler struct {
 	ctrl     *gomock.Controller
-	recorder *MockEndpointsReconcilerInterfaceMockRecorder
+	recorder *MockEndpointsReconcilerMockRecorder
 }
 
-// MockEndpointsReconcilerInterfaceMockRecorder is the mock recorder for MockEndpointsReconcilerInterface.
-type MockEndpointsReconcilerInterfaceMockRecorder struct {
-	mock *MockEndpointsReconcilerInterface
+// MockEndpointsReconcilerMockRecorder is the mock recorder for MockEndpointsReconciler.
+type MockEndpointsReconcilerMockRecorder struct {
+	mock *MockEndpointsReconciler
 }
 
-// NewMockEndpointsReconcilerInterface creates a new mock instance.
-func NewMockEndpointsReconcilerInterface(ctrl *gomock.Controller) *MockEndpointsReconcilerInterface {
-	mock := &MockEndpointsReconcilerInterface{ctrl: ctrl}
-	mock.recorder = &MockEndpointsReconcilerInterfaceMockRecorder{mock}
+// NewMockEndpointsReconciler creates a new mock instance.
+func NewMockEndpointsReconciler(ctrl *gomock.Controller) *MockEndpointsReconciler {
+	mock := &MockEndpointsReconciler{ctrl: ctrl}
+	mock.recorder = &MockEndpointsReconcilerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockEndpointsReconcilerInterface) EXPECT() *MockEndpointsReconcilerInterfaceMockRecorder {
+func (m *MockEndpointsReconciler) EXPECT() *MockEndpointsReconcilerMockRecorder {
 	return m.recorder
 }
 
+// InitIngressReferencedServicesIndex mocks base method.
+func (m *MockEndpointsReconciler) InitIngressReferencedServicesIndex(mgr controllerruntime.Manager) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitIngressReferencedServicesIndex", mgr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitIngressReferencedServicesIndex indicates an expected call of InitIngressReferencedServicesIndex.
+func (mr *MockEndpointsReconcilerMockRecorder) InitIngressReferencedServicesIndex(mgr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitIngressReferencedServicesIndex", reflect.TypeOf((*MockEndpointsReconciler)(nil).InitIngressReferencedServicesIndex), mgr)
+}
+
+// InjectRecorder mocks base method.
+func (m *MockEndpointsReconciler) InjectRecorder(recorder record.EventRecorder) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InjectRecorder", recorder)
+}
+
+// InjectRecorder indicates an expected call of InjectRecorder.
+func (mr *MockEndpointsReconcilerMockRecorder) InjectRecorder(recorder interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectRecorder", reflect.TypeOf((*MockEndpointsReconciler)(nil).InjectRecorder), recorder)
+}
+
 // Reconcile mocks base method.
-func (m *MockEndpointsReconcilerInterface) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
+func (m *MockEndpointsReconciler) Reconcile(ctx context.Context, req controllerruntime.Request) (controllerruntime.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reconcile", ctx, req)
 	ret0, _ := ret[0].(controllerruntime.Result)
@@ -45,7 +72,21 @@ func (m *MockEndpointsReconcilerInterface) Reconcile(ctx context.Context, req co
 }
 
 // Reconcile indicates an expected call of Reconcile.
-func (mr *MockEndpointsReconcilerInterfaceMockRecorder) Reconcile(ctx, req interface{}) *gomock.Call {
+func (mr *MockEndpointsReconcilerMockRecorder) Reconcile(ctx, req interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockEndpointsReconcilerInterface)(nil).Reconcile), ctx, req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockEndpointsReconciler)(nil).Reconcile), ctx, req)
+}
+
+// SetupWithManager mocks base method.
+func (m *MockEndpointsReconciler) SetupWithManager(mgr controllerruntime.Manager) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetupWithManager", mgr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetupWithManager indicates an expected call of SetupWithManager.
+func (mr *MockEndpointsReconcilerMockRecorder) SetupWithManager(mgr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupWithManager", reflect.TypeOf((*MockEndpointsReconciler)(nil).SetupWithManager), mgr)
 }

--- a/src/operator/controllers/intents_reconcilers/network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy_test.go
@@ -25,12 +25,12 @@ import (
 type NetworkPolicyReconcilerTestSuite struct {
 	testbase.MocksSuiteBase
 	Reconciler          *NetworkPolicyReconciler
-	endpointsReconciler *mocks.MockEndpointsReconcilerInterface
+	endpointsReconciler *mocks.MockEndpointsReconciler
 }
 
 func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.endpointsReconciler = mocks.NewMockEndpointsReconcilerInterface(s.Controller)
+	s.endpointsReconciler = mocks.NewMockEndpointsReconciler(s.Controller)
 	restrictToNamespaces := make([]string, 0)
 
 	s.Reconciler = NewNetworkPolicyReconciler(

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -558,6 +558,10 @@ type Mutation {
 		namespace: String!
 		intents: [IntentInput!]!
 	): Boolean!
+	reportNetworkPolicies(
+		namespace: String!
+		policies: [NetworkPolicyInput!]!
+	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
@@ -586,6 +590,12 @@ input NamespacedPodOwner {
 type NetworkMapperComponent {
 	type: ComponentType!
 	status: ComponentStatus!
+}
+
+input NetworkPolicyInput {
+	namespace: String!
+	serverName: String!
+	externalTrafficPolicy: Boolean!
 }
 
 type Organization {


### PR DESCRIPTION
Introduces the `EndpointsReconciler` interface. The implementation of this mock for this interface was already pushed and merged in a previous PR but without the type change itself,

- [x] This change adds test coverage for new/changed/fixed functionality
