### PR TITLE
Add protected service count telemetry

### DIFF
--- a/src/operator/controllers/protected_service_reconcilers/cloud_reconciler_test.go
+++ b/src/operator/controllers/protected_service_reconcilers/cloud_reconciler_test.go
@@ -47,7 +47,7 @@ func (s *CloudReconcilerTestSuite) TestUploadSingleProtectedService() {
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
 
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 	}
@@ -60,7 +60,7 @@ func (s *CloudReconcilerTestSuite) TestUploadSingleProtectedService() {
 
 	services := []graphqlclient.ProtectedServiceInput{
 		{
-			Name: protectedService,
+			Name: protectedServiceName,
 		},
 	}
 	s.cloudClient.EXPECT().ReportProtectedServices(gomock.Any(), gomock.Eq(testNamespace), MatchProtectedServicesMatcher(services)).Return(nil)
@@ -87,7 +87,7 @@ func (s *CloudReconcilerTestSuite) TestUploadMultipleProtectedServices() {
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
 
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func (s *CloudReconcilerTestSuite) TestUploadMultipleProtectedServices() {
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
 
-				Name: anotherProtectedService,
+				Name: anotherProtectedServiceName,
 			},
 		},
 	}
@@ -110,10 +110,10 @@ func (s *CloudReconcilerTestSuite) TestUploadMultipleProtectedServices() {
 
 	services := []graphqlclient.ProtectedServiceInput{
 		{
-			Name: protectedService,
+			Name: protectedServiceName,
 		},
 		{
-			Name: anotherProtectedService,
+			Name: anotherProtectedServiceName,
 		},
 	}
 	s.cloudClient.EXPECT().ReportProtectedServices(gomock.Any(), gomock.Eq(testNamespace), MatchProtectedServicesMatcher(services)).Return(nil)

--- a/src/operator/controllers/protected_service_reconcilers/default_deny_test.go
+++ b/src/operator/controllers/protected_service_reconcilers/default_deny_test.go
@@ -20,10 +20,10 @@ import (
 
 const (
 	protectedServicesResourceName        = "staging-protected-services"
-	protectedService                     = "test-service"
+	protectedServiceName                 = "test-service"
 	protectedServiceFormattedName        = "test-service-test-namespace-b0207e"
 	anotherProtectedServiceResourceName  = "protect-other-services"
-	anotherProtectedService              = "other-test-service"
+	anotherProtectedServiceName          = "other-test-service"
 	anotherProtectedServiceFormattedName = "other-test-service-test-namespace-398a04"
 	testNamespace                        = "test-namespace"
 )
@@ -62,7 +62,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreateGlobalNetpol
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 	}
@@ -102,7 +102,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreate() {
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 	}
@@ -165,7 +165,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreateFromMultiple
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 		{
@@ -174,7 +174,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServicesCreateFromMultiple
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: anotherProtectedService,
+				Name: anotherProtectedServiceName,
 			},
 		},
 	}
@@ -260,7 +260,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceNotInList() {
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: anotherProtectedService,
+				Name: anotherProtectedServiceName,
 			},
 		},
 	}
@@ -349,7 +349,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceResourceBeingDelete
 				DeletionTimestamp: &metav1.Time{Time: time.Date(2020, 12, 1, 17, 14, 0, 0, time.UTC)},
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 	}
@@ -466,7 +466,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceAlreadyExists() {
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 		{
@@ -475,7 +475,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceAlreadyExists() {
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: anotherProtectedService,
+				Name: anotherProtectedServiceName,
 			},
 		},
 	}
@@ -567,7 +567,7 @@ func (s *DefaultDenyReconcilerTestSuite) TestProtectedServiceUpdate() {
 				Namespace: testNamespace,
 			},
 			Spec: otterizev1alpha3.ProtectedServiceSpec{
-				Name: protectedService,
+				Name: protectedServiceName,
 			},
 		},
 	}

