### PR TITLE
Create reconciler group for KafkaServerConfig

### DIFF
--- a/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_controller_test.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_controller_test.go
@@ -1,4 +1,4 @@
-package controllers
+package kafka_server_config_reconcilers
 
 import (
 	"context"

--- a/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_controller_test.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"testing"
 	"time"
 )
@@ -130,7 +129,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigUpload() {
 	// Create kafka server config resource
 	kafkaServerConfig := s.generateKafkaServerConfig()
 	kafkaServerConfig.SetNamespace(testNamespace)
-	controllerutil.AddFinalizer(&kafkaServerConfig, finalizerName)
 
 	// Get the resource
 	emptyKSC := otterizev1alpha3.KafkaServerConfig{}
@@ -181,7 +179,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestRequeueKafkaServerConfigOnFai
 	// Create kafka server config resource
 	kafkaServerConfig := s.generateKafkaServerConfig()
 	kafkaServerConfig.SetNamespace(testNamespace)
-	controllerutil.AddFinalizer(&kafkaServerConfig, finalizerName)
 
 	// Get the resource
 	emptyKSC := otterizev1alpha3.KafkaServerConfig{}
@@ -223,11 +220,9 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestRequeueKafkaServerConfigOnFai
 
 func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigDelete() {
 	// Return deleted kafka server config resource
-	kscWithoutFinializer := s.generateKafkaServerConfig()
-	kscWithoutFinializer.SetNamespace(testNamespace)
-	kscWithoutFinializer.DeletionTimestamp = &metav1.Time{Time: time.Date(2022, 9, 16, 0, 55, 0, 0, time.UTC)}
-	controllerutil.AddFinalizer(&kscWithoutFinializer, finalizerName)
-	controllerutil.RemoveFinalizer(&kscWithoutFinializer, finalizerName)
+	deletedKSC := s.generateKafkaServerConfig()
+	deletedKSC.SetNamespace(testNamespace)
+	deletedKSC.DeletionTimestamp = &metav1.Time{Time: time.Date(2022, 9, 16, 0, 55, 0, 0, time.UTC)}
 
 	// Get the resource
 	emptyKSC := otterizev1alpha3.KafkaServerConfig{}
@@ -237,8 +232,7 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigDelete() {
 	}
 	s.Client.EXPECT().Get(gomock.Any(), objectName, &emptyKSC).DoAndReturn(
 		func(ctx context.Context, name types.NamespacedName, actualKSC *otterizev1alpha3.KafkaServerConfig, _ ...client.GetOption) error {
-			kscWithoutFinializer.DeepCopyInto(actualKSC)
-			controllerutil.AddFinalizer(actualKSC, finalizerName)
+			deletedKSC.DeepCopyInto(actualKSC)
 			return nil
 		})
 
@@ -246,7 +240,7 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigDelete() {
 	emptyList := &otterizev1alpha3.KafkaServerConfigList{}
 	s.Client.EXPECT().List(gomock.Any(), emptyList, client.InNamespace(testNamespace), &client.ListOptions{Namespace: testNamespace}).DoAndReturn(
 		func(ctx context.Context, list *otterizev1alpha3.KafkaServerConfigList, _ ...client.ListOption) error {
-			list.Items = append(list.Items, kscWithoutFinializer)
+			list.Items = append(list.Items, deletedKSC)
 			return nil
 		})
 
@@ -255,9 +249,8 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestKafkaServerConfigDelete() {
 	)
 
 	gomock.InOrder(
-		s.mockIntentsAdmin.EXPECT().RemoveServerIntents(kscWithoutFinializer.Spec.Topics).Return(nil),
+		s.mockIntentsAdmin.EXPECT().RemoveServerIntents(deletedKSC.Spec.Topics).Return(nil),
 		s.mockIntentsAdmin.EXPECT().Close().Times(1),
-		s.Client.EXPECT().Update(gomock.Any(), gomock.Eq(&kscWithoutFinializer)).Return(nil),
 	)
 
 	res, err := s.reconciler.Reconcile(context.Background(), ctrl.Request{
@@ -278,7 +271,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestIntentsGeneratedForOperator()
 	// Create kafka server config resource
 	kafkaServerConfig := s.generateKafkaServerConfig()
 	kafkaServerConfig.SetNamespace(testNamespace)
-	controllerutil.AddFinalizer(&kafkaServerConfig, finalizerName)
 	kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator = false
 
 	// Handle operator intents for the new kafka server
@@ -366,7 +358,6 @@ func (s *KafkaServerConfigReconcilerTestSuite) TestUpdateIntentsGeneratedForOper
 	// Create kafka server config resource
 	kafkaServerConfig := s.generateKafkaServerConfig()
 	kafkaServerConfig.SetNamespace(testNamespace)
-	controllerutil.AddFinalizer(&kafkaServerConfig, finalizerName)
 	kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator = false
 
 	// Set operator intents for the updated kafka server

--- a/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_reconciler.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_reconciler.go
@@ -1,0 +1,358 @@
+package kafka_server_config_reconcilers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
+)
+
+const (
+	finalizerName                              = "intents.otterize.com/kafkaserverconfig-finalizer"
+	ReasonIntentsOperatorIdentityResolveFailed = "IntentsOperatorIdentityResolveFailed"
+	ReasonApplyingKafkaServerConfigFailed      = "ApplyingKafkaServerConfigFailed"
+	ReasonSuccessfullyAppliedKafkaServerConfig = "SuccessfullyAppliedKafkaServerConfig"
+)
+
+// KafkaServerConfigReconciler reconciles a KafkaServerConfig object
+type KafkaServerConfigReconciler struct {
+	client.Client
+	Scheme               *runtime.Scheme
+	ServersStore         kafkaacls.ServersStore
+	operatorPodName      string
+	operatorPodNamespace string
+	otterizeClient       operator_cloud_client.CloudClient
+	injectablerecorder.InjectableRecorder
+	serviceResolver serviceidresolver.ServiceResolver
+}
+
+func NewKafkaServerConfigReconciler(
+	client client.Client,
+	scheme *runtime.Scheme,
+	serversStore kafkaacls.ServersStore,
+	operatorPodName string,
+	operatorPodNameSpace string,
+	cloudClient operator_cloud_client.CloudClient,
+	serviceResolver serviceidresolver.ServiceResolver,
+) *KafkaServerConfigReconciler {
+	return &KafkaServerConfigReconciler{
+		Client:               client,
+		Scheme:               scheme,
+		ServersStore:         serversStore,
+		operatorPodName:      operatorPodName,
+		operatorPodNamespace: operatorPodNameSpace,
+		otterizeClient:       cloudClient,
+		serviceResolver:      serviceResolver,
+	}
+}
+
+//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=k8s.otterize.com,resources=clientintents,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs/finalizers,verbs=update
+
+func (r *KafkaServerConfigReconciler) removeKafkaServerFromStore(kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) error {
+	logger := logrus.WithFields(
+		logrus.Fields{
+			"name":      kafkaServerConfig.Name,
+			"namespace": kafkaServerConfig.Namespace,
+		},
+	)
+
+	intentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
+	if err != nil && errors.Is(err, kafkaacls.ServerSpecNotFound) {
+		logger.Info("Kafka server not registered to servers store")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	defer intentsAdmin.Close()
+
+	logger.Info("Removing associated ACLs")
+	if err := intentsAdmin.RemoveServerIntents(kafkaServerConfig.Spec.Topics); err != nil {
+		return err
+	}
+
+	logger.Info("Removing Kafka server from store")
+	r.ServersStore.Remove(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
+	return nil
+}
+
+func (r *KafkaServerConfigReconciler) ensureFinalizerRunForOperatorIntents(ctx context.Context, config *otterizev1alpha3.KafkaServerConfig) error {
+	operatorPod := &v1.Pod{}
+	err := r.Get(ctx, types.NamespacedName{Name: r.operatorPodName, Namespace: r.operatorPodNamespace}, operatorPod)
+	if err != nil {
+		return err
+	}
+	operatorIntentsName := FormatIntentsName(config)
+	intents := &otterizev1alpha3.ClientIntents{}
+	err = r.Get(ctx, types.NamespacedName{Name: operatorIntentsName, Namespace: operatorPod.Namespace}, intents)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return r.Delete(ctx, intents)
+}
+
+func (r *KafkaServerConfigReconciler) ensureFinalizerRun(ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(kafkaServerConfig, finalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.removeKafkaServerFromStore(kafkaServerConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator {
+		err := r.ensureFinalizerRunForOperatorIntents(ctx, kafkaServerConfig)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	controllerutil.RemoveFinalizer(kafkaServerConfig, finalizerName)
+	if err := r.Update(ctx, kafkaServerConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigDeleted, 1)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *KafkaServerConfigReconciler) ensureFinalizerRegistered(
+	ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) error {
+	logger := logrus.WithFields(
+		logrus.Fields{
+			"name":      kafkaServerConfig.Name,
+			"namespace": kafkaServerConfig.Namespace,
+		},
+	)
+
+	if controllerutil.ContainsFinalizer(kafkaServerConfig, finalizerName) {
+		return nil
+	}
+
+	logger.Infof("Adding finalizer %s", finalizerName)
+	controllerutil.AddFinalizer(kafkaServerConfig, finalizerName)
+	if err := r.Update(ctx, kafkaServerConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *KafkaServerConfigReconciler) createIntentsFromOperatorToKafkaServer(ctx context.Context, config *otterizev1alpha3.KafkaServerConfig) error {
+	annotatedServiceName, ok, err := r.serviceResolver.GetPodAnnotatedName(ctx, r.operatorPodName, r.operatorPodNamespace)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		r.RecordWarningEventf(config, ReasonIntentsOperatorIdentityResolveFailed, "failed resolving intents operator identity - service name annotation required")
+		return fmt.Errorf("failed resolving intents operator identity - service name annotation required")
+	}
+
+	newIntents := &otterizev1alpha3.ClientIntents{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      FormatIntentsName(config),
+			Namespace: r.operatorPodNamespace,
+		},
+		Spec: &otterizev1alpha3.IntentsSpec{
+			Service: otterizev1alpha3.Service{
+				Name: annotatedServiceName,
+			},
+			Calls: []otterizev1alpha3.Intent{{
+				Type: otterizev1alpha3.IntentTypeKafka,
+				Name: fmt.Sprintf("%s.%s", config.Spec.Service.Name, config.Namespace),
+				Topics: []otterizev1alpha3.KafkaTopic{{
+					Name: "*",
+					Operations: []otterizev1alpha3.KafkaOperation{
+						otterizev1alpha3.KafkaOperationDescribe,
+						otterizev1alpha3.KafkaOperationAlter,
+					},
+				}},
+			}},
+		},
+	}
+
+	existingIntents := &otterizev1alpha3.ClientIntents{}
+	err = r.Get(ctx, types.NamespacedName{Name: newIntents.Name, Namespace: newIntents.Namespace}, existingIntents)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			err := r.Create(ctx, newIntents)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else {
+		intentsCopy := existingIntents.DeepCopy()
+		intentsCopy.Spec = newIntents.Spec
+
+		err := r.Patch(ctx, intentsCopy, client.MergeFrom(existingIntents))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *KafkaServerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := logrus.WithField("namespaced_name", req.NamespacedName.String())
+
+	kafkaServerConfig := &otterizev1alpha3.KafkaServerConfig{}
+
+	err := r.Get(ctx, req.NamespacedName, kafkaServerConfig)
+	if err != nil && k8serrors.IsNotFound(err) {
+		logger.Info("No kafka server config found")
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	result, err := r.reconcileObject(ctx, kafkaServerConfig)
+	if err != nil {
+		return result, err
+	}
+
+	if err := r.uploadKafkaServerConfigs(ctx, req.Namespace); err != nil {
+		logrus.WithError(err).Error("failed to upload KafkaServerConfig to cloud")
+		return ctrl.Result{RequeueAfter: time.Minute}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *KafkaServerConfigReconciler) reconcileObject(ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) (ctrl.Result, error) {
+	if !kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator {
+		err := r.createIntentsFromOperatorToKafkaServer(ctx, kafkaServerConfig)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	if !kafkaServerConfig.ObjectMeta.DeletionTimestamp.IsZero() {
+		// The object is being deleted
+		return r.ensureFinalizerRun(ctx, kafkaServerConfig)
+	}
+
+	if err := r.ensureFinalizerRegistered(ctx, kafkaServerConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.ServersStore.Add(kafkaServerConfig)
+
+	kafkaIntentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	defer kafkaIntentsAdmin.Close()
+
+	if err := kafkaIntentsAdmin.ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics); err != nil {
+		r.RecordWarningEventf(kafkaServerConfig, ReasonApplyingKafkaServerConfigFailed, "failed to apply server config to Kafka broker: %s", err.Error())
+		return ctrl.Result{}, err
+	}
+
+	r.RecordNormalEvent(kafkaServerConfig, ReasonSuccessfullyAppliedKafkaServerConfig, "successfully applied server config")
+	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigApplied, len(kafkaServerConfig.Spec.Topics))
+	return ctrl.Result{}, nil
+}
+
+func (r *KafkaServerConfigReconciler) uploadKafkaServerConfigs(ctx context.Context, namespace string) error {
+	if r.otterizeClient == nil {
+		return nil
+	}
+
+	kafkaServerConfigs := &otterizev1alpha3.KafkaServerConfigList{}
+	err := r.List(ctx, kafkaServerConfigs, client.InNamespace(namespace), &client.ListOptions{Namespace: namespace})
+	if err != nil {
+		return err
+	}
+
+	inputs := make([]graphqlclient.KafkaServerConfigInput, 0)
+	for _, kafkaServerConfig := range kafkaServerConfigs.Items {
+		if kafkaServerConfig.DeletionTimestamp != nil {
+			continue
+		}
+		input, err := kafkaServerConfigCRDToCloudModel(kafkaServerConfig)
+		if err != nil {
+			return err
+		}
+
+		inputs = append(inputs, input)
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutKey))
+	defer cancel()
+
+	return r.otterizeClient.ReportKafkaServerConfig(timeoutCtx, namespace, inputs)
+}
+
+func kafkaServerConfigCRDToCloudModel(kafkaServerConfig otterizev1alpha3.KafkaServerConfig) (graphqlclient.KafkaServerConfigInput, error) {
+	topics := make([]graphqlclient.KafkaTopicInput, 0)
+	for _, topic := range kafkaServerConfig.Spec.Topics {
+		pattern, err := crdPatternToCloudPattern(topic.Pattern)
+		if err != nil {
+			return graphqlclient.KafkaServerConfigInput{}, err
+		}
+
+		topics = append(topics, graphqlclient.KafkaTopicInput{
+			ClientIdentityRequired: topic.ClientIdentityRequired,
+			IntentsRequired:        topic.IntentsRequired,
+			Pattern:                pattern,
+			Topic:                  topic.Topic,
+		})
+	}
+
+	input := graphqlclient.KafkaServerConfigInput{
+		Name:      kafkaServerConfig.Spec.Service.Name,
+		Namespace: kafkaServerConfig.Namespace,
+		Address:   kafkaServerConfig.Spec.Addr,
+		Topics:    topics,
+	}
+
+	return input, nil
+}
+
+func crdPatternToCloudPattern(pattern otterizev1alpha3.ResourcePatternType) (graphqlclient.KafkaTopicPattern, error) {
+	var result graphqlclient.KafkaTopicPattern
+	switch pattern {
+	case otterizev1alpha3.ResourcePatternTypePrefix:
+		result = graphqlclient.KafkaTopicPatternPrefix
+	case otterizev1alpha3.ResourcePatternTypeLiteral:
+		result = graphqlclient.KafkaTopicPatternLiteral
+	default:
+		return "", fmt.Errorf("unknown pattern type: %s", pattern)
+	}
+
+	return result, nil
+}
+
+func FormatIntentsName(conf *otterizev1alpha3.KafkaServerConfig) string {
+	return fmt.Sprintf("operator-to-kafkaserverconfig-%s-namespace-%s", conf.Name, conf.Namespace)
+}

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -85,7 +85,8 @@ func (r *KafkaServerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	r.InjectRecorder(mgr.GetEventRecorderFor("intents-operator"))
+	r.kscReconciler.InjectRecorder(mgr.GetEventRecorderFor("intents-operator"))
+
 	return nil
 }
 

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
+	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -37,11 +38,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const (
+	finalizerName = "intents.otterize.com/kafkaserverconfig-finalizer"
+)
+
 // KafkaServerConfigReconciler reconciles a KafkaServerConfig object
 type KafkaServerConfigReconciler struct {
 	client.Client
 	injectablerecorder.InjectableRecorder
-	kscReconciler *kafka_server_config_reconcilers.KafkaServerConfigReconciler
+	group *reconcilergroup.Group
 }
 
 func NewKafkaServerConfigReconciler(
@@ -63,14 +68,23 @@ func NewKafkaServerConfigReconciler(
 		serviceResolver,
 	)
 
+	group := reconcilergroup.NewGroup("kafka-server-config-reconciler",
+		client,
+		scheme,
+		&otterizev1alpha3.KafkaServerConfig{},
+		finalizerName,
+		nil,
+		kscReconciler,
+	)
+
 	return &KafkaServerConfigReconciler{
-		Client:        client,
-		kscReconciler: kscReconciler,
+		Client: client,
+		group:  group,
 	}
 }
 
 func (r *KafkaServerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.kscReconciler.Reconcile(ctx, req)
+	return r.group.Reconcile(ctx, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -85,7 +99,7 @@ func (r *KafkaServerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	r.kscReconciler.InjectRecorder(mgr.GetEventRecorderFor("intents-operator"))
+	r.group.InjectRecorder(mgr.GetEventRecorderFor("intents-operator"))
 
 	return nil
 }

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -18,53 +18,30 @@ package controllers
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/operator/controllers/kafka_server_config_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
-	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
-	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
-	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
-	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
-)
-
-const (
-	finalizerName                              = "intents.otterize.com/kafkaserverconfig-finalizer"
-	ReasonIntentsOperatorIdentityResolveFailed = "IntentsOperatorIdentityResolveFailed"
-	ReasonApplyingKafkaServerConfigFailed      = "ApplyingKafkaServerConfigFailed"
-	ReasonSuccessfullyAppliedKafkaServerConfig = "SuccessfullyAppliedKafkaServerConfig"
 )
 
 // KafkaServerConfigReconciler reconciles a KafkaServerConfig object
 type KafkaServerConfigReconciler struct {
 	client.Client
-	Scheme               *runtime.Scheme
-	ServersStore         kafkaacls.ServersStore
-	operatorPodName      string
-	operatorPodNamespace string
-	otterizeClient       operator_cloud_client.CloudClient
 	injectablerecorder.InjectableRecorder
-	serviceResolver serviceidresolver.ServiceResolver
+	kscReconciler *kafka_server_config_reconcilers.KafkaServerConfigReconciler
 }
 
 func NewKafkaServerConfigReconciler(
@@ -76,303 +53,24 @@ func NewKafkaServerConfigReconciler(
 	cloudClient operator_cloud_client.CloudClient,
 	serviceResolver serviceidresolver.ServiceResolver,
 ) *KafkaServerConfigReconciler {
+	kscReconciler := kafka_server_config_reconcilers.NewKafkaServerConfigReconciler(
+		client,
+		scheme,
+		serversStore,
+		operatorPodName,
+		operatorPodNameSpace,
+		cloudClient,
+		serviceResolver,
+	)
+
 	return &KafkaServerConfigReconciler{
-		Client:               client,
-		Scheme:               scheme,
-		ServersStore:         serversStore,
-		operatorPodName:      operatorPodName,
-		operatorPodNamespace: operatorPodNameSpace,
-		otterizeClient:       cloudClient,
-		serviceResolver:      serviceResolver,
+		Client:        client,
+		kscReconciler: kscReconciler,
 	}
-}
-
-//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=k8s.otterize.com,resources=clientintents,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=k8s.otterize.com,resources=kafkaserverconfigs/finalizers,verbs=update
-
-func (r *KafkaServerConfigReconciler) removeKafkaServerFromStore(kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) error {
-	logger := logrus.WithFields(
-		logrus.Fields{
-			"name":      kafkaServerConfig.Name,
-			"namespace": kafkaServerConfig.Namespace,
-		},
-	)
-
-	intentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
-	if err != nil && errors.Is(err, kafkaacls.ServerSpecNotFound) {
-		logger.Info("Kafka server not registered to servers store")
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	defer intentsAdmin.Close()
-
-	logger.Info("Removing associated ACLs")
-	if err := intentsAdmin.RemoveServerIntents(kafkaServerConfig.Spec.Topics); err != nil {
-		return err
-	}
-
-	logger.Info("Removing Kafka server from store")
-	r.ServersStore.Remove(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
-	return nil
-}
-
-func (r *KafkaServerConfigReconciler) ensureFinalizerRunForOperatorIntents(ctx context.Context, config *otterizev1alpha3.KafkaServerConfig) error {
-	operatorPod := &v1.Pod{}
-	err := r.Get(ctx, types.NamespacedName{Name: r.operatorPodName, Namespace: r.operatorPodNamespace}, operatorPod)
-	if err != nil {
-		return err
-	}
-	operatorIntentsName := formatIntentsName(config)
-	intents := &otterizev1alpha3.ClientIntents{}
-	err = r.Get(ctx, types.NamespacedName{Name: operatorIntentsName, Namespace: operatorPod.Namespace}, intents)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	return r.Delete(ctx, intents)
-}
-
-func (r *KafkaServerConfigReconciler) ensureFinalizerRun(ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) (ctrl.Result, error) {
-	if !controllerutil.ContainsFinalizer(kafkaServerConfig, finalizerName) {
-		return ctrl.Result{}, nil
-	}
-
-	if err := r.removeKafkaServerFromStore(kafkaServerConfig); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if !kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator {
-		err := r.ensureFinalizerRunForOperatorIntents(ctx, kafkaServerConfig)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	controllerutil.RemoveFinalizer(kafkaServerConfig, finalizerName)
-	if err := r.Update(ctx, kafkaServerConfig); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigDeleted, 1)
-
-	return ctrl.Result{}, nil
-}
-
-func (r *KafkaServerConfigReconciler) ensureFinalizerRegistered(
-	ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) error {
-	logger := logrus.WithFields(
-		logrus.Fields{
-			"name":      kafkaServerConfig.Name,
-			"namespace": kafkaServerConfig.Namespace,
-		},
-	)
-
-	if controllerutil.ContainsFinalizer(kafkaServerConfig, finalizerName) {
-		return nil
-	}
-
-	logger.Infof("Adding finalizer %s", finalizerName)
-	controllerutil.AddFinalizer(kafkaServerConfig, finalizerName)
-	if err := r.Update(ctx, kafkaServerConfig); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *KafkaServerConfigReconciler) createIntentsFromOperatorToKafkaServer(ctx context.Context, config *otterizev1alpha3.KafkaServerConfig) error {
-	annotatedServiceName, ok, err := r.serviceResolver.GetPodAnnotatedName(ctx, r.operatorPodName, r.operatorPodNamespace)
-	if err != nil {
-		return err
-	}
-
-	if !ok {
-		r.RecordWarningEventf(config, ReasonIntentsOperatorIdentityResolveFailed, "failed resolving intents operator identity - service name annotation required")
-		return fmt.Errorf("failed resolving intents operator identity - service name annotation required")
-	}
-
-	newIntents := &otterizev1alpha3.ClientIntents{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      formatIntentsName(config),
-			Namespace: r.operatorPodNamespace,
-		},
-		Spec: &otterizev1alpha3.IntentsSpec{
-			Service: otterizev1alpha3.Service{
-				Name: annotatedServiceName,
-			},
-			Calls: []otterizev1alpha3.Intent{{
-				Type: otterizev1alpha3.IntentTypeKafka,
-				Name: fmt.Sprintf("%s.%s", config.Spec.Service.Name, config.Namespace),
-				Topics: []otterizev1alpha3.KafkaTopic{{
-					Name: "*",
-					Operations: []otterizev1alpha3.KafkaOperation{
-						otterizev1alpha3.KafkaOperationDescribe,
-						otterizev1alpha3.KafkaOperationAlter,
-					},
-				}},
-			}},
-		},
-	}
-
-	existingIntents := &otterizev1alpha3.ClientIntents{}
-	err = r.Get(ctx, types.NamespacedName{Name: newIntents.Name, Namespace: newIntents.Namespace}, existingIntents)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			err := r.Create(ctx, newIntents)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	} else {
-		intentsCopy := existingIntents.DeepCopy()
-		intentsCopy.Spec = newIntents.Spec
-
-		err := r.Patch(ctx, intentsCopy, client.MergeFrom(existingIntents))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (r *KafkaServerConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := logrus.WithField("namespaced_name", req.NamespacedName.String())
-
-	kafkaServerConfig := &otterizev1alpha3.KafkaServerConfig{}
-
-	err := r.Get(ctx, req.NamespacedName, kafkaServerConfig)
-	if err != nil && k8serrors.IsNotFound(err) {
-		logger.Info("No kafka server config found")
-		return ctrl.Result{}, nil
-	} else if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	result, err := r.reconcileObject(ctx, kafkaServerConfig)
-	if err != nil {
-		return result, err
-	}
-
-	if err := r.uploadKafkaServerConfigs(ctx, req.Namespace); err != nil {
-		logrus.WithError(err).Error("failed to upload KafkaServerConfig to cloud")
-		return ctrl.Result{RequeueAfter: time.Minute}, err
-	}
-
-	return ctrl.Result{}, nil
-}
-
-func (r *KafkaServerConfigReconciler) reconcileObject(ctx context.Context, kafkaServerConfig *otterizev1alpha3.KafkaServerConfig) (ctrl.Result, error) {
-	if !kafkaServerConfig.Spec.NoAutoCreateIntentsForOperator {
-		err := r.createIntentsFromOperatorToKafkaServer(ctx, kafkaServerConfig)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	if !kafkaServerConfig.ObjectMeta.DeletionTimestamp.IsZero() {
-		// The object is being deleted
-		return r.ensureFinalizerRun(ctx, kafkaServerConfig)
-	}
-
-	if err := r.ensureFinalizerRegistered(ctx, kafkaServerConfig); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	r.ServersStore.Add(kafkaServerConfig)
-
-	kafkaIntentsAdmin, err := r.ServersStore.Get(kafkaServerConfig.Spec.Service.Name, kafkaServerConfig.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	defer kafkaIntentsAdmin.Close()
-
-	if err := kafkaIntentsAdmin.ApplyServerTopicsConf(kafkaServerConfig.Spec.Topics); err != nil {
-		r.RecordWarningEventf(kafkaServerConfig, ReasonApplyingKafkaServerConfigFailed, "failed to apply server config to Kafka broker: %s", err.Error())
-		return ctrl.Result{}, err
-	}
-
-	r.RecordNormalEvent(kafkaServerConfig, ReasonSuccessfullyAppliedKafkaServerConfig, "successfully applied server config")
-	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigApplied, len(kafkaServerConfig.Spec.Topics))
-	return ctrl.Result{}, nil
-}
-
-func (r *KafkaServerConfigReconciler) uploadKafkaServerConfigs(ctx context.Context, namespace string) error {
-	if r.otterizeClient == nil {
-		return nil
-	}
-
-	kafkaServerConfigs := &otterizev1alpha3.KafkaServerConfigList{}
-	err := r.List(ctx, kafkaServerConfigs, client.InNamespace(namespace), &client.ListOptions{Namespace: namespace})
-	if err != nil {
-		return err
-	}
-
-	inputs := make([]graphqlclient.KafkaServerConfigInput, 0)
-	for _, kafkaServerConfig := range kafkaServerConfigs.Items {
-		if kafkaServerConfig.DeletionTimestamp != nil {
-			continue
-		}
-		input, err := kafkaServerConfigCRDToCloudModel(kafkaServerConfig)
-		if err != nil {
-			return err
-		}
-
-		inputs = append(inputs, input)
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutKey))
-	defer cancel()
-
-	return r.otterizeClient.ReportKafkaServerConfig(timeoutCtx, namespace, inputs)
-}
-
-func kafkaServerConfigCRDToCloudModel(kafkaServerConfig otterizev1alpha3.KafkaServerConfig) (graphqlclient.KafkaServerConfigInput, error) {
-	topics := make([]graphqlclient.KafkaTopicInput, 0)
-	for _, topic := range kafkaServerConfig.Spec.Topics {
-		pattern, err := crdPatternToCloudPattern(topic.Pattern)
-		if err != nil {
-			return graphqlclient.KafkaServerConfigInput{}, err
-		}
-
-		topics = append(topics, graphqlclient.KafkaTopicInput{
-			ClientIdentityRequired: topic.ClientIdentityRequired,
-			IntentsRequired:        topic.IntentsRequired,
-			Pattern:                pattern,
-			Topic:                  topic.Topic,
-		})
-	}
-
-	input := graphqlclient.KafkaServerConfigInput{
-		Name:      kafkaServerConfig.Spec.Service.Name,
-		Namespace: kafkaServerConfig.Namespace,
-		Address:   kafkaServerConfig.Spec.Addr,
-		Topics:    topics,
-	}
-
-	return input, nil
-}
-
-func crdPatternToCloudPattern(pattern otterizev1alpha3.ResourcePatternType) (graphqlclient.KafkaTopicPattern, error) {
-	var result graphqlclient.KafkaTopicPattern
-	switch pattern {
-	case otterizev1alpha3.ResourcePatternTypePrefix:
-		result = graphqlclient.KafkaTopicPatternPrefix
-	case otterizev1alpha3.ResourcePatternTypeLiteral:
-		result = graphqlclient.KafkaTopicPatternLiteral
-	default:
-		return "", fmt.Errorf("unknown pattern type: %s", pattern)
-	}
-
-	return result, nil
+	return r.kscReconciler.Reconcile(ctx, req)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -431,8 +129,4 @@ func (r *KafkaServerConfigReconciler) getKSCsForProtectedService(protectedServic
 
 	kscsToReconcile = append(kscsToReconcile, kafkaServerConfigs.Items...)
 	return kscsToReconcile
-}
-
-func formatIntentsName(conf *otterizev1alpha3.KafkaServerConfig) string {
-	return fmt.Sprintf("operator-to-kafkaserverconfig-%s-namespace-%s", conf.Name, conf.Namespace)
 }

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	finalizerName = "intents.otterize.com/kafkaserverconfig-finalizer"
+	groupName     = "kafka-server-config-reconciler"
 )
 
 // KafkaServerConfigReconciler reconciles a KafkaServerConfig object
@@ -68,7 +69,8 @@ func NewKafkaServerConfigReconciler(
 		serviceResolver,
 	)
 
-	group := reconcilergroup.NewGroup("kafka-server-config-reconciler",
+	group := reconcilergroup.NewGroup(
+		groupName,
 		client,
 		scheme,
 		&otterizev1alpha3.KafkaServerConfig{},
@@ -99,7 +101,7 @@ func (r *KafkaServerConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	r.group.InjectRecorder(mgr.GetEventRecorderFor("intents-operator"))
+	r.group.InjectRecorder(mgr.GetEventRecorderFor(groupName))
 
 	return nil
 }


### PR DESCRIPTION
### Description

Create reconciler group for KSC to enable extending its logic with new reconcilers, and also remove the redundant logic who handle the finalizers since the group already implement that as in any other Otterize resource.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
