### PR TITLE
Add Sarama client ID

### DIFF
--- a/src/operator/controllers/kafkaacls/intents_admin.go
+++ b/src/operator/controllers/kafkaacls/intents_admin.go
@@ -21,6 +21,7 @@ type IntentsAdminFactoryFunction func(serverConfig otterizev1alpha3.KafkaServerC
 type TopicToACLList map[sarama.Resource][]sarama.Acl
 
 const (
+	intentsOperatorClientID    = "intents-operator"
 	AnonymousUserPrincipalName = "User:ANONYMOUS"
 	AnyUserPrincipalName       = "User:*"
 )
@@ -149,6 +150,7 @@ func NewKafkaIntentsAdmin(kafkaServer otterizev1alpha3.KafkaServerConfig, defaul
 
 	config.Net.TLS.Config = tlsConfig
 	config.Net.TLS.Enable = true
+	config.ClientID = intentsOperatorClientID
 
 	sarama.Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
 


### PR DESCRIPTION
### Description

Setting Kafka client ID just to avoid using the Sarama default client and suppress the warning log it generates when using the default ID.

### Testing

The log line `ClientID is the default of 'sarama', you should consider setting it` can be seen in the log when Kafka server is configured.