### PR TITLE
Clean access policies if server is not protected

### DIFF
--- a/src/operator/controllers/intents_reconcilers/network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/network_policy.go
@@ -303,7 +303,7 @@ func (r *NetworkPolicyReconciler) handleIntentRemoval(
 func (r *NetworkPolicyReconciler) removeOrphanNetworkPolicies(ctx context.Context) error {
 	logrus.Info("Searching for orphaned network policies")
 	networkPolicyList := &v1.NetworkPolicyList{}
-	selector, err := r.matchAccessNetworkPolicy()
+	selector, err := MatchAccessNetworkPolicy()
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func (r *NetworkPolicyReconciler) removeNetworkPolicy(ctx context.Context, netwo
 	return nil
 }
 
-func (r *NetworkPolicyReconciler) matchAccessNetworkPolicy() (labels.Selector, error) {
+func MatchAccessNetworkPolicy() (labels.Selector, error) {
 	isOtterizeNetworkPolicy := metav1.LabelSelectorRequirement{
 		Key:      otterizev1alpha2.OtterizeNetworkPolicy,
 		Operator: metav1.LabelSelectorOpExists,

--- a/src/operator/controllers/protected_service_reconcilers/default_deny.go
+++ b/src/operator/controllers/protected_service_reconcilers/default_deny.go
@@ -23,6 +23,7 @@ type DefaultDenyReconciler struct {
 type ExternalNepolHandler interface {
 	HandlePodsByNamespace(ctx context.Context, namespace string) error
 	HandleAllPods(ctx context.Context) error
+	HandleBeforeAccessPolicyRemoval(ctx context.Context, accessPolicy *v1.NetworkPolicy) error
 }
 
 func NewDefaultDenyReconciler(client client.Client, extNetpolHandler ExternalNepolHandler) *DefaultDenyReconciler {

--- a/src/operator/controllers/protected_service_reconcilers/default_deny_test.go
+++ b/src/operator/controllers/protected_service_reconcilers/default_deny_test.go
@@ -22,6 +22,7 @@ const (
 	protectedServicesResourceName        = "staging-protected-services"
 	protectedService                     = "test-service"
 	protectedServiceFormattedName        = "test-service-test-namespace-b0207e"
+	anotherProtectedServiceResourceName  = "protect-other-services"
 	anotherProtectedService              = "other-test-service"
 	anotherProtectedServiceFormattedName = "other-test-service-test-namespace-398a04"
 	testNamespace                        = "test-namespace"

--- a/src/operator/controllers/protected_service_reconcilers/mocks/ext_netpol_handler_mock.go
+++ b/src/operator/controllers/protected_service_reconcilers/mocks/ext_netpol_handler_mock.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
+	v1 "k8s.io/api/networking/v1"
 )
 
 // MockExternalNepolHandler is a mock of ExternalNepolHandler interface.
@@ -46,6 +47,20 @@ func (m *MockExternalNepolHandler) HandleAllPods(ctx context.Context) error {
 func (mr *MockExternalNepolHandlerMockRecorder) HandleAllPods(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAllPods", reflect.TypeOf((*MockExternalNepolHandler)(nil).HandleAllPods), ctx)
+}
+
+// HandleBeforeAccessPolicyRemoval mocks base method.
+func (m *MockExternalNepolHandler) HandleBeforeAccessPolicyRemoval(ctx context.Context, accessPolicy *v1.NetworkPolicy) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleBeforeAccessPolicyRemoval", ctx, accessPolicy)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleBeforeAccessPolicyRemoval indicates an expected call of HandleBeforeAccessPolicyRemoval.
+func (mr *MockExternalNepolHandlerMockRecorder) HandleBeforeAccessPolicyRemoval(ctx, accessPolicy interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBeforeAccessPolicyRemoval", reflect.TypeOf((*MockExternalNepolHandler)(nil).HandleBeforeAccessPolicyRemoval), ctx, accessPolicy)
 }
 
 // HandlePodsByNamespace mocks base method.

--- a/src/operator/controllers/protected_service_reconcilers/policy_cleaner.go
+++ b/src/operator/controllers/protected_service_reconcilers/policy_cleaner.go
@@ -1,0 +1,80 @@
+package protected_service_reconcilers
+
+import (
+	"context"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PolicyCleanerReconciler reconciles a ProtectedService object
+type PolicyCleanerReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	extNetpolHandler ExternalNepolHandler
+}
+
+func NewPolicyCleanerReconciler(client client.Client, extNetpolHandler ExternalNepolHandler) *PolicyCleanerReconciler {
+	return &PolicyCleanerReconciler{
+		Client:           client,
+		extNetpolHandler: extNetpolHandler,
+	}
+}
+
+func (r *PolicyCleanerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	selector, err := intents_reconcilers.MatchAccessNetworkPolicy()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	namespace := req.Namespace
+	policies := &v1.NetworkPolicyList{}
+	err = r.List(ctx, policies, &client.ListOptions{Namespace: namespace, LabelSelector: selector})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if len(policies.Items) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	var protectedServicesResources otterizev1alpha2.ProtectedServiceList
+	err = r.List(ctx, &protectedServicesResources, &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	protectedServersByNamespace := sets.Set[string]{}
+	for _, protectedService := range protectedServicesResources.Items {
+		serverName := otterizev1alpha2.GetFormattedOtterizeIdentity(protectedService.Spec.Name, namespace)
+		protectedServersByNamespace.Insert(serverName)
+	}
+
+	for _, networkPolicy := range policies.Items {
+		serverName := networkPolicy.Labels[otterizev1alpha2.OtterizeNetworkPolicy]
+		if !protectedServersByNamespace.Has(serverName) {
+			err = r.removeNetworkPolicy(ctx, networkPolicy)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PolicyCleanerReconciler) removeNetworkPolicy(ctx context.Context, networkPolicy v1.NetworkPolicy) error {
+	err := r.extNetpolHandler.HandleBeforeAccessPolicyRemoval(ctx, &networkPolicy)
+	if err != nil {
+		return err
+	}
+	err = r.Delete(ctx, &networkPolicy)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/operator/controllers/protected_service_reconcilers/policy_cleaner_test.go
+++ b/src/operator/controllers/protected_service_reconcilers/policy_cleaner_test.go
@@ -1,0 +1,373 @@
+package protected_service_reconcilers
+
+import (
+	"context"
+	"fmt"
+	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	protectedservicesmock "github.com/otterize/intents-operator/src/operator/controllers/protected_service_reconcilers/mocks"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+}
+
+type PolicyCleanerReconcilerTestSuite struct {
+	testbase.MocksSuiteBase
+	reconciler       *PolicyCleanerReconciler
+	extNetpolHandler *protectedservicesmock.MockExternalNepolHandler
+}
+
+func (s *PolicyCleanerReconcilerTestSuite) SetupTest() {
+	s.MocksSuiteBase.SetupTest()
+
+	s.extNetpolHandler = protectedservicesmock.NewMockExternalNepolHandler(s.Controller)
+	s.reconciler = NewPolicyCleanerReconciler(s.Client, s.extNetpolHandler)
+}
+
+func (s *PolicyCleanerReconcilerTestSuite) TearDownTest() {
+	viper.Reset()
+	s.reconciler = nil
+	s.MocksSuiteBase.TearDownTest()
+}
+
+func (s *PolicyCleanerReconcilerTestSuite) TestAllServerAreProtected() {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicy,
+			Operator: metav1.LabelSelectorOpExists,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+	}})
+	s.Require().NoError(err)
+
+	networkPolicies := []v1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "policy-name",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					otterizev1alpha2.OtterizeNetworkPolicy: protectedServiceFormattedName,
+				},
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						otterizev1alpha2.OtterizeServerLabelKey: protectedServiceFormattedName,
+					},
+				},
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										fmt.Sprintf(
+											otterizev1alpha2.OtterizeAccessLabelKey, protectedServiceFormattedName): "true",
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										otterizev1alpha2.OtterizeNamespaceLabelKey: testNamespace,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "another-policy-name",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					otterizev1alpha2.OtterizeNetworkPolicy: anotherProtectedServiceFormattedName,
+				},
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						otterizev1alpha2.OtterizeServerLabelKey: anotherProtectedServiceFormattedName,
+					},
+				},
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										fmt.Sprintf(
+											otterizev1alpha2.OtterizeAccessLabelKey, anotherProtectedServiceFormattedName): "true",
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										otterizev1alpha2.OtterizeNamespaceLabelKey: testNamespace,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Client.EXPECT().List(
+		gomock.Any(),
+		gomock.Eq(&v1.NetworkPolicyList{}),
+		&client.ListOptions{Namespace: testNamespace, LabelSelector: selector},
+	).DoAndReturn(
+		func(ctx context.Context, list *v1.NetworkPolicyList, opts ...client.ListOption) error {
+			list.Items = append(list.Items, networkPolicies...)
+			return nil
+		})
+
+	var protectedServicesResources otterizev1alpha2.ProtectedServiceList
+	protectedServicesResources.Items = []otterizev1alpha2.ProtectedService{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      protectedServicesResourceName,
+				Namespace: testNamespace,
+			},
+			Spec: otterizev1alpha2.ProtectedServiceSpec{
+				Name: protectedService,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      anotherProtectedServiceResourceName,
+				Namespace: testNamespace,
+			},
+			Spec: otterizev1alpha2.ProtectedServiceSpec{
+				Name: anotherProtectedService,
+			},
+		},
+	}
+
+	s.Client.EXPECT().List(gomock.Any(), gomock.Eq(&otterizev1alpha2.ProtectedServiceList{}), &client.ListOptions{Namespace: testNamespace}).DoAndReturn(
+		func(ctx context.Context, list *otterizev1alpha2.ProtectedServiceList, opts ...client.ListOption) error {
+			protectedServicesResources.DeepCopyInto(list)
+			return nil
+		})
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      protectedServicesResourceName,
+		},
+	}
+
+	res, err := s.reconciler.Reconcile(context.Background(), request)
+	s.Require().Empty(res)
+	s.Require().NoError(err)
+}
+
+func (s *PolicyCleanerReconcilerTestSuite) TestUnprotectedServerWithAccessPolicy() {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicy,
+			Operator: metav1.LabelSelectorOpExists,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+	}})
+	s.Require().NoError(err)
+
+	networkPolicies := []v1.NetworkPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "policy-name",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					otterizev1alpha2.OtterizeNetworkPolicy: protectedServiceFormattedName,
+				},
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						otterizev1alpha2.OtterizeServerLabelKey: protectedServiceFormattedName,
+					},
+				},
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										fmt.Sprintf(
+											otterizev1alpha2.OtterizeAccessLabelKey, protectedServiceFormattedName): "true",
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										otterizev1alpha2.OtterizeNamespaceLabelKey: testNamespace,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "another-policy-name",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					otterizev1alpha2.OtterizeNetworkPolicy: anotherProtectedServiceFormattedName,
+				},
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						otterizev1alpha2.OtterizeServerLabelKey: anotherProtectedServiceFormattedName,
+					},
+				},
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										fmt.Sprintf(
+											otterizev1alpha2.OtterizeAccessLabelKey, anotherProtectedServiceFormattedName): "true",
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										otterizev1alpha2.OtterizeNamespaceLabelKey: testNamespace,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Client.EXPECT().List(
+		gomock.Any(),
+		gomock.Eq(&v1.NetworkPolicyList{}),
+		&client.ListOptions{Namespace: testNamespace, LabelSelector: selector},
+	).DoAndReturn(
+		func(ctx context.Context, list *v1.NetworkPolicyList, opts ...client.ListOption) error {
+			list.Items = append(list.Items, networkPolicies...)
+			return nil
+		})
+
+	var protectedServicesResources otterizev1alpha2.ProtectedServiceList
+	protectedServicesResources.Items = []otterizev1alpha2.ProtectedService{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      protectedServicesResourceName,
+				Namespace: testNamespace,
+			},
+			Spec: otterizev1alpha2.ProtectedServiceSpec{
+				Name: protectedService,
+			},
+		},
+	}
+
+	s.Client.EXPECT().List(gomock.Any(), gomock.Eq(&otterizev1alpha2.ProtectedServiceList{}), &client.ListOptions{Namespace: testNamespace}).DoAndReturn(
+		func(ctx context.Context, list *otterizev1alpha2.ProtectedServiceList, opts ...client.ListOption) error {
+			protectedServicesResources.DeepCopyInto(list)
+			return nil
+		})
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      protectedServicesResourceName,
+		},
+	}
+
+	s.extNetpolHandler.EXPECT().HandleBeforeAccessPolicyRemoval(gomock.Any(), &networkPolicies[1]).Times(1)
+	s.Client.EXPECT().Delete(gomock.Any(), &networkPolicies[1]).Times(1)
+	res, err := s.reconciler.Reconcile(context.Background(), request)
+	s.Require().Empty(res)
+	s.Require().NoError(err)
+}
+
+func (s *PolicyCleanerReconcilerTestSuite) TestNoNetworkPolicies() {
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicy,
+			Operator: metav1.LabelSelectorOpExists,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyExternalTraffic,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+		{
+			Key:      otterizev1alpha2.OtterizeNetworkPolicyServiceDefaultDeny,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+	}})
+	s.Require().NoError(err)
+	// Get all existing network policies
+	// No network policies exist
+	var networkPolicies v1.NetworkPolicyList
+	s.Client.EXPECT().List(
+		gomock.Any(),
+		gomock.Eq(&networkPolicies),
+		&client.ListOptions{Namespace: testNamespace, LabelSelector: selector},
+	).Return(nil).Times(1)
+
+	var protectedServicesResources otterizev1alpha2.ProtectedServiceList
+	protectedServicesResources.Items = []otterizev1alpha2.ProtectedService{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      protectedServicesResourceName,
+				Namespace: testNamespace,
+			},
+			Spec: otterizev1alpha2.ProtectedServiceSpec{
+				Name: protectedService,
+			},
+		},
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      protectedServicesResourceName,
+		},
+	}
+
+	res, err := s.reconciler.Reconcile(context.Background(), request)
+	s.Require().Empty(res)
+	s.Require().NoError(err)
+}
+
+func TestPolicyCleanerReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(PolicyCleanerReconcilerTestSuite))
+}

