### PR TITLE
Fixes a few bugs in AWS role management:

### DIFF
--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -21,7 +21,7 @@ func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName
 	}
 
 	if !exists {
-		return fmt.Errorf("role not found: %s", a.GenerateRoleName(namespace, accountName))
+		return fmt.Errorf("role not found: %s", a.generateRoleName(namespace, accountName))
 	}
 
 	policyArn := a.generatePolicyArn(namespace, policyName)
@@ -126,7 +126,7 @@ func (a *Agent) DeleteRolePolicy(ctx context.Context, namespace, policyName stri
 
 func (a *Agent) SetRolePolicy(ctx context.Context, namespace, accountName string, statements []StatementEntry) error {
 	logger := logrus.WithField("account", accountName).WithField("namespace", namespace)
-	roleName := a.GenerateRoleName(namespace, accountName)
+	roleName := a.generateRoleName(namespace, accountName)
 
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
 

--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -109,7 +109,7 @@ func (a *Agent) DeleteOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 	}
 
 	_, found := lo.Find(role.Tags, func(tag types.Tag) bool {
-		response := false
+		response := true
 		response = response && (*tag.Key == serviceAccountNameTagKey && *tag.Value == accountName)
 		response = response && (*tag.Key == serviceAccountNamespaceTagKey && *tag.Value == namespaceName)
 		response = response && (*tag.Key == clusterNameTagKey && *tag.Value == a.clusterName)

--- a/src/shared/awsagent/types.go
+++ b/src/shared/awsagent/types.go
@@ -5,10 +5,13 @@ const iamEffectAllow = "Allow"
 
 const serviceAccountNameTagKey = "otterize/serviceAccountName"
 const serviceAccountNamespaceTagKey = "otterize/serviceAccountNamespace"
+const clusterNameTagKey = "otterize/clusterName"
 
 const policyNameTagKey = "otterize/policyName"
 const policyNamespaceTagKey = "otterize/policyNamespace"
 const policyHashTagKey = "otterize/policyHash"
+
+const iamRoleDescription = "This IAM role was created by Otterize AWS Integration. For more details go to https://otterize.com"
 
 // PolicyDocument is our definition of our policies to be uploaded to IAM.
 type PolicyDocument struct {
@@ -25,3 +28,7 @@ type StatementEntry struct {
 	Sid       string            `json:"Sid,omitempty"`
 	Condition map[string]any    `json:"Condition,omitempty"`
 }
+
+const maxAWSNameLength = 64
+const truncatedHashLength = 6
+const maxTruncatedLength = maxAWSNameLength - truncatedHashLength - 1 // add another char for the hyphen


### PR DESCRIPTION
1. The controller tries to create role names that are too long (the AWS limit is 64 characters).
2. The tag check for deletion did not include cluster name, and succeeded on the first correct tag (instead of checking them all).

### Testing
The too long role name is pretty easy to achieve since it includes a lot of data
