### PR TITLE
Create protected services reconciler group

### DIFF
--- a/src/operator/controllers/protected_services_reconcilers/default_deny.go
+++ b/src/operator/controllers/protected_services_reconcilers/default_deny.go
@@ -1,0 +1,171 @@
+package protected_services_reconcilers
+
+import (
+	"context"
+	"fmt"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DefaultDenyReconciler reconciles a ProtectedServices object
+type DefaultDenyReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	injectablerecorder.InjectableRecorder
+}
+
+func NewDefaultDenyReconciler(client client.Client, scheme *runtime.Scheme) *DefaultDenyReconciler {
+	return &DefaultDenyReconciler{
+		Client: client,
+		Scheme: scheme,
+	}
+}
+
+func (r *DefaultDenyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !viper.GetBool(operatorconfig.EnableProtectedServicesKey) {
+		return r.DeleteAllDefaultDeny(ctx, req.Namespace)
+	}
+
+	var ProtectedServicesResources otterizev1alpha2.ProtectedServicesList
+
+	err := r.List(ctx, &ProtectedServicesResources, client.InNamespace(req.Namespace))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.blockAccessToServices(ctx, ProtectedServicesResources, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DefaultDenyReconciler) blockAccessToServices(ctx context.Context, ProtectedServicesResources otterizev1alpha2.ProtectedServicesList, namespace string) error {
+	serversToProtect := map[string]v1.NetworkPolicy{}
+	for _, list := range ProtectedServicesResources.Items {
+		if list.DeletionTimestamp != nil {
+			logrus.Infof("Protected service %s is being deleted and ignored", list.Name)
+			continue
+		}
+
+		for _, service := range list.Spec.ProtectedServices {
+			formattedServerName := otterizev1alpha2.GetFormattedOtterizeIdentity(service.Name, namespace)
+			policy := r.buildNetworkPolicyObjectForIntent(formattedServerName, service.Name, namespace)
+			serversToProtect[formattedServerName] = policy
+		}
+	}
+
+	var networkPolicies v1.NetworkPolicyList
+	err := r.List(ctx, &networkPolicies, client.InNamespace(namespace), client.MatchingLabels{
+		otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, existingPolicy := range networkPolicies.Items {
+		existingPolicyServerName := existingPolicy.Labels[otterizev1alpha2.OtterizeNetworkPolicy]
+		_, found := serversToProtect[existingPolicyServerName]
+		if found {
+			desiredPolicy := serversToProtect[existingPolicyServerName]
+			err = r.updateIfNeeded(existingPolicy, desiredPolicy)
+			if err != nil {
+				return err
+			}
+			delete(serversToProtect, existingPolicyServerName)
+		} else {
+			err = r.Delete(ctx, &existingPolicy)
+			if err != nil {
+				return err
+			}
+			logrus.Infof("Deleted network policy %s", existingPolicy.Name)
+		}
+	}
+
+	for _, networkPolicy := range serversToProtect {
+		err = r.Create(ctx, &networkPolicy)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("Created network policy %s", networkPolicy.Name)
+	}
+
+	return nil
+}
+
+func (r *DefaultDenyReconciler) updateIfNeeded(
+	existingPolicy v1.NetworkPolicy,
+	newPolicy v1.NetworkPolicy,
+) error {
+	if reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) && reflect.DeepEqual(existingPolicy.Labels, newPolicy.Labels) {
+		return nil
+	}
+
+	existingPolicy.Spec = newPolicy.Spec
+	existingPolicy.Labels = newPolicy.Labels
+
+	err := r.Update(context.Background(), &existingPolicy)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Updated network policy %s", existingPolicy.Name)
+	return nil
+}
+
+func (r *DefaultDenyReconciler) buildNetworkPolicyObjectForIntent(
+	formattedServerName string,
+	serviceName string,
+	namespace string,
+) v1.NetworkPolicy {
+	policyName := fmt.Sprintf("default-deny-%s", serviceName)
+	return v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
+				otterizev1alpha2.OtterizeNetworkPolicy:                   formattedServerName,
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					otterizev1alpha2.OtterizeServerLabelKey: formattedServerName,
+				},
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{},
+		},
+	}
+}
+
+func (r *DefaultDenyReconciler) DeleteAllDefaultDeny(ctx context.Context, namespace string) (ctrl.Result, error) {
+	var networkPolicies v1.NetworkPolicyList
+	err := r.List(ctx, &networkPolicies, client.InNamespace(namespace), client.MatchingLabels{
+		otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, existingPolicy := range networkPolicies.Items {
+		err = r.Delete(ctx, &existingPolicy)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		logrus.Infof("Deleted network policy %s", existingPolicy.Name)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/protected_services_reconcilers/default_deny_test.go
+++ b/src/operator/controllers/protected_services_reconcilers/default_deny_test.go
@@ -1,4 +1,4 @@
-package controllers
+package protected_services_reconcilers
 
 import (
 	"context"
@@ -24,28 +24,29 @@ const (
 	protectedServiceFormattedName        = "test-service-test-namespace-b0207e"
 	anotherProtectedService              = "other-test-service"
 	anotherProtectedServiceFormattedName = "other-test-service-test-namespace-398a04"
+	testNamespace                        = "test-namespace"
 )
 
-type ProtectedServiceReconcilerTestSuite struct {
+type DefaultDenyReconcilerTestSuite struct {
 	testbase.MocksSuiteBase
-	reconciler *ProtectedServicesReconciler
+	reconciler *DefaultDenyReconciler
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) SetupTest() {
+func (s *DefaultDenyReconcilerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
 
 	scheme := runtime.NewScheme()
-	s.reconciler = NewProtectedServicesReconciler(s.Client, scheme)
+	s.reconciler = NewDefaultDenyReconciler(s.Client, scheme)
 	viper.Set(operatorconfig.EnableProtectedServicesKey, true)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TearDownTest() {
+func (s *DefaultDenyReconcilerTestSuite) TearDownTest() {
 	viper.Reset()
 	s.reconciler = nil
 	s.MocksSuiteBase.TearDownTest()
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServicesCreate() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreate() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -111,7 +112,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServicesCreate() {
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServicesCreateFromMultipleLists() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreateFromMultipleLists() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -213,7 +214,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServicesCreateFromMul
 }
 
 // TestDeleteProtectedServices tests the deletion of a protected service when the service is no longer in the list of protected services
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceNotInList() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceNotInList() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -280,7 +281,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceNotInList() {
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceResourceBeingDeleted() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceResourceBeingDeleted() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -351,7 +352,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceResourceBeingD
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceResourceAlreadyDeleted() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceResourceAlreadyDeleted() {
 	s.Client.EXPECT().List(gomock.Any(), gomock.Eq(&otterizev1alpha2.ProtectedServicesList{}), client.InNamespace(testNamespace)).Return(nil)
 
 	request := ctrl.Request{
@@ -400,7 +401,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceResourceAlread
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceAlreadyExists() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceAlreadyExists() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -497,7 +498,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceAlreadyExists(
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceUpdate() {
+func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceUpdate() {
 	var protectedServicesResources otterizev1alpha2.ProtectedServicesList
 	protectedServicesResources.Items = []otterizev1alpha2.ProtectedServices{
 		{
@@ -584,7 +585,7 @@ func (s *ProtectedServiceReconcilerTestSuite) TestProtectedServiceUpdate() {
 	s.Require().NoError(err)
 }
 
-func (s *ProtectedServiceReconcilerTestSuite) TestDeleteAllWhenFeatureDisabled() {
+func (s *DefaultDenyReconcilerTestSuite) TestDeleteAllWhenFeatureDisabled() {
 	viper.Set(operatorconfig.EnableProtectedServicesKey, false)
 
 	formattedServerName := protectedServiceFormattedName
@@ -653,6 +654,6 @@ func (s *ProtectedServiceReconcilerTestSuite) TestDeleteAllWhenFeatureDisabled()
 
 }
 
-func TestProtectedServiceReconcilerTestSuite(t *testing.T) {
-	suite.Run(t, new(ProtectedServiceReconcilerTestSuite))
+func TestDefaultDenyReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(DefaultDenyReconcilerTestSuite))
 }

--- a/src/operator/controllers/protectedservices_controller.go
+++ b/src/operator/controllers/protectedservices_controller.go
@@ -18,15 +18,10 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/otterize/intents-operator/src/operator/controllers/protected_services_reconcilers"
+	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/samber/lo"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	v1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,10 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	protectedServicesGroupName = "protected-services"
+)
+
 // ProtectedServicesReconciler reconciles a ProtectedServices object
 type ProtectedServicesReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	group *reconcilergroup.Group
 }
 
 //+kubebuilder:rbac:groups=k8s.otterize.com,resources=protectedservices,verbs=get;list;watch;create;update;patch;delete
@@ -45,156 +44,28 @@ type ProtectedServicesReconciler struct {
 //+kubebuilder:rbac:groups=k8s.otterize.com,resources=protectedservices/finalizers,verbs=update
 
 func NewProtectedServicesReconciler(client client.Client, scheme *runtime.Scheme) *ProtectedServicesReconciler {
+	group := reconcilergroup.NewGroup(protectedServicesGroupName, client, scheme,
+		protected_services_reconcilers.NewDefaultDenyReconciler(client, scheme))
 	return &ProtectedServicesReconciler{
 		Client: client,
-		Scheme: scheme,
+		group:  group,
 	}
 }
 
 func (r *ProtectedServicesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if !viper.GetBool(operatorconfig.EnableProtectedServicesKey) {
-		return r.DeleteAllDefaultDeny(ctx, req.Namespace)
-	}
-
-	var ProtectedServicesResources otterizev1alpha2.ProtectedServicesList
-
-	err := r.List(ctx, &ProtectedServicesResources, client.InNamespace(req.Namespace))
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.blockAccessToServices(ctx, ProtectedServicesResources, req.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func (r *ProtectedServicesReconciler) blockAccessToServices(ctx context.Context, ProtectedServicesResources otterizev1alpha2.ProtectedServicesList, namespace string) error {
-	serversToProtect := map[string]v1.NetworkPolicy{}
-	for _, list := range ProtectedServicesResources.Items {
-		if list.DeletionTimestamp != nil {
-			logrus.Infof("Protected service %s is being deleted and ignored", list.Name)
-			continue
-		}
-
-		for _, service := range list.Spec.ProtectedServices {
-			formattedServerName := otterizev1alpha2.GetFormattedOtterizeIdentity(service.Name, namespace)
-			policy := r.buildNetworkPolicyObjectForIntent(formattedServerName, service.Name, namespace)
-			serversToProtect[formattedServerName] = policy
-		}
-	}
-
-	var networkPolicies v1.NetworkPolicyList
-	err := r.List(ctx, &networkPolicies, client.InNamespace(namespace), client.MatchingLabels{
-		otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, existingPolicy := range networkPolicies.Items {
-		existingPolicyServerName := existingPolicy.Labels[otterizev1alpha2.OtterizeNetworkPolicy]
-		_, found := serversToProtect[existingPolicyServerName]
-		if found {
-			desiredPolicy := serversToProtect[existingPolicyServerName]
-			err = r.updateIfNeeded(existingPolicy, desiredPolicy)
-			if err != nil {
-				return err
-			}
-			delete(serversToProtect, existingPolicyServerName)
-		} else {
-			err = r.Delete(ctx, &existingPolicy)
-			if err != nil {
-				return err
-			}
-			logrus.Infof("Deleted network policy %s", existingPolicy.Name)
-		}
-	}
-
-	for _, networkPolicy := range serversToProtect {
-		err = r.Create(ctx, &networkPolicy)
-		if err != nil {
-			return err
-		}
-		logrus.Infof("Created network policy %s", networkPolicy.Name)
-	}
-
-	return nil
-}
-
-func (r *ProtectedServicesReconciler) updateIfNeeded(
-	existingPolicy v1.NetworkPolicy,
-	newPolicy v1.NetworkPolicy,
-) error {
-	if reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) && reflect.DeepEqual(existingPolicy.Labels, newPolicy.Labels) {
-		return nil
-	}
-
-	existingPolicy.Spec = newPolicy.Spec
-	existingPolicy.Labels = newPolicy.Labels
-
-	err := r.Update(context.Background(), &existingPolicy)
-	if err != nil {
-		return err
-	}
-
-	logrus.Infof("Updated network policy %s", existingPolicy.Name)
-	return nil
-}
-
-func (r *ProtectedServicesReconciler) buildNetworkPolicyObjectForIntent(
-	formattedServerName string,
-	serviceName string,
-	namespace string,
-) v1.NetworkPolicy {
-	policyName := fmt.Sprintf("default-deny-%s", serviceName)
-	return v1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
-				otterizev1alpha2.OtterizeNetworkPolicy:                   formattedServerName,
-			},
-		},
-		Spec: v1.NetworkPolicySpec{
-			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					otterizev1alpha2.OtterizeServerLabelKey: formattedServerName,
-				},
-			},
-			Ingress: []v1.NetworkPolicyIngressRule{},
-		},
-	}
-}
-
-func (r *ProtectedServicesReconciler) DeleteAllDefaultDeny(ctx context.Context, namespace string) (ctrl.Result, error) {
-	var networkPolicies v1.NetworkPolicyList
-	err := r.List(ctx, &networkPolicies, client.InNamespace(namespace), client.MatchingLabels{
-		otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny: "true",
-	})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	for _, existingPolicy := range networkPolicies.Items {
-		err = r.Delete(ctx, &existingPolicy)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		logrus.Infof("Deleted network policy %s", existingPolicy.Name)
-	}
-
-	return ctrl.Result{}, nil
+	return r.group.Reconcile(ctx, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ProtectedServicesReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&otterizev1alpha2.ProtectedServices{}).
 		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
 		Complete(r)
+	if err != nil {
+		return err
+	}
+
+	r.group.InjectRecorder(mgr.GetEventRecorderFor(protectedServicesGroupName))
+	return nil
 }

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -267,10 +267,9 @@ func main() {
 		logrus.WithError(err).Fatal("unable to create controller", "controller", "KafkaServerConfig")
 	}
 
-	if err = (&controllers.ProtectedServicesReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	protectedServicesReconciler := controllers.NewProtectedServicesReconciler(mgr.GetClient(), mgr.GetScheme())
+	err = protectedServicesReconciler.SetupWithManager(mgr)
+	if err != nil {
 		logrus.WithError(err).Fatal("unable to create controller", "controller", "ProtectedServices")
 	}
 


### PR DESCRIPTION
To enable adding new reconcilers for protected services, this PR moves the default deny logic to a new reconciler and create the group.