--- a/src/operator/controllers/protectedservices_controller.go
+++ b/src/operator/controllers/protectedservices_controller.go
@@ -49,9 +49,15 @@ func NewProtectedServiceReconciler(
 	scheme *runtime.Scheme,
 	otterizeClient operator_cloud_client.CloudClient,
 	extNetpolHandler protected_service_reconcilers.ExternalNepolHandler,
+	enforcementDefaultState bool,
 ) *ProtectedServiceReconciler {
 	group := reconcilergroup.NewGroup(protectedServicesGroupName, client, scheme,
 		protected_service_reconcilers.NewDefaultDenyReconciler(client, extNetpolHandler))
+
+	if !enforcementDefaultState {
+		policyCleaner := protected_service_reconcilers.NewPolicyCleanerReconciler(client, extNetpolHandler)
+		group.AddToGroup(policyCleaner)
+	}
 
 	if otterizeClient != nil {
 		otterizeCloudReconciler := protected_service_reconcilers.NewCloudReconciler(client, scheme, otterizeClient)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -280,7 +280,7 @@ func main() {
 		logrus.WithError(err).Fatal("unable to create controller", "controller", "KafkaServerConfig")
 	}
 
-	protectedServicesReconciler := controllers.NewProtectedServiceReconciler(mgr.GetClient(), mgr.GetScheme(), otterizeCloudClient, extNetpolHandler)
+	protectedServicesReconciler := controllers.NewProtectedServiceReconciler(mgr.GetClient(), mgr.GetScheme(), otterizeCloudClient, extNetpolHandler, enforcementConfig.EnforcementDefaultState)
 	err = protectedServicesReconciler.SetupWithManager(mgr)
 	if err != nil {
 		logrus.WithError(err).Fatal("unable to create controller", "controller", "ProtectedServices")


### PR DESCRIPTION
If the operator run in shadow mode there should be no access policies for server who aren't defined as protected services.
After any change in protected services in the namespace the policy cleaner reconciler will run to clean policies that may got created by older protected server resource who got deleted or from previous operator run when default enforcement was on.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
