### PR TITLE
Remove unused field in PortNetworkPolicyReconciler

### DIFF
--- a/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
@@ -35,12 +35,11 @@ type externalNetpolHandler interface {
 
 type PortNetworkPolicyReconciler struct {
 	client.Client
-	Scheme                                        *runtime.Scheme
-	extNetpolHandler                              externalNetpolHandler
-	RestrictToNamespaces                          []string
-	enableNetworkPolicyCreation                   bool
-	enforcementDefaultState                       bool
-	externalNetworkPoliciesCreatedEvenIfNoIntents bool
+	Scheme                      *runtime.Scheme
+	extNetpolHandler            externalNetpolHandler
+	RestrictToNamespaces        []string
+	enableNetworkPolicyCreation bool
+	enforcementDefaultState     bool
 	injectablerecorder.InjectableRecorder
 }
 
@@ -51,7 +50,7 @@ func NewPortNetworkPolicyReconciler(
 	restrictToNamespaces []string,
 	enableNetworkPolicyCreation bool,
 	enforcementDefaultState bool,
-	externalNetworkPoliciesCreatedEvenIfNoIntents bool) *PortNetworkPolicyReconciler {
+) *PortNetworkPolicyReconciler {
 	return &PortNetworkPolicyReconciler{
 		Client:                      c,
 		Scheme:                      s,
@@ -59,7 +58,6 @@ func NewPortNetworkPolicyReconciler(
 		RestrictToNamespaces:        restrictToNamespaces,
 		enableNetworkPolicyCreation: enableNetworkPolicyCreation,
 		enforcementDefaultState:     enforcementDefaultState,
-		externalNetworkPoliciesCreatedEvenIfNoIntents: externalNetworkPoliciesCreatedEvenIfNoIntents,
 	}
 }
 

--- a/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy_test.go
@@ -65,7 +65,6 @@ func (s *NetworkPolicyReconcilerTestSuite) SetupTest() {
 		restrictToNamespaces,
 		true,
 		true,
-		false,
 	)
 
 	s.Reconciler.Recorder = s.Recorder

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -189,7 +189,7 @@ func main() {
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), extNetpolHandler)
 	externalPolicySvcReconciler := external_traffic.NewServiceReconciler(mgr.GetClient(), extNetpolHandler)
 	networkPolicyHandler := intents_reconcilers.NewNetworkPolicyReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState, autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement)
-	svcNetworkPolicyHandler := port_network_policy.NewPortNetworkPolicyReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState, autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement)
+	svcNetworkPolicyHandler := port_network_policy.NewPortNetworkPolicyReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState)
 
 	if err = endpointReconciler.InitIngressReferencedServicesIndex(mgr); err != nil {
 		logrus.WithError(err).Fatal("unable to init index for ingress")

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -92,6 +92,17 @@ type Client {
 	secret: String!
 }
 
+type ClientIntentsFileRepresentation {
+	clientName: String!
+	rows: [ClientIntentsRow!]!
+	content: String!
+}
+
+type ClientIntentsRow {
+	text: String!
+	diff: RowDiff
+}
+
 type Cluster {
 	id: ID!
 	name: String!
@@ -727,6 +738,10 @@ type Query {
 	accessGraph(
 		filter: InputAccessGraphFilter
 	): AccessGraph!
+	serviceClientIntents(
+		id: ID!
+		lastSeenAfter: Time!
+	): ServiceClientIntents!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -807,6 +822,11 @@ type Query {
 		namespaceId: ID
 		name: String
 	): Service
+}
+
+enum RowDiff {
+	ADDED
+	REMOVED
 }
 
 type ServerBlockingStatus {
@@ -890,6 +910,11 @@ type ServiceAccessStatus {
 	protectionStatuses: ServerProtectionStatuses!
 	blockingStatus: ServerBlockingStatus!
 	hasAppliedIntents: Boolean!
+}
+
+type ServiceClientIntents {
+	asClient: [ClientIntentsFileRepresentation!]!
+	asServer: [ClientIntentsFileRepresentation!]!
 }
 
 scalar Time

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -65,6 +65,9 @@ const (
 	EventTypeIstioPoliciesDeleted        EventType = "ISTIO_POLICIES_DELETED"
 	EventTypeStarted                     EventType = "STARTED"
 	EventTypeServiceDiscovered           EventType = "SERVICE_DISCOVERED"
+	EventTypeNamespaceDiscovered         EventType = "NAMESPACE_DISCOVERED"
+	EventTypeProtectedServiceApplied     EventType = "PROTECTED_SERVICE_APPLIED"
+	EventTypeProtectedServiceDeleted     EventType = "PROTECTED_SERVICE_DELETED"
 )
 
 // SendTelemetriesResponse is returned by SendTelemetries on success.

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -76,6 +76,9 @@ enum EventType {
 	ISTIO_POLICIES_DELETED
 	STARTED
 	SERVICE_DISCOVERED
+	NAMESPACE_DISCOVERED
+	PROTECTED_SERVICE_APPLIED
+	PROTECTED_SERVICE_DELETED
 }
 
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""


### PR DESCRIPTION
The field `externalNetworkPoliciesCreatedEvenIfNoIntents` seems like a copy-paste error, and isn't used in PortNetworkPolicyReconciler.