### PR TITLE
Fix bug: External network policy uploader get panic when no cloud client

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy_reconciler.go
+++ b/src/operator/controllers/external_traffic/network_policy_reconciler.go
@@ -109,17 +109,26 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		})
 	}
 
-	err = r.otterizeClient.ReportNetworkPolicies(ctx, req.Namespace, inputs)
-
+	err = r.ReportPolicies(ctx, req.Namespace, inputs)
 	if err != nil {
-		logrus.WithError(err).
-			WithField("namespace", req.Namespace).
-			Error("failed reporting network policies")
-
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *NetworkPolicyReconciler) ReportPolicies(ctx context.Context, namespace string, policies []graphqlclient.NetworkPolicyInput) error {
+	if r.otterizeClient == nil {
+		return nil
+	}
+
+	err := r.otterizeClient.ReportNetworkPolicies(ctx, namespace, policies)
+	if err != nil {
+		logrus.WithError(err).WithField("namespace", namespace).Error("failed reporting network policies")
+		return err
+	}
+
+	return nil
 }
 
 func filterOtterizeNetworkPolicy() predicate.Predicate {

--- a/src/operator/controllers/external_traffic/network_policy_uploader.go
+++ b/src/operator/controllers/external_traffic/network_policy_uploader.go
@@ -10,7 +10,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-type NetworkPolicyReconciler struct {
+type NetworkPolicyUploaderReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	serviceIdResolver *serviceidresolver.Resolver
@@ -30,12 +30,12 @@ type NetworkPolicyReconciler struct {
 	injectablerecorder.InjectableRecorder
 }
 
-func NewNetworkPolicyReconciler(
+func NewNetworkPolicyUploaderReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	otterizeClient operator_cloud_client.CloudClient,
-) *NetworkPolicyReconciler {
-	return &NetworkPolicyReconciler{
+) *NetworkPolicyUploaderReconciler {
+	return &NetworkPolicyUploaderReconciler{
 		Client:            client,
 		Scheme:            scheme,
 		serviceIdResolver: serviceidresolver.NewResolver(client),
@@ -43,7 +43,7 @@ func NewNetworkPolicyReconciler(
 	}
 }
 
-func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *NetworkPolicyUploaderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	recorder := mgr.GetEventRecorderFor("intents-operator")
 	r.InjectRecorder(recorder)
 
@@ -54,7 +54,7 @@ func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *NetworkPolicyUploaderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logrus.WithField("policy", req.NamespacedName.String()).Debug("Reconcile Otterize NetworkPolicy")
 
 	netpol := &v1.NetworkPolicy{}
@@ -75,7 +75,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	var podList v12.PodList
+	var podList corev1.PodList
 	err = r.List(
 		ctx, &podList,
 		&client.MatchingLabelsSelector{Selector: selector},
@@ -109,26 +109,15 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		})
 	}
 
-	err = r.ReportPolicies(ctx, req.Namespace, inputs)
+	err = r.otterizeClient.ReportNetworkPolicies(ctx, req.Namespace, inputs)
 	if err != nil {
+		logrus.WithError(err).
+			WithField("namespace", req.Namespace).
+			Error("failed reporting network policies")
 		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
-}
-
-func (r *NetworkPolicyReconciler) ReportPolicies(ctx context.Context, namespace string, policies []graphqlclient.NetworkPolicyInput) error {
-	if r.otterizeClient == nil {
-		return nil
-	}
-
-	err := r.otterizeClient.ReportNetworkPolicies(ctx, namespace, policies)
-	if err != nil {
-		logrus.WithError(err).WithField("namespace", namespace).Error("failed reporting network policies")
-		return err
-	}
-
-	return nil
 }
 
 func filterOtterizeNetworkPolicy() predicate.Predicate {

--- a/src/operator/controllers/external_traffic/network_policy_uploader_test.go
+++ b/src/operator/controllers/external_traffic/network_policy_uploader_test.go
@@ -1,0 +1,129 @@
+package external_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	otterizecloudmocks "github.com/otterize/intents-operator/src/shared/otterizecloud/mocks"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"testing"
+)
+
+const (
+	testNamespace = "test-namespace"
+)
+
+type NetworkPolicyReconcilerTestSuite struct {
+	testbase.MocksSuiteBase
+	reconciler  *NetworkPolicyUploaderReconciler
+	cloudClient *otterizecloudmocks.MockCloudClient
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
+	s.MocksSuiteBase.SetupTest()
+
+	controller := gomock.NewController(s.T())
+	s.cloudClient = otterizecloudmocks.NewMockCloudClient(controller)
+	s.reconciler = NewNetworkPolicyUploaderReconciler(
+		s.Client,
+		&runtime.Scheme{},
+		s.cloudClient,
+	)
+
+	s.reconciler.Recorder = s.Recorder
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) TearDownTest() {
+	s.cloudClient = nil
+	s.reconciler = nil
+	s.MocksSuiteBase.TearDownTest()
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) TestUploadNetworkPolicy() {
+	accessNetworkPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-access-to-client-A",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				v1alpha2.OtterizeNetworkPolicyExternalTraffic: "client-A",
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1alpha2.OtterizeServerLabelKey,
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				{},
+			},
+		},
+	}
+
+	emptyNetworkPolicy := v1.NetworkPolicy{}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      accessNetworkPolicy.Name,
+		},
+	}
+
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(&emptyNetworkPolicy)).DoAndReturn(
+		func(ctx context.Context, namespacedName types.NamespacedName, networkPolicy *v1.NetworkPolicy, _ ...client.GetOption) error {
+			accessNetworkPolicy.DeepCopyInto(networkPolicy)
+			return nil
+		})
+
+	podList := &corev1.PodList{}
+	selector, err := metav1.LabelSelectorAsSelector(&accessNetworkPolicy.Spec.PodSelector)
+	s.Require().NoError(err)
+
+	s.Client.EXPECT().List(gomock.Any(),
+		gomock.Eq(podList),
+		&client.MatchingLabelsSelector{Selector: selector},
+		&client.ListOptions{Namespace: testNamespace}).DoAndReturn(
+		func(ctx context.Context, podList *corev1.PodList, listOptions ...client.ListOption) error {
+			podList.Items = []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod-1",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							"intents.otterize.com/service-name": "client-A",
+						},
+					},
+				},
+			}
+			return nil
+		})
+
+	uploadedNetworkPolicy := graphqlclient.NetworkPolicyInput{
+		Namespace:                    testNamespace,
+		Name:                         accessNetworkPolicy.Name,
+		ServerName:                   "client-A",
+		ExternalNetworkTrafficPolicy: true,
+	}
+
+	s.cloudClient.EXPECT().ReportNetworkPolicies(gomock.Any(), testNamespace, []graphqlclient.NetworkPolicyInput{uploadedNetworkPolicy}).Return(nil)
+
+	res, err := s.reconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+}
+
+func TestNetworkPolicyReconcilerSuite(t *testing.T) {
+	suite.Run(t, new(NetworkPolicyReconcilerTestSuite))
+}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -205,17 +205,17 @@ func main() {
 	if connectedToCloud {
 		uploadConfiguration(signalHandlerCtx, otterizeCloudClient, enforcementConfig)
 		operator_cloud_client.StartPeriodicallyReportConnectionToCloud(otterizeCloudClient, signalHandlerCtx)
+
+		netpolUploader := external_traffic.NewNetworkPolicyUploaderReconciler(mgr.GetClient(), mgr.GetScheme(), otterizeCloudClient)
+		if err = netpolUploader.SetupWithManager(mgr); err != nil {
+			logrus.WithError(err).Fatal("unable to initialize NetworkPolicy reconciler")
+		}
 	} else {
 		logrus.Info("Not configured for cloud integration")
 	}
 
 	if !enforcementConfig.EnforcementDefaultState {
 		logrus.Infof("Running with enforcement disabled globally, won't perform any enforcement")
-	}
-
-	netpolReconciler := external_traffic.NewNetworkPolicyReconciler(mgr.GetClient(), mgr.GetScheme(), otterizeCloudClient)
-	if err = netpolReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to initialize NetworkPolicy reconciler")
 	}
 
 	intentsReconciler := controllers.NewIntentsReconciler(


### PR DESCRIPTION
Until this PR external network policy reconciler was registered always, even when the operator wasn't connected to the cloud.  This resulted in panic due to dereferencing nil pointer of the cloud client.

This PR avoids registration of the reconciler if no cloud client is provided. It also renames it to network policy uploader to avoid confusion with intent network policy reconciler and adds a nice basic test.