### PR TITLE
Don׳t replace underscore with dots

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -205,7 +205,6 @@ func (in *Intent) GetServerName() string {
 		name = nameWithNamespace[0]
 	}
 
-	name = strings.ReplaceAll(name, "_", ".")
 	return name
 }
 

--- a/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/otterizecloud/cloud_reconciler_test.go
@@ -55,7 +55,14 @@ func (s *CloudReconcilerTestSuite) TearDownTest() {
 
 func (s *CloudReconcilerTestSuite) TestAppliedIntentsUpload() {
 	server := "test-server"
+	server2 := "other-server"
+	server2Namespace := "other-namespace"
 
+	s.assertUploadIntent(server, server2, server2Namespace)
+}
+
+func (s *CloudReconcilerTestSuite) assertUploadIntent(server string, server2 string, server2Namespace string) {
+	server2FullName := server2 + "." + server2Namespace
 	clientIntents := otterizev1alpha2.ClientIntents{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      intentsObjectName,
@@ -72,7 +79,7 @@ func (s *CloudReconcilerTestSuite) TestAppliedIntentsUpload() {
 					Type: "",
 				},
 				{
-					Name: "other-server.other-namespace",
+					Name: server2FullName,
 				},
 			},
 		},
@@ -87,11 +94,12 @@ func (s *CloudReconcilerTestSuite) TestAppliedIntentsUpload() {
 		Topics:          nil,
 		Resources:       nil,
 	}
+
 	expectedIntentInOtherNamespace := graphqlclient.IntentInput{
 		ClientName:      lo.ToPtr(clientName),
-		ServerName:      lo.ToPtr("other-server"),
+		ServerName:      lo.ToPtr(server2),
 		Namespace:       lo.ToPtr(testNamespace),
-		ServerNamespace: lo.ToPtr("other-namespace"),
+		ServerNamespace: lo.ToPtr(server2Namespace),
 		Type:            nil,
 		Topics:          nil,
 		Resources:       nil,
@@ -103,6 +111,14 @@ func (s *CloudReconcilerTestSuite) TestAppliedIntentsUpload() {
 	}
 
 	s.assertReportedIntents(clientIntents, expectedIntents)
+}
+
+func (s *CloudReconcilerTestSuite) TestAppliedIntentsUploadUnderscore() {
+	server := "metric-server_3_6_9"
+	server2 := "other-server_2_0_0"
+	server2Namespace := "other-namespace"
+
+	s.assertUploadIntent(server, server2, server2Namespace)
 }
 
 func (s *CloudReconcilerTestSuite) TestAppliedIntentsRetryWhenUploadFailed() {


### PR DESCRIPTION
Since dots are illegal Otterize service names but are valid deployment names, we replace the dots with underscores when detecting a service name from deployment. 

There is no reason to bring it back internally to dots, especially because we can't know if the real service name had underscores in it in the first place.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

(this is already documented)
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
