### PR TITLE
Fix ProtectedService manifest generation

### DIFF
--- a/src/operator/webhooks/protectedservices_webhook.go
+++ b/src/operator/webhooks/protectedservices_webhook.go
@@ -48,7 +48,7 @@ func NewProtectedServiceValidator(c client.Client) *ProtectedServiceValidator {
 	}
 }
 
-//+kubebuilder:webhook:path=/validate-k8s-otterize-com-v1alpha2-protectedservices,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=protectedservices,verbs=create;update,versions=v1alpha2,name=protectedservice.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-k8s-otterize-com-v1alpha2-protectedservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=protectedservice,verbs=create;update,versions=v1alpha2,name=protectedservice.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &ProtectedServiceValidator{}
 


### PR DESCRIPTION
ProtectedService CRD had changed from plural to single and the helm chart was updated accordingly. This PR fixes the web-hook validation manifest generation to align with the new change and the current state of the Helm chart subrepo.