### PR TITLE
Support user specified annotation for service name override

### DIFF
--- a/src/shared/serviceidresolver/config.go
+++ b/src/shared/serviceidresolver/config.go
@@ -1,0 +1,19 @@
+package serviceidresolver
+
+import (
+	"github.com/spf13/viper"
+	"strings"
+)
+
+const (
+	serviceNameOverrideAnnotationKey        = "service-name-override-annotation"
+	serviceNameOverrideAnnotationKeyDefault = "intents.otterize.com/service-name"
+	EnvPrefix                               = "OTTERIZE"
+)
+
+func init() {
+	viper.SetDefault(serviceNameOverrideAnnotationKey, serviceNameOverrideAnnotationKeyDefault)
+	viper.SetEnvPrefix(EnvPrefix)
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+}

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -6,16 +6,13 @@ import (
 	"fmt"
 	"github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
-)
-
-const (
-	ServiceNameAnnotation = "intents.otterize.com/service-name"
 )
 
 var PodNotFound = errors.New("pod not found")
@@ -35,7 +32,7 @@ func NewResolver(c client.Client) *Resolver {
 }
 
 func ResolvePodToServiceIdentityUsingAnnotationOnly(pod *corev1.Pod) (string, bool) {
-	annotation, ok := pod.Annotations[ServiceNameAnnotation]
+	annotation, ok := pod.Annotations[viper.GetString(serviceNameOverrideAnnotationKey)]
 	return annotation, ok
 }
 

--- a/src/shared/serviceidresolver/serviceidresolver_test.go
+++ b/src/shared/serviceidresolver/serviceidresolver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	serviceidresolvermocks "github.com/otterize/intents-operator/src/shared/serviceidresolver/mocks"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -99,7 +100,7 @@ func (s *ServiceIdResolverTestSuite) TestGetPodAnnotatedName_PodExists() {
 
 	s.Client.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: podName, Namespace: podNamespace}, gomock.AssignableToTypeOf(&corev1.Pod{})).Do(
 		func(_ context.Context, _ types.NamespacedName, pod *corev1.Pod, _ ...any) {
-			pod.Annotations = map[string]string{ServiceNameAnnotation: serviceName}
+			pod.Annotations = map[string]string{viper.GetString(serviceNameOverrideAnnotationKey): serviceName}
 		}).Return(nil)
 
 	name, found, err := s.Resolver.GetPodAnnotatedName(context.Background(), podName, podNamespace)

--- a/src/shared/serviceidresolver/serviceidresolver_test.go
+++ b/src/shared/serviceidresolver/serviceidresolver_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 )
@@ -244,6 +245,15 @@ func (s *ServiceIdResolverTestSuite) TestDeploymentRead() {
 	service, err := s.Resolver.ResolvePodToServiceIdentity(context.Background(), &myPod)
 	s.Require().NoError(err)
 	s.Require().Equal(deploymentName, service.Name)
+}
+
+func (s *ServiceIdResolverTestSuite) TestUserSpecifiedAnnotationForServiceName() {
+	annotationName := "coolAnnotationName"
+	expectedEnvVarName := "OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION"
+	_ = os.Setenv(expectedEnvVarName, annotationName)
+	s.Require().Equal(annotationName, viper.GetString(serviceNameOverrideAnnotationKey))
+	_ = os.Unsetenv(expectedEnvVarName)
+	s.Require().Equal(serviceNameOverrideAnnotationKeyDefault, viper.GetString(serviceNameOverrideAnnotationKey))
 }
 
 func TestServiceIdResolverTestSuite(t *testing.T) {


### PR DESCRIPTION
### Description

Following https://github.com/otterize/network-mapper/issues/128 , adding support for user-specified annotation for service name override. The default will be `intents.otterize.com/service-name` as it used to be, and it will be configurable through the environment variable: `OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION`. 

After this PR we should update `go.mod` for credentials-operator and network-mapper, And then expose the new env var as an helm chart value. 


### References

https://github.com/otterize/network-mapper/issues/128

### Testing


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
