### PR TITLE
Report ProtectedServicesEnabled only if network policy creation is enabled

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -299,7 +299,7 @@ func uploadConfiguration(ctx context.Context, otterizeCloudClient operator_cloud
 		NetworkPolicyEnforcementEnabled: config.EnforcementDefaultState && config.EnableNetworkPolicy,
 		KafkaACLEnforcementEnabled:      config.EnforcementDefaultState && config.EnableKafkaACL,
 		IstioPolicyEnforcementEnabled:   config.EnforcementDefaultState && config.EnableIstioPolicy,
-		ProtectedServicesEnabled:        true, // this version always sends true - tells the cloud the feature exists so it correctly simulates behavior
+		ProtectedServicesEnabled:        config.EnableNetworkPolicy, // in this version, protected services are enabled if network policy creation is enabled, regardless of enforcement default state
 	})
 	if err != nil {
 		logrus.WithError(err).Error("Failed to report configuration to the cloud")


### PR DESCRIPTION
This PR changes the behavior of when the operator reports ProtectedServicesEnabled to the cloud - instead of always, it now only does it when network policy creation is enabled. The cloud can use this information to determine whether this feature is both supported and will result in network policies being created, when simulating the effects of network policies.