### PR TITLE
Create unique event counter for telemetries

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,6 +22,7 @@ require (
 	go.uber.org/mock v0.2.0
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	golang.org/x/oauth2 v0.6.0
+	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v0.0.0-20230310175855-3be9c0870417
 	istio.io/client-go v1.17.1
 	k8s.io/api v0.26.5
@@ -108,7 +109,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.26.5 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect

--- a/src/shared/telemetries/telemetrysender/config.go
+++ b/src/shared/telemetries/telemetrysender/config.go
@@ -6,17 +6,19 @@ import (
 )
 
 const (
-	TelemetryAPIAddressKey       = "telemetry-address"
-	TimeoutKey                   = "telemetry-client-timeout"
-	CloudClientTimeoutDefault    = "30s"
-	TelemetryEnabledKey          = "telemetry-enabled"
-	TelemetryEnabledDefault      = false
-	TelemetryMaxBatchSizeKey     = "telemetry-max-batch-size"
-	TelemetryMaxBatchSizeDefault = 100
-	TelemetryIntervalKey         = "telemetry-interval-seconds"
-	TelemetryIntervalDefault     = 5
-	TelemetryAddressDefault      = "https://app.otterize.com/api/telemetry/query"
-	EnvPrefix                    = "OTTERIZE"
+	TelemetryAPIAddressKey                = "telemetry-address"
+	TimeoutKey                            = "telemetry-client-timeout"
+	CloudClientTimeoutDefault             = "30s"
+	TelemetryEnabledKey                   = "telemetry-enabled"
+	TelemetryEnabledDefault               = false
+	TelemetryMaxBatchSizeKey              = "telemetry-max-batch-size"
+	TelemetryMaxBatchSizeDefault          = 100
+	TelemetryIntervalKey                  = "telemetry-interval-seconds"
+	TelemetryIntervalDefault              = 5
+	TelemetryAddressDefault               = "https://app.otterize.com/api/telemetry/query"
+	TelemetrySnapshotResetIntervalKey     = "telemetry-snapshot-reset-interval-duration"
+	TelemetrySnapshotResetIntervalDefault = "24h"
+	EnvPrefix                             = "OTTERIZE"
 )
 
 func init() {
@@ -25,6 +27,7 @@ func init() {
 	viper.SetDefault(TelemetryIntervalKey, TelemetryIntervalDefault)
 	viper.SetDefault(TelemetryMaxBatchSizeKey, TelemetryMaxBatchSizeDefault)
 	viper.SetDefault(TelemetryEnabledKey, TelemetryEnabledDefault)
+	viper.SetDefault(TelemetrySnapshotResetIntervalKey, TelemetrySnapshotResetIntervalDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/telemetries/telemetrysender/config.go
+++ b/src/shared/telemetries/telemetrysender/config.go
@@ -6,19 +6,19 @@ import (
 )
 
 const (
-	TelemetryAPIAddressKey                = "telemetry-address"
-	TimeoutKey                            = "telemetry-client-timeout"
-	CloudClientTimeoutDefault             = "30s"
-	TelemetryEnabledKey                   = "telemetry-enabled"
-	TelemetryEnabledDefault               = false
-	TelemetryMaxBatchSizeKey              = "telemetry-max-batch-size"
-	TelemetryMaxBatchSizeDefault          = 100
-	TelemetryIntervalKey                  = "telemetry-interval-seconds"
-	TelemetryIntervalDefault              = 5
-	TelemetryAddressDefault               = "https://app.otterize.com/api/telemetry/query"
-	TelemetrySnapshotResetIntervalKey     = "telemetry-snapshot-reset-interval-duration"
-	TelemetrySnapshotResetIntervalDefault = "24h"
-	EnvPrefix                             = "OTTERIZE"
+	TelemetryAPIAddressKey        = "telemetry-address"
+	TimeoutKey                    = "telemetry-client-timeout"
+	CloudClientTimeoutDefault     = "30s"
+	TelemetryEnabledKey           = "telemetry-enabled"
+	TelemetryEnabledDefault       = false
+	TelemetryMaxBatchSizeKey      = "telemetry-max-batch-size"
+	TelemetryMaxBatchSizeDefault  = 100
+	TelemetryIntervalKey          = "telemetry-interval-seconds"
+	TelemetryIntervalDefault      = 5
+	TelemetryAddressDefault       = "https://app.otterize.com/api/telemetry/query"
+	TelemetryResetIntervalKey     = "telemetry-reset-interval-duration"
+	TelemetryResetIntervalDefault = "24h"
+	EnvPrefix                     = "OTTERIZE"
 )
 
 func init() {
@@ -27,7 +27,7 @@ func init() {
 	viper.SetDefault(TelemetryIntervalKey, TelemetryIntervalDefault)
 	viper.SetDefault(TelemetryMaxBatchSizeKey, TelemetryMaxBatchSizeDefault)
 	viper.SetDefault(TelemetryEnabledKey, TelemetryEnabledDefault)
-	viper.SetDefault(TelemetrySnapshotResetIntervalKey, TelemetrySnapshotResetIntervalDefault)
+	viper.SetDefault(TelemetryResetIntervalKey, TelemetryResetIntervalDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/telemetries/telemetrysender/sender.go
+++ b/src/shared/telemetries/telemetrysender/sender.go
@@ -12,9 +12,13 @@ import (
 )
 
 type TelemetrySender struct {
-	batcher           *basicbatch.Batcher[telemetriesgql.TelemetryInput]
-	telemetriesClient graphql.Client
-	enabled           bool
+	eventBatcher          *basicbatch.Batcher[telemetriesgql.TelemetryInput]
+	uniqueEventBatcher    *basicbatch.Batcher[UniqueEvent]
+	uniqueEventsCounter   *UniqueCounter
+	snapshotResetInterval time.Duration
+	lastSnapshotResetTime time.Time
+	telemetriesClient     graphql.Client
+	enabled               bool
 }
 
 func newGqlClient() graphql.Client {
@@ -38,12 +42,23 @@ func New() *TelemetrySender {
 	maxBatchSize := viper.GetInt(TelemetryMaxBatchSizeKey)
 	interval := viper.GetInt(TelemetryIntervalKey)
 	telemetriesClient := newGqlClient()
-	sender := &TelemetrySender{telemetriesClient: telemetriesClient, enabled: enabled}
+	snapshotResetInterval := viper.GetDuration(TelemetrySnapshotResetIntervalKey)
+
+	sender := &TelemetrySender{
+		snapshotResetInterval: snapshotResetInterval,
+		lastSnapshotResetTime: time.Now(),
+		telemetriesClient:     telemetriesClient,
+		enabled:               enabled,
+	}
+
 	batchSendFunc := func(telemetries []telemetriesgql.TelemetryInput) error {
 		return batchSendTelemetries(context.Background(), sender.telemetriesClient, telemetries)
-
 	}
-	sender.batcher = basicbatch.NewBatcher(batchSendFunc, time.Duration(interval)*time.Second, maxBatchSize, 5000)
+
+	sender.uniqueEventsCounter = NewUniqueCounter()
+	sender.uniqueEventBatcher = basicbatch.NewBatcher(sender.HandleCounters, time.Duration(interval)*time.Second, maxBatchSize, 5000)
+	sender.eventBatcher = basicbatch.NewBatcher(batchSendFunc, time.Duration(interval)*time.Second, maxBatchSize, 5000)
+
 	return sender
 
 }
@@ -55,6 +70,58 @@ func (t *TelemetrySender) Send(component telemetriesgql.Component, eventType tel
 
 	telemetryData := telemetriesgql.TelemetryData{EventType: eventType, Count: count}
 	telemetry := telemetriesgql.TelemetryInput{Component: component, Data: telemetryData}
-	t.batcher.AddNoWait(telemetry)
+	t.eventBatcher.AddNoWait(telemetry)
+
 	return nil
+}
+
+func (t *TelemetrySender) IncrementCounter(component telemetriesgql.Component, eventType telemetriesgql.EventType, key string) error {
+	if !t.enabled {
+		return nil
+	}
+
+	item := UniqueEvent{
+		Event: UniqueEventMetadata{
+			Component: component,
+			EventType: eventType,
+		},
+		Key: key,
+	}
+	t.uniqueEventBatcher.AddNoWait(item)
+	return nil
+}
+
+func (t *TelemetrySender) HandleCounters(batch []UniqueEvent) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	logrus.Infof("Telemetry batch: %v", batch)
+
+	for _, item := range batch {
+		t.uniqueEventsCounter.IncrementCounter(item.Event.Component, item.Event.EventType, item.Key)
+	}
+
+	counts := t.uniqueEventsCounter.Get()
+	logrus.Infof("Sending telemetry snapshot: %v", counts)
+	timeUntilReset := t.lastSnapshotResetTime.Add(t.snapshotResetInterval)
+
+	if time.Now().After(timeUntilReset) {
+		t.uniqueEventsCounter.Reset()
+		t.lastSnapshotResetTime = time.Now()
+	}
+
+	telemetries := make([]telemetriesgql.TelemetryInput, 0)
+	for _, count := range counts {
+		telemetry := telemetriesgql.TelemetryInput{
+			Component: count.Event.Component,
+			Data: telemetriesgql.TelemetryData{
+				EventType: count.Event.EventType,
+				Count:     count.Count,
+			},
+		}
+		telemetries = append(telemetries, telemetry)
+	}
+
+	return batchSendTelemetries(context.Background(), t.telemetriesClient, telemetries)
 }

--- a/src/shared/telemetries/telemetrysender/service_counter.go
+++ b/src/shared/telemetries/telemetrysender/service_counter.go
@@ -1,0 +1,68 @@
+package telemetrysender
+
+import (
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type UniqueEventMetadata struct {
+	Component telemetriesgql.Component
+	EventType telemetriesgql.EventType
+}
+
+type UniqueEvent struct {
+	Event UniqueEventMetadata
+	Key   string
+}
+
+type UniqueEventCount struct {
+	Event UniqueEventMetadata
+	Count int
+}
+
+type CountersByEvent map[UniqueEventMetadata]sets.Set[string]
+
+type UniqueCounter struct {
+	countersByType CountersByEvent
+}
+
+func NewUniqueCounter() *UniqueCounter {
+	return &UniqueCounter{
+		countersByType: make(CountersByEvent),
+	}
+}
+
+func (s *UniqueCounter) IncrementCounter(component telemetriesgql.Component, eventType telemetriesgql.EventType, eventKey string) {
+	event := UniqueEventMetadata{
+		Component: component,
+		EventType: eventType,
+	}
+
+	if _, ok := s.countersByType[event]; !ok {
+		s.countersByType[event] = make(sets.Set[string])
+	}
+
+	s.countersByType[event].Insert(eventKey)
+}
+
+func (s *UniqueCounter) Get() []UniqueEventCount {
+	counts := make([]UniqueEventCount, 0)
+	for event := range s.countersByType {
+		count := s.getCount(event)
+		counts = append(counts, UniqueEventCount{Event: event, Count: count})
+	}
+
+	return counts
+}
+
+func (s *UniqueCounter) getCount(event UniqueEventMetadata) int {
+	if _, ok := s.countersByType[event]; !ok {
+		return 0
+	}
+
+	return s.countersByType[event].Len()
+}
+
+func (s *UniqueCounter) Reset() {
+	s.countersByType = make(CountersByEvent)
+}

--- a/src/shared/telemetries/telemetrysender/service_counter_test.go
+++ b/src/shared/telemetries/telemetrysender/service_counter_test.go
@@ -1,0 +1,56 @@
+package telemetrysender
+
+import (
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+const (
+	eventTypeServiceDiscovered                = "ServiceDiscovered"
+	eventTypeServiceDiscoveredFromServiceMesh = "ServiceDiscoveredFromServiceMesh"
+)
+
+type ServiceCounterSuite struct {
+	suite.Suite
+}
+
+func (s *ServiceCounterSuite) TestAddService() {
+	counter := NewUniqueCounter()
+	component := telemetriesgql.Component{
+		ComponentType:       "test-component",
+		ComponentInstanceId: "test-component-instance-id",
+		ContextId:           "test-context-id",
+		Version:             "test-version",
+		CloudClientId:       "test-cloud-client-id",
+	}
+
+	counter.IncrementCounter(component, eventTypeServiceDiscovered, Anonymize("service1"))
+	counter.IncrementCounter(component, eventTypeServiceDiscovered, Anonymize("service2"))
+	counter.IncrementCounter(component, eventTypeServiceDiscovered, Anonymize("service1"))
+	counter.IncrementCounter(component, eventTypeServiceDiscovered, Anonymize("service3"))
+	counter.IncrementCounter(component, eventTypeServiceDiscoveredFromServiceMesh, Anonymize("service1"))
+	counter.IncrementCounter(component, eventTypeServiceDiscoveredFromServiceMesh, Anonymize("service2"))
+	counter.IncrementCounter(component, eventTypeServiceDiscoveredFromServiceMesh, Anonymize("service1"))
+
+	results := counter.Get()
+	s.Require().Equal(2, len(results))
+	s.Require().Contains(results, UniqueEventCount{Event: UniqueEventMetadata{Component: component, EventType: eventTypeServiceDiscovered}, Count: 3})
+	s.Require().Contains(results, UniqueEventCount{Event: UniqueEventMetadata{Component: component, EventType: eventTypeServiceDiscoveredFromServiceMesh}, Count: 2})
+
+	counter.IncrementCounter(component, eventTypeServiceDiscoveredFromServiceMesh, Anonymize("service3"))
+
+	results = counter.Get()
+	s.Require().Equal(2, len(results))
+	s.Require().Contains(results, UniqueEventCount{Event: UniqueEventMetadata{Component: component, EventType: eventTypeServiceDiscovered}, Count: 3})
+	s.Require().Contains(results, UniqueEventCount{Event: UniqueEventMetadata{Component: component, EventType: eventTypeServiceDiscoveredFromServiceMesh}, Count: 3})
+
+	counter.Reset()
+
+	results = counter.Get()
+	s.Require().Equal(0, len(results))
+}
+
+func TestServiceCounterSuite(t *testing.T) {
+	suite.Run(t, &ServiceCounterSuite{})
+}


### PR DESCRIPTION
Unique event counter allow to count distinct events and send them as telemetry while using only anonymized and hashed data and send only the distinct count of the event. 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
