### PR TITLE
Fix bug where IAM policy could be already deleted or non-existent, in the case of a non-IAM ClientIntents, and lead to reconcile error loop

### DIFF
--- a/src/operator/controllers/intents_reconcilers/aws_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/aws_reconciler.go
@@ -88,11 +88,11 @@ func (r *AWSIntentsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		return ctrl.Result{}, err
 	}
 
-	if pod.Annotations == nil {
+	if pod.Labels == nil {
 		return ctrl.Result{}, nil
 	}
 
-	if _, ok := pod.Annotations["credentials-operator.otterize.com/create-aws-role"]; !ok {
+	if _, ok := pod.Labels["credentials-operator.otterize.com/create-aws-role"]; !ok {
 		return ctrl.Result{}, nil
 	}
 

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -63,6 +63,10 @@ func (a *Agent) DeleteRolePolicy(ctx context.Context, namespace, policyName stri
 	})
 
 	if err != nil {
+		if isNoSuchEntityException(err) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (a *Agent) AddRolePolicy(ctx context.Context, namespace, accountName, policyName string, statements []StatementEntry) error {
+func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, policyName string, statements []StatementEntry) error {
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
 
 	if err != nil {

--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -84,7 +84,7 @@ func (a *Agent) CreateOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 			return nil, err
 		}
 
-		logger.Debugf("created existing role, arn: %s", *createRoleOutput.Role.Arn)
+		logger.Debugf("created new role, arn: %s", *createRoleOutput.Role.Arn)
 		return createRoleOutput.Role, nil
 	}
 }


### PR DESCRIPTION
### Description

Fix bug where IAM policy could be already deleted or non-existent, in the case of a non-IAM ClientIntents, and lead to reconcile error loop.

Also changes the pod annotation into a pod label.


### References

https://github.com/otterize/helm-charts/pull/133
https://github.com/otterize/credentials-operator/pull/93

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
