### PR TITLE
Fix protected services validator

### DIFF
--- a/src/operator/webhooks/protectedservices_webhook.go
+++ b/src/operator/webhooks/protectedservices_webhook.go
@@ -96,11 +96,14 @@ func (v *ProtectedServicesValidator) ValidateDelete(ctx context.Context, obj run
 }
 
 // validateSpec
-func (v *ProtectedServicesValidator) validateSpec(intents *otterizev1alpha2.ProtectedServices) *field.Error {
-	for _, service := range intents.Spec.ProtectedServices {
-		serviceName := strings.Trim(service.Name, "-_")
+func (v *ProtectedServicesValidator) validateSpec(protectedServices *otterizev1alpha2.ProtectedServices) *field.Error {
+	for _, service := range protectedServices.Spec.ProtectedServices {
+		serviceName := strings.ReplaceAll(service.Name, "-", "")
+		serviceName = strings.ReplaceAll(serviceName, "_", "")
 		// Validate Service Name contains only lowercase alphanumeric characters
-		if !govalidator.IsAlphanumeric(serviceName) {
+		// Service name should be a valid RFC 1123 subdomain name
+		// It's a namespaced resource, we do not expect resources in other namespaces
+		if !govalidator.IsAlphanumeric(serviceName) || !govalidator.IsLowerCase(serviceName) {
 			message := fmt.Sprintf("Invalid Name: %s. Service name must contain only lowercase alphanumeric characters, '-' or '_'", service.Name)
 			return &field.Error{
 				Type:   field.ErrorTypeForbidden,


### PR DESCRIPTION
Fixing two errors in Protected Services CRD validation:
1. Only lowercase letters should be allowed
2. The use of the function `Trim` was wrong since it only works at the end of the string

- [x] This change adds test coverage for new/changed/fixed functionality

- Those rules will be documented when development will be done and before publishing the feature in our helm chart