### PR TITLE
Fix bug: KSC telemetry reported twice instead of once

### DIFF
--- a/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_reconciler.go
+++ b/src/operator/controllers/kafka_server_config_reconcilers/kafka_server_config_reconciler.go
@@ -241,7 +241,6 @@ func (r *KafkaServerConfigReconciler) reconcileObject(ctx context.Context, kafka
 	}
 
 	r.RecordNormalEvent(kafkaServerConfig, ReasonSuccessfullyAppliedKafkaServerConfig, "successfully applied server config")
-	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeKafkaServerConfigApplied, len(kafkaServerConfig.Spec.Topics))
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
### Description

The telemetry `KAFKA_SERVER_CONFIG_APPLIED` is reported twice whenever the resource is applied instead of once. It should be handled in the resource's telemetry reconciler, not in the main one.  

### Testing

Telemetries logic is disabled globally in tests so there is no integration tests for it. It can be reproduce manually by applying the resource.