### PR TITLE
Fix problem where healthz/readyz would not wait for webhook server to start

### DIFF
--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -258,21 +258,28 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 		assert.NotNil(intentsDeleted.DeletionTimestamp)
 	})
 
-	res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: s.TestNamespace,
-			Name:      intents.Name,
-		},
-	})
-	s.Require().NoError(err)
-	s.Require().Empty(res)
-
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: s.TestNamespace,
+				Name:      intents.Name,
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().Empty(res)
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: intentNetworkPolicyName}, &v1.NetworkPolicy{})
 		assert.True(errors.IsNotFound(err))
 	})
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: s.TestNamespace,
+				Name:      intents.Name,
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().Empty(res)
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, &v1.NetworkPolicy{})
 		assert.True(errors.IsNotFound(err))
 	})

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -62,14 +62,12 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	istiosecurityscheme "istio.io/client-go/pkg/apis/security/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-
-	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -412,11 +410,12 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Panic()
 	}
+
 	//+kubebuilder:scaffold:builder
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		logrus.WithError(err).Fatal("unable to set up health check")
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", mgr.GetWebhookServer().StartedChecker()); err != nil {
 		logrus.WithError(err).Fatal("unable to set up ready check")
 	}
 


### PR DESCRIPTION
### Description

Previously, the readyz/healthz check would not wait for webhook server to start. This would not cause problems in a real scenario as the controller would crash if the webhook server did not start successfully, but in automated testing this could result in the test starting too quickly, before the webhook server is listening, causing intermittent failures.