--- a/src/operator/controllers/protected_service_reconcilers/telemetry_reconciler.go
+++ b/src/operator/controllers/protected_service_reconcilers/telemetry_reconciler.go
@@ -1,0 +1,55 @@
+package protected_service_reconcilers
+
+import (
+	"context"
+	"fmt"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type TelemetryReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	protectedServicesCounter sets.Set[string]
+}
+
+func NewTelemetryReconciler(client client.Client) *TelemetryReconciler {
+	return &TelemetryReconciler{
+		Client:                   client,
+		protectedServicesCounter: sets.New[string](),
+	}
+}
+
+func (r *TelemetryReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	protectedService := &otterizev1alpha3.ProtectedService{}
+	err := r.Get(ctx, req.NamespacedName, protectedService)
+	if k8serrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	anonymizedServerName := telemetrysender.Anonymize(fmt.Sprintf("%s/%s",
+		protectedService.Namespace,
+		protectedService.Spec.Name,
+	))
+
+	if !protectedService.DeletionTimestamp.IsZero() {
+		delete(r.protectedServicesCounter, anonymizedServerName)
+		return ctrl.Result{}, nil
+	}
+
+	r.protectedServicesCounter.Insert(anonymizedServerName)
+
+	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeProtectedServiceApplied, r.protectedServicesCounter.Len())
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/protected_service_reconcilers/telemetry_reconciler_test.go
+++ b/src/operator/controllers/protected_service_reconcilers/telemetry_reconciler_test.go
@@ -1,0 +1,157 @@
+package protected_service_reconcilers
+
+import (
+	"context"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+	"time"
+)
+
+const (
+	protectedServiceResourceName = "test-resource-name"
+	anotherNamespace             = "another-test-namespace"
+)
+
+type CountReconcilerTestSuite struct {
+	testbase.MocksSuiteBase
+	Reconciler *TelemetryReconciler
+}
+
+func (s *CountReconcilerTestSuite) SetupTest() {
+	s.MocksSuiteBase.SetupTest()
+
+	s.Reconciler = NewTelemetryReconciler(s.Client)
+	s.Reconciler.Recorder = s.Recorder
+}
+
+func (s *CountReconcilerTestSuite) TearDownTest() {
+	s.Reconciler = nil
+}
+
+func (s *CountReconcilerTestSuite) TestAppliedProtectedServices() {
+	server := "test-server"
+	anotherServer := "another-test-server"
+
+	protectedService := otterizev1alpha3.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      protectedServiceResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.ProtectedServiceSpec{
+			Name: server,
+		},
+	}
+
+	s.applyProtectedService(protectedService)
+	s.Require().Equal(1, s.Reconciler.protectedServicesCounter.Len())
+
+	s.applyProtectedService(protectedService)
+	s.Require().Equal(1, s.Reconciler.protectedServicesCounter.Len())
+
+	anotherProtectedService := otterizev1alpha3.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      protectedServiceResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.ProtectedServiceSpec{
+			Name: anotherServer,
+		},
+	}
+	s.applyProtectedService(anotherProtectedService)
+	s.Require().Equal(2, s.Reconciler.protectedServicesCounter.Len())
+
+	protectedService = otterizev1alpha3.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      protectedServiceResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.ProtectedServiceSpec{
+			Name: server,
+		},
+	}
+	s.applyProtectedService(protectedService)
+	s.Require().Equal(2, s.Reconciler.protectedServicesCounter.Len())
+
+	protectedServiceInAnotherNamespace := otterizev1alpha3.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      protectedServiceResourceName,
+			Namespace: anotherNamespace,
+		},
+		Spec: otterizev1alpha3.ProtectedServiceSpec{
+			Name: server,
+		},
+	}
+	s.applyProtectedService(protectedServiceInAnotherNamespace)
+	s.Require().Equal(3, s.Reconciler.protectedServicesCounter.Len())
+
+	anotherProtectedServiceInAnotherNamespace := otterizev1alpha3.ProtectedService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      protectedServiceResourceName,
+			Namespace: anotherNamespace,
+		},
+		Spec: otterizev1alpha3.ProtectedServiceSpec{
+			Name: anotherServer,
+		},
+	}
+
+	s.applyProtectedService(anotherProtectedServiceInAnotherNamespace)
+	s.Require().Equal(4, s.Reconciler.protectedServicesCounter.Len())
+
+	s.removeProtectedService(protectedService)
+	s.Require().Equal(3, s.Reconciler.protectedServicesCounter.Len())
+
+	s.removeProtectedService(anotherProtectedService)
+	s.Require().Equal(2, s.Reconciler.protectedServicesCounter.Len())
+}
+
+func (s *CountReconcilerTestSuite) applyProtectedService(resource otterizev1alpha3.ProtectedService) {
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      protectedServiceResourceName,
+		},
+	}
+
+	emptyProtectedServices := &otterizev1alpha3.ProtectedService{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyProtectedServices)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, protectedService *otterizev1alpha3.ProtectedService, options ...client.ListOption) error {
+			resource.DeepCopyInto(protectedService)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Equal(ctrl.Result{}, res)
+}
+
+func (s *CountReconcilerTestSuite) removeProtectedService(resource otterizev1alpha3.ProtectedService) {
+	resource.DeletionTimestamp = &metav1.Time{Time: time.Date(2020, 12, 1, 17, 14, 0, 0, time.UTC)}
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      protectedServiceResourceName,
+		},
+	}
+
+	emptyProtectedServices := &otterizev1alpha3.ProtectedService{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyProtectedServices)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, protectedService *otterizev1alpha3.ProtectedService, options ...client.ListOption) error {
+			resource.DeepCopyInto(protectedService)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Equal(ctrl.Result{}, res)
+}
+
+func TestCountReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(CountReconcilerTestSuite))
+}

--- a/src/operator/controllers/protectedservices_controller.go
+++ b/src/operator/controllers/protectedservices_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/protected_service_reconcilers"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -80,6 +81,11 @@ func NewProtectedServiceReconciler(
 	if otterizeClient != nil {
 		otterizeCloudReconciler := protected_service_reconcilers.NewCloudReconciler(client, scheme, otterizeClient)
 		group.AddToGroup(otterizeCloudReconciler)
+	}
+
+	if telemetrysender.IsTelemetryEnabled() {
+		telemetryReconciler := protected_service_reconcilers.NewTelemetryReconciler(client)
+		group.AddToGroup(telemetryReconciler)
 	}
 
 	return &ProtectedServiceReconciler{


### PR DESCRIPTION
### Description

Send count of total protected services as telemetry, if telemetries are enabled.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
