### PR TITLE
Send KafkaServerConfig count telemetry

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd
+	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.33.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -27,6 +28,7 @@ require (
 	go.uber.org/mock v0.2.0
 	golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
 	golang.org/x/oauth2 v0.6.0
+	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v0.0.0-20230310175855-3be9c0870417
 	istio.io/client-go v1.17.1
 	k8s.io/api v0.26.5
@@ -91,7 +93,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
@@ -121,7 +122,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.26.5 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect

--- a/src/operator/controllers/kafka_server_config_reconcilers/telemetry_reconciler.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/telemetry_reconciler.go
@@ -1,0 +1,55 @@
+package kafka_server_config_reconcilers
+
+import (
+	"context"
+	"fmt"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type TelemetryReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	kafkaServerCounter sets.Set[string]
+}
+
+func NewTelemetryReconciler(client client.Client) *TelemetryReconciler {
+	return &TelemetryReconciler{
+		Client:             client,
+		kafkaServerCounter: sets.New[string](),
+	}
+}
+
+func (r *TelemetryReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	kafkaServerConfig := &otterizev1alpha3.KafkaServerConfig{}
+	err := r.Get(ctx, req.NamespacedName, kafkaServerConfig)
+	if k8serrors.IsNotFound(err) {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	anonymizedServerName := telemetrysender.Anonymize(fmt.Sprintf("%s/%s",
+		kafkaServerConfig.Namespace,
+		kafkaServerConfig.Spec.Service.Name,
+	))
+
+	if !kafkaServerConfig.DeletionTimestamp.IsZero() {
+		delete(r.kafkaServerCounter, anonymizedServerName)
+		return ctrl.Result{}, nil
+	}
+
+	r.kafkaServerCounter.Insert(anonymizedServerName)
+
+	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigApplied, r.kafkaServerCounter.Len())
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/kafka_server_config_reconcilers/telemetry_reconciler_test.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/telemetry_reconciler_test.go
@@ -1,0 +1,167 @@
+package kafka_server_config_reconcilers
+
+import (
+	"context"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+	"time"
+)
+
+const (
+	kscResourceName  = "test-resource-name"
+	anotherNamespace = "another-test-namespace"
+)
+
+type CountReconcilerTestSuite struct {
+	testbase.MocksSuiteBase
+	Reconciler *TelemetryReconciler
+}
+
+func (s *CountReconcilerTestSuite) SetupTest() {
+	s.MocksSuiteBase.SetupTest()
+
+	s.Reconciler = NewTelemetryReconciler(s.Client)
+	s.Reconciler.Recorder = s.Recorder
+}
+
+func (s *CountReconcilerTestSuite) TearDownTest() {
+	s.Reconciler = nil
+}
+
+func (s *CountReconcilerTestSuite) TestAppliedProtectedServices() {
+	server := "test-server"
+	anotherServer := "another-test-server"
+
+	serverConfig := otterizev1alpha3.KafkaServerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kscResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.KafkaServerConfigSpec{
+			Service: otterizev1alpha3.Service{
+				Name: server,
+			},
+		},
+	}
+
+	s.applyConfig(serverConfig)
+	s.Require().Equal(1, s.Reconciler.kafkaServerCounter.Len())
+
+	s.applyConfig(serverConfig)
+	s.Require().Equal(1, s.Reconciler.kafkaServerCounter.Len())
+
+	anotherConfig := otterizev1alpha3.KafkaServerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kscResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.KafkaServerConfigSpec{
+			Service: otterizev1alpha3.Service{
+				Name: anotherServer,
+			},
+		},
+	}
+	s.applyConfig(anotherConfig)
+	s.Require().Equal(2, s.Reconciler.kafkaServerCounter.Len())
+
+	serverConfig = otterizev1alpha3.KafkaServerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kscResourceName,
+			Namespace: testNamespace,
+		},
+		Spec: otterizev1alpha3.KafkaServerConfigSpec{
+			Service: otterizev1alpha3.Service{
+				Name: server,
+			},
+		},
+	}
+	s.applyConfig(serverConfig)
+	s.Require().Equal(2, s.Reconciler.kafkaServerCounter.Len())
+
+	configInAnotherNamespace := otterizev1alpha3.KafkaServerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kscResourceName,
+			Namespace: anotherNamespace,
+		},
+		Spec: otterizev1alpha3.KafkaServerConfigSpec{
+			Service: otterizev1alpha3.Service{
+				Name: server,
+			},
+		},
+	}
+	s.applyConfig(configInAnotherNamespace)
+	s.Require().Equal(3, s.Reconciler.kafkaServerCounter.Len())
+
+	anotherConfigInAnotherNamespace := otterizev1alpha3.KafkaServerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kscResourceName,
+			Namespace: anotherNamespace,
+		},
+		Spec: otterizev1alpha3.KafkaServerConfigSpec{
+			Service: otterizev1alpha3.Service{
+				Name: anotherServer,
+			},
+		},
+	}
+
+	s.applyConfig(anotherConfigInAnotherNamespace)
+	s.Require().Equal(4, s.Reconciler.kafkaServerCounter.Len())
+
+	s.removeConfig(serverConfig)
+	s.Require().Equal(3, s.Reconciler.kafkaServerCounter.Len())
+
+	s.removeConfig(anotherConfig)
+	s.Require().Equal(2, s.Reconciler.kafkaServerCounter.Len())
+}
+
+func (s *CountReconcilerTestSuite) applyConfig(resource otterizev1alpha3.KafkaServerConfig) {
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      kscResourceName,
+		},
+	}
+
+	emptyConfig := &otterizev1alpha3.KafkaServerConfig{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyConfig)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, serverConfig *otterizev1alpha3.KafkaServerConfig, options ...client.ListOption) error {
+			resource.DeepCopyInto(serverConfig)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Equal(ctrl.Result{}, res)
+}
+
+func (s *CountReconcilerTestSuite) removeConfig(resource otterizev1alpha3.KafkaServerConfig) {
+	resource.DeletionTimestamp = &metav1.Time{Time: time.Date(2020, 12, 1, 17, 14, 0, 0, time.UTC)}
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      kscResourceName,
+		},
+	}
+
+	emptyConfig := &otterizev1alpha3.KafkaServerConfig{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyConfig)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, serverConfig *otterizev1alpha3.KafkaServerConfig, options ...client.ListOption) error {
+			resource.DeepCopyInto(serverConfig)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Equal(ctrl.Result{}, res)
+}
+
+func TestCountReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(CountReconcilerTestSuite))
+}

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,6 +78,11 @@ func NewKafkaServerConfigReconciler(
 		nil,
 		kscReconciler,
 	)
+
+	if telemetrysender.IsTelemetryEnabled() {
+		telemetryReconciler := kafka_server_config_reconcilers.NewTelemetryReconciler(client)
+		group.AddToGroup(telemetryReconciler)
+	}
 
 	return &KafkaServerConfigReconciler{
 		Client: client,


### PR DESCRIPTION
### Description

Send the count of KafkaServerConfig applied resources as a telemetry, if telemetries are enabled.

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality
