### PR TITLE
Fix bug: Empty intents list reported when there are no database intents

### DIFF
--- a/src/operator/controllers/intents_reconcilers/exp/database.go
+++ b/src/operator/controllers/intents_reconcilers/exp/database.go
@@ -63,6 +63,10 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		intentInputList = append(intentInputList, intentInput)
 	}
 
+	if len(intentInputList) == 0 {
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.otterizeClient.ApplyDatabaseIntent(ctx, intentInputList, action); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
### Description

Until this PR, database reconciler reports nil pointer when client intents doesn't contain any database type. This cause backend error since the GraphQL mutation doesn't support nil variable. In the case there are no `Database` typed intents there is no database action to perform, so nothing should be done and we can skip the API call.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality