### PR TITLE
Add databaseName field to database-typed intents.

### DIFF
--- a/src/operator/api/v1alpha2/clientintents_webhook.go
+++ b/src/operator/api/v1alpha2/clientintents_webhook.go
@@ -53,6 +53,7 @@ func convertDatabaseResourcesV1alpha2toV1alpha3(srcResources []DatabaseResource)
 	dstResources := make([]v1alpha3.DatabaseResource, len(srcResources))
 	for i, resource := range srcResources {
 		dstResources[i].Table = resource.Table
+		dstResources[i].DatabaseName = resource.DatabaseName
 		dstResources[i].Operations = lo.Map(resource.Operations, func(operation DatabaseOperation, _ int) v1alpha3.DatabaseOperation {
 			return v1alpha3.DatabaseOperation(operation)
 		})
@@ -102,6 +103,7 @@ func (in *ClientIntents) ConvertFrom(srcRaw conversion.Hub) error {
 func convertDatabaseResourcesV1alpha3toV1alpha2(srcResources []v1alpha3.DatabaseResource) []DatabaseResource {
 	dstResources := make([]DatabaseResource, len(srcResources))
 	for i, resource := range srcResources {
+		dstResources[i].DatabaseName = resource.DatabaseName
 		dstResources[i].Table = resource.Table
 		dstResources[i].Operations = lo.Map(resource.Operations, func(operation v1alpha3.DatabaseOperation, _ int) DatabaseOperation {
 			return DatabaseOperation(operation)

--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -150,8 +150,9 @@ type Intent struct {
 }
 
 type DatabaseResource struct {
-	Table      string              `json:"table" yaml:"table"`
-	Operations []DatabaseOperation `json:"operations" yaml:"operations"`
+	DatabaseName string              `json:"databaseName" yaml:"databaseName"`
+	Table        string              `json:"table" yaml:"table"`
+	Operations   []DatabaseOperation `json:"operations" yaml:"operations"`
 }
 
 type HTTPResource struct {

--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -162,8 +162,9 @@ type Intent struct {
 }
 
 type DatabaseResource struct {
-	Table      string              `json:"table" yaml:"table"`
-	Operations []DatabaseOperation `json:"operations" yaml:"operations"`
+	DatabaseName string              `json:"databaseName" yaml:"databaseName"`
+	Table        string              `json:"table" yaml:"table"`
+	Operations   []DatabaseOperation `json:"operations" yaml:"operations"`
 }
 
 type HTTPResource struct {
@@ -484,7 +485,8 @@ func (in *Intent) ConvertToCloudFormat(resourceNamespace string, clientName stri
 	if in.DatabaseResources != nil {
 		intentInput.DatabaseResources = lo.Map(in.DatabaseResources, func(resource DatabaseResource, _ int) *graphqlclient.DatabaseConfigInput {
 			databaseConfigInput := graphqlclient.DatabaseConfigInput{
-				Table: lo.ToPtr(resource.Table),
+				Table:  lo.ToPtr(resource.Table),
+				Dbname: lo.ToPtr(resource.DatabaseName),
 				Operations: lo.Map(resource.Operations, func(operation DatabaseOperation, _ int) *graphqlclient.DatabaseOperation {
 					cloudOperation := databaseOperationToCloud(operation)
 					return &cloudOperation

--- a/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
@@ -41,6 +41,8 @@ spec:
                     databaseResources:
                       items:
                         properties:
+                          databaseName:
+                            type: string
                           operations:
                             items:
                               enum:
@@ -54,6 +56,7 @@ spec:
                           table:
                             type: string
                         required:
+                        - databaseName
                         - operations
                         - table
                         type: object
@@ -196,6 +199,8 @@ spec:
                     databaseResources:
                       items:
                         properties:
+                          databaseName:
+                            type: string
                           operations:
                             items:
                               enum:
@@ -209,6 +214,7 @@ spec:
                           table:
                             type: string
                         required:
+                        - databaseName
                         - operations
                         - table
                         type: object

--- a/src/operator/controllers/intents_reconcilers/exp/database_test.go
+++ b/src/operator/controllers/intents_reconcilers/exp/database_test.go
@@ -24,6 +24,7 @@ const (
 	clientName        string = "test-client"
 	integrationName   string = "test-integration"
 	tableName         string = "test-table"
+	dbName            string = "testdb"
 )
 
 type DatabaseReconcilerTestSuite struct {
@@ -85,7 +86,8 @@ func (s *DatabaseReconcilerTestSuite) TestSimpleDatabase() {
 					Name: integrationName,
 					Type: otterizev1alpha3.IntentTypeDatabase,
 					DatabaseResources: []otterizev1alpha3.DatabaseResource{{
-						Table: tableName,
+						DatabaseName: dbName,
+						Table:        tableName,
 						Operations: []otterizev1alpha3.DatabaseOperation{
 							otterizev1alpha3.DatabaseOperationSelect,
 							otterizev1alpha3.DatabaseOperationInsert,
@@ -103,7 +105,8 @@ func (s *DatabaseReconcilerTestSuite) TestSimpleDatabase() {
 		ServerNamespace: lo.ToPtr(testNamespace),
 		Type:            lo.ToPtr(graphqlclient.IntentTypeDatabase),
 		DatabaseResources: []*graphqlclient.DatabaseConfigInput{{
-			Table: lo.ToPtr(tableName),
+			Table:  lo.ToPtr(tableName),
+			Dbname: lo.ToPtr(dbName),
 			Operations: []*graphqlclient.DatabaseOperation{
 				lo.ToPtr(graphqlclient.DatabaseOperationSelect),
 				lo.ToPtr(graphqlclient.DatabaseOperationInsert),

--- a/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
@@ -46,6 +46,8 @@ spec:
                       databaseResources:
                         items:
                           properties:
+                            databaseName:
+                              type: string
                             operations:
                               items:
                                 enum:
@@ -59,6 +61,7 @@ spec:
                             table:
                               type: string
                           required:
+                            - databaseName
                             - operations
                             - table
                           type: object
@@ -196,6 +199,8 @@ spec:
                       databaseResources:
                         items:
                           properties:
+                            databaseName:
+                              type: string
                             operations:
                               items:
                                 enum:
@@ -209,6 +214,7 @@ spec:
                             table:
                               type: string
                           required:
+                            - databaseName
                             - operations
                             - table
                           type: object

--- a/src/shared/otterizecloud/graphqlclient/generate.go
+++ b/src/shared/otterizecloud/graphqlclient/generate.go
@@ -2,5 +2,5 @@ package graphqlclient
 
 import _ "github.com/suessflorian/gqlfetch"
 
-//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql"
+//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:3000/api/graphql/v1beta > schema.graphql"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -24,9 +24,13 @@ const (
 )
 
 type DatabaseConfigInput struct {
+	Dbname     *string              `json:"dbname"`
 	Table      *string              `json:"table"`
 	Operations []*DatabaseOperation `json:"operations"`
 }
+
+// GetDbname returns DatabaseConfigInput.Dbname, and is useful for accessing the field via an interface.
+func (v *DatabaseConfigInput) GetDbname() *string { return v.Dbname }
 
 // GetTable returns DatabaseConfigInput.Table, and is useful for accessing the field via an interface.
 func (v *DatabaseConfigInput) GetTable() *string { return v.Table }

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -85,6 +85,7 @@ type AWSInfo {
 	region: String!
 	namespace: String!
 	eksClusterName: String!
+	awsAccountId: String!
 }
 
 input AWSInfoInput {
@@ -92,6 +93,7 @@ input AWSInfoInput {
 	region: String!
 	namespace: String!
 	eksClusterName: String!
+	awsAccountId: String!
 }
 
 type AWSResource {
@@ -126,11 +128,6 @@ enum CertificateProvider {
 	CERT_MANAGER
 	CLOUD
 	NONE
-}
-
-type Client {
-	id: ID!
-	secret: String!
 }
 
 type ClientIntentsFileRepresentation {
@@ -218,11 +215,13 @@ enum CustomConstraint {
 }
 
 type DatabaseConfig {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]
 }
 
 input DatabaseConfigInput {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]!
 }
@@ -233,13 +232,11 @@ input DatabaseCredentialsInput {
 }
 
 type DatabaseInfo {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 }
 
 input DatabaseInfoInput {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!
@@ -565,41 +562,6 @@ type MeMutation {
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""Create client"""
-	createClient: Client!
-"""Delete client"""
-	deleteClient(
-		id: ID!
-	): ID!
-"""Create user invite"""
-	createInvite(
-		email: String!
-	): Invite!
-"""Delete user invite"""
-	deleteInvite(
-		id: ID!
-	): ID!
-"""Accept user invite"""
-	acceptInvite(
-		id: ID!
-	): Invite!
-"""Operate on the current logged-in user"""
-	me: MeMutation!
-"""Create a new organization"""
-	createOrganization(
-		name: String
-	): Organization!
-"""Update organization"""
-	updateOrganization(
-		id: ID!
-		name: String
-		imageURL: String
-	): Organization!
-"""Remove user from organization"""
-	removeUserFromOrganization(
-		id: ID!
-		userId: ID!
-	): ID!
 """Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
 	registerKubernetesPodOwnerCertificateRequest(
 		podOwner: NamespacedPodOwner!
@@ -713,15 +675,44 @@ type Mutation {
 		namespace: String!
 		policies: [NetworkPolicyInput!]!
 	): Boolean!
+"""Create user invite"""
+	createInvite(
+		email: String!
+	): Invite!
+"""Delete user invite"""
+	deleteInvite(
+		id: ID!
+	): ID!
+"""Accept user invite"""
+	acceptInvite(
+		id: ID!
+	): Invite!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
 	): Boolean!
+"""Operate on the current logged-in user"""
+	me: MeMutation!
 """Associate namespace to environment"""
 	associateNamespaceToEnv(
 		id: ID!
 		environmentId: ID
 	): Namespace!
+"""Create a new organization"""
+	createOrganization(
+		name: String
+	): Organization!
+"""Update organization"""
+	updateOrganization(
+		id: ID!
+		name: String
+		imageURL: String
+	): Organization!
+"""Remove user from organization"""
+	removeUserFromOrganization(
+		id: ID!
+		userId: ID!
+	): ID!
 	reportProtectedServicesSnapshot(
 		namespace: String!
 		services: [ProtectedServiceInput!]!
@@ -767,38 +758,6 @@ input ProtectedServiceInput {
 type Query {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""Get client"""
-	client(
-		id: ID!
-	): Client!
-"""List user invites"""
-	invites(
-		email: String
-		status: InviteStatus
-	): [Invite!]!
-"""Get user invite"""
-	invite(
-		id: ID!
-	): Invite!
-"""Get one user invite"""
-	oneInvite(
-		email: String
-		status: InviteStatus
-	): Invite!
-"""Get information regarding the current logged-in user"""
-	me: Me!
-"""List organizations"""
-	organizations: [Organization!]!
-"""Get organization"""
-	organization(
-		id: ID!
-	): Organization!
-"""List users"""
-	users: [User!]!
-"""Get user"""
-	user(
-		id: ID!
-	): User!
 """Get access graph"""
 	accessGraph(
 		filter: InputAccessGraphFilter
@@ -854,6 +813,22 @@ type Query {
 		clusterId: ID
 		name: String
 	): Integration!
+"""List user invites"""
+	invites(
+		email: String
+		status: InviteStatus
+	): [Invite!]!
+"""Get user invite"""
+	invite(
+		id: ID!
+	): Invite!
+"""Get one user invite"""
+	oneInvite(
+		email: String
+		status: InviteStatus
+	): Invite!
+"""Get information regarding the current logged-in user"""
+	me: Me!
 """Get namespace"""
 	namespace(
 		id: ID!
@@ -870,6 +845,12 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
+"""List organizations"""
+	organizations: [Organization!]!
+"""Get organization"""
+	organization(
+		id: ID!
+	): Organization!
 """Get service"""
 	service(
 		id: ID!
@@ -886,6 +867,12 @@ type Query {
 		namespaceId: ID
 		name: String
 	): Service
+"""List users"""
+	users: [User!]!
+"""Get user"""
+	user(
+		id: ID!
+	): User!
 }
 
 enum RowDiff {
@@ -1005,6 +992,16 @@ type User {
 type UserAndPassword {
 	username: String!
 	password: String!
+}
+
+enum UserErrorType {
+	UNAUTHENTICATED
+	NOT_FOUND
+	INTERNAL_SERVER_ERROR
+	BAD_REQUEST
+	FORBIDDEN
+	CONFLICT
+	BAD_USER_INPUT
 }
 
 


### PR DESCRIPTION


### Description

We used to include the database name (dbName) in the Integration declaration. However, we discovered that it makes more sense to specify the dbname using the intents. This is because a single Postgres server can hold multiple databases. Therefore, in order to support multiple databases, one needed to create multiple integrations to the same server.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
