### PR TITLE
Create ProtectedService CRD if missing, add webhook to validate duplicate protected services

### DIFF
--- a/src/operator/protectedservicescrd/applyProtectedServicesCRD.go
+++ b/src/operator/protectedservicescrd/applyProtectedServicesCRD.go
@@ -29,7 +29,7 @@ func EnsureProtectedServicesCRD(ctx context.Context, client client.Client) error
 	if k8serrors.IsNotFound(err) {
 		err := client.Create(ctx, &crdToCreate)
 		if err != nil {
-			return fmt.Errorf("could not get protected services CRD: %w", err)
+			return fmt.Errorf("could not create protected services CRD: %w", err)
 		}
 		return nil
 	}

--- a/src/operator/protectedservicescrd/applyProtectedServicesCRD.go
+++ b/src/operator/protectedservicescrd/applyProtectedServicesCRD.go
@@ -1,0 +1,38 @@
+package protectedservicescrd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:embed protectedservices-customresourcedefinition.yaml
+var crdContents []byte
+
+func EnsureProtectedServicesCRD(ctx context.Context, client client.Client) error {
+	crdToCreate := apiextensionsv1.CustomResourceDefinition{}
+	err := yaml.Unmarshal(crdContents, &crdToCreate)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal protected services CRD: %w", err)
+	}
+	crd := apiextensionsv1.CustomResourceDefinition{}
+	err = client.Get(ctx, types.NamespacedName{Name: crdToCreate.Name}, &crd)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("could not get protected services CRD: %w", err)
+	}
+
+	if k8serrors.IsNotFound(err) {
+		err := client.Create(ctx, &crdToCreate)
+		if err != nil {
+			return fmt.Errorf("could not get protected services CRD: %w", err)
+		}
+		return nil
+	}
+
+	return nil
+}

--- a/src/operator/protectedservicescrd/protectedservices-customresourcedefinition.yaml
+++ b/src/operator/protectedservicescrd/protectedservices-customresourcedefinition.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+    "helm.sh/resource-policy": keep
+  creationTimestamp: null
+  name: protectedservices.k8s.otterize.com
+spec:
+  group: k8s.otterize.com
+  names:
+    kind: ProtectedService
+    listKind: ProtectedServiceList
+    plural: protectedservices
+    singular: protectedservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ProtectedService is the Schema for the protectedservice API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProtectedServiceSpec defines the desired state of ProtectedService
+            properties:
+              name:
+                type: string
+            type: object
+          status:
+            description: ProtectedServiceStatus defines the observed state of ProtectedService
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/src/operator/webhooks/protectedservices_webhook.go
+++ b/src/operator/webhooks/protectedservices_webhook.go
@@ -55,9 +55,18 @@ var _ webhook.CustomValidator = &ProtectedServiceValidator{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (v *ProtectedServiceValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	var allErrs field.ErrorList
-	intentsObj := obj.(*otterizev1alpha2.ProtectedService)
+	protectedService := obj.(*otterizev1alpha2.ProtectedService)
 
-	if err := v.validateSpec(intentsObj); err != nil {
+	protectedServicesList := &otterizev1alpha2.ProtectedServiceList{}
+	if err := v.List(ctx, protectedServicesList, &client.ListOptions{Namespace: protectedService.Namespace}); err != nil {
+		return err
+	}
+
+	if err := v.validateNoDuplicateClients(protectedService, protectedServicesList); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := v.validateSpec(protectedService); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -65,27 +74,27 @@ func (v *ProtectedServiceValidator) ValidateCreate(ctx context.Context, obj runt
 		return nil
 	}
 
-	gvk := intentsObj.GroupVersionKind()
+	gvk := protectedService.GroupVersionKind()
 	return errors.NewInvalid(
 		schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind},
-		intentsObj.Name, allErrs)
+		protectedService.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (v *ProtectedServiceValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
 	var allErrs field.ErrorList
-	protectedServices := newObj.(*otterizev1alpha2.ProtectedService)
+	protectedService := newObj.(*otterizev1alpha2.ProtectedService)
 
 	protectedServicesList := &otterizev1alpha2.ProtectedServiceList{}
-	if err := v.List(ctx, protectedServicesList, &client.ListOptions{Namespace: protectedServices.Namespace}); err != nil {
+	if err := v.List(ctx, protectedServicesList, &client.ListOptions{Namespace: protectedService.Namespace}); err != nil {
 		return err
 	}
 
-	if err := v.validateNoDuplicateClients(protectedServices, protectedServicesList); err != nil {
+	if err := v.validateNoDuplicateClients(protectedService, protectedServicesList); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
-	if err := v.validateSpec(protectedServices); err != nil {
+	if err := v.validateSpec(protectedService); err != nil {
 		allErrs = append(allErrs, err)
 	}
 
@@ -93,10 +102,10 @@ func (v *ProtectedServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		return nil
 	}
 
-	gvk := protectedServices.GroupVersionKind()
+	gvk := protectedService.GroupVersionKind()
 	return errors.NewInvalid(
 		schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind},
-		protectedServices.Name, allErrs)
+		protectedService.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/src/operator/webhooks/webhook_suite_test.go
+++ b/src/operator/webhooks/webhook_suite_test.go
@@ -170,6 +170,32 @@ func (s *ValidationWebhookTestSuite) TestValidateProtectedServicesFailIfDotFound
 	s.Require().Error(err)
 }
 
+func (s *ValidationWebhookTestSuite) TestValidateProtectedServicesFailIfSameName() {
+	fakeValidator := NewProtectedServiceValidator(nil)
+
+	protectedServiceList := otterizev1alpha2.ProtectedServiceList{Items: []otterizev1alpha2.ProtectedService{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "protected-services",
+			Namespace: "test-namespace",
+		},
+		Spec: otterizev1alpha2.ProtectedServiceSpec{
+			Name: "my-service.test-namespace",
+		},
+	}}}
+
+	protectedService := otterizev1alpha2.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "protected-services",
+			Namespace: "test-namespace",
+		},
+		Spec: otterizev1alpha2.ProtectedServiceSpec{
+			Name: "my-service",
+		},
+	}
+	err := fakeValidator.validateNoDuplicateClients(&protectedService, &protectedServiceList)
+	s.Require().Error(err)
+}
+
 func (s *ValidationWebhookTestSuite) TestValidateProtectedServicesFailIfUppercase() {
 	fakeValidator := NewProtectedServiceValidator(nil)
 


### PR DESCRIPTION
This PR makes the operator create the ProtectedService CRD if it is missing. This is a temporary measure, as we switch from using Helm charts to manage our CRDs to asking users to apply CRDs prior to installation. Once we do so and that has been released for a while, we will remove this workaround.

Also in this PR: missing webhook to validate that there are no duplicate protected services

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
