### PR TITLE
Fix panic in automatic external traffic handling

### DIFF
--- a/src/operator/controllers/external_traffic/shared.go
+++ b/src/operator/controllers/external_traffic/shared.go
@@ -12,9 +12,11 @@ func serviceNamesFromIngress(ingress *v1.Ingress) sets.Set[string] {
 	}
 
 	for _, rule := range ingress.Spec.Rules {
-		for _, path := range rule.HTTP.Paths {
-			if path.Backend.Service != nil {
-				serviceNames.Insert(path.Backend.Service.Name)
+		if rule.HTTP != nil {
+			for _, path := range rule.HTTP.Paths {
+				if path.Backend.Service != nil {
+					serviceNames.Insert(path.Backend.Service.Name)
+				}
 			}
 		}
 	}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
 
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	"github.com/otterize/intents-operator/src/operator/controllers"
@@ -119,6 +120,9 @@ func main() {
 
 	podName := MustGetEnvVar(operatorconfig.IntentsOperatorPodNameKey)
 	podNamespace := MustGetEnvVar(operatorconfig.IntentsOperatorPodNamespaceKey)
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339,
+	})
 	debugLogs := viper.GetBool(operatorconfig.DebugLogKey)
 
 	ctrl.SetLogger(logrusr.New(logrus.StandardLogger()))


### PR DESCRIPTION
### Description
This PR fixes a crash where Ingress resources that had an empty (`{}`) IngressRule would cause the Ingress Service indexer to crash.

```
time="2023-11-22T20:08:46Z" level=info msg="Serving webhook server" host= logger=controller-runtime.webhook port=9443
time="2023-11-22T20:08:46Z" level=info msg="Starting certificate watcher" logger=controller-runtime.certwatcher
E1122 20:08:46.071723       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 120 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1c8e420?, 0x3114250})
	/go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0008405a0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.27.2/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x1c8e420?, 0x3114250?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/otterize/intents-operator/src/operator/controllers/external_traffic.serviceNamesFromIngress(0xc0009e66e0)
	/workspace/operator/controllers/external_traffic/shared.go:15 +0xa9
github.com/otterize/intents-operator/src/operator/controllers/external_traffic.(*EndpointsReconcilerImpl).InitIngressReferencedServicesIndex.func1({0x2279e08?, 0xc0009e66e0?})
	/workspace/operator/controllers/external_traffic/endpoints_reconciler.go:85 +0x2d
sigs.k8s.io/controller-runtime/pkg/cache.indexByField.func1({0x1f00f40, 0xc0009e66e0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/cache/informer_cache.go:187 +0xaa
k8s.io/client-go/tools/cache.(*storeIndex).updateIndices(0xc0002a2030, {0x0, 0x0}, {0x1f00f40?, 0xc0009e66e0}, {0xc000a8e270, 0x25})
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/thread_safe_store.go:157 +0x1e3
k8s.io/client-go/tools/cache.(*threadSafeMap).Update(0xc00067ad80, {0xc000a8e270, 0x25}, {0x1f00f40?, 0xc0009e66e0})
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/thread_safe_store.go:226 +0x145
k8s.io/client-go/tools/cache.(*threadSafeMap).Add(0x1f00f40?, {0xc000a8e270?, 0x1f00f40?}, {0x1f00f40?, 0xc0009e66e0?})
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/thread_safe_store.go:218 +0x25
k8s.io/client-go/tools/cache.(*cache).Add(0xc000672528, {0x1f00f40, 0xc0009e66e0})
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/store.go:155 +0xa7
k8s.io/client-go/tools/cache.processDeltas({0x2262570, 0xc0002b86e0}, {0x226b9e0, 0xc000672528}, {0xc0004104c0?, 0x1, 0x3172b20?}, 0x0?)
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/controller.go:459 +0x1c4
k8s.io/client-go/tools/cache.(*sharedIndexInformer).HandleDeltas(0xc0002b86e0, {0x1cdb280?, 0xc000840588?}, 0x1?)
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/shared_informer.go:638 +0x165
k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc00089e000, 0xc0008a8010)
	/go/pkg/mod/k8s.io/client-go@v0.27.2/tools/cache/delta_fifo.go:603 +0x55e
```
