### PR TITLE
Add finalizer to protected services 

### DIFF
--- a/src/operator/controllers/protected_service_reconcilers/cloud_reconciler.go
+++ b/src/operator/controllers/protected_service_reconcilers/cloud_reconciler.go
@@ -6,10 +6,16 @@ import (
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	CloudReconcilerFinalizerName = "protectedservice.otterize.com/finalizer"
 )
 
 type CloudReconciler struct {
@@ -32,10 +38,47 @@ func NewCloudReconciler(
 }
 
 func (r *CloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var protectedServices otterizev1alpha2.ProtectedServiceList
-	err := r.List(ctx, &protectedServices, client.InNamespace(req.Namespace))
+	err := r.handleReconcilerFinalizer(ctx, req)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	err = r.reportAllProtectedServicesInNamespace(ctx, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *CloudReconciler) handleReconcilerFinalizer(ctx context.Context, req ctrl.Request) error {
+	var protectedService otterizev1alpha2.ProtectedService
+	err := r.Get(ctx, req.NamespacedName, &protectedService)
+	if err != nil {
+		return err
+	}
+
+	if protectedService.DeletionTimestamp != nil {
+		controllerutil.RemoveFinalizer(&protectedService, CloudReconcilerFinalizerName)
+		return r.Update(ctx, &protectedService)
+	}
+
+	if !controllerutil.ContainsFinalizer(&protectedService, CloudReconcilerFinalizerName) {
+		controllerutil.AddFinalizer(&protectedService, CloudReconcilerFinalizerName)
+		return r.Update(ctx, &protectedService)
+	}
+
+	return nil
+}
+
+func (r *CloudReconciler) reportAllProtectedServicesInNamespace(ctx context.Context, namespace string) error {
+	var protectedServices otterizev1alpha2.ProtectedServiceList
+	err := r.List(ctx, &protectedServices, client.InNamespace(namespace))
+	if err != nil {
+		return err
 	}
 
 	services := sets.Set[string]{}
@@ -48,12 +91,7 @@ func (r *CloudReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	protectedServicesInput := r.formatAsCloudProtectedService(sets.List(services))
-	err = r.otterizeClient.ReportProtectedServices(ctx, req.Namespace, protectedServicesInput)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return r.otterizeClient.ReportProtectedServices(ctx, namespace, protectedServicesInput)
 }
 
 func (r *CloudReconciler) formatAsCloudProtectedService(services []string) []graphqlclient.ProtectedServiceInput {


### PR DESCRIPTION
Add finalizer to protected services to make sure we won't skip handling on any deletion event even when the operator is down.