### PR TITLE
Add support for creating db intents to all the tables in a single database

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -150,9 +150,11 @@ type Intent struct {
 }
 
 type DatabaseResource struct {
-	DatabaseName string              `json:"databaseName" yaml:"databaseName"`
-	Table        string              `json:"table" yaml:"table"`
-	Operations   []DatabaseOperation `json:"operations" yaml:"operations"`
+	DatabaseName string `json:"databaseName" yaml:"databaseName"`
+	//+optional
+	Table string `json:"table" yaml:"table"`
+	//+optional
+	Operations []DatabaseOperation `json:"operations" yaml:"operations"`
 }
 
 type HTTPResource struct {

--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -162,9 +162,11 @@ type Intent struct {
 }
 
 type DatabaseResource struct {
-	DatabaseName string              `json:"databaseName" yaml:"databaseName"`
-	Table        string              `json:"table" yaml:"table"`
-	Operations   []DatabaseOperation `json:"operations" yaml:"operations"`
+	DatabaseName string `json:"databaseName" yaml:"databaseName"`
+	//+optional
+	Table string `json:"table" yaml:"table"`
+	//+optional
+	Operations []DatabaseOperation `json:"operations" yaml:"operations"`
 }
 
 type HTTPResource struct {

--- a/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
@@ -57,8 +57,6 @@ spec:
                             type: string
                         required:
                         - databaseName
-                        - operations
-                        - table
                         type: object
                       type: array
                     name:
@@ -215,8 +213,6 @@ spec:
                             type: string
                         required:
                         - databaseName
-                        - operations
-                        - table
                         type: object
                       type: array
                     kafkaTopics:

--- a/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
@@ -62,8 +62,6 @@ spec:
                               type: string
                           required:
                             - databaseName
-                            - operations
-                            - table
                           type: object
                         type: array
                       name:
@@ -215,8 +213,6 @@ spec:
                               type: string
                           required:
                             - databaseName
-                            - operations
-                            - table
                           type: object
                         type: array
                       kafkaTopics:


### PR DESCRIPTION


### Description

The table and operations fields are no longer required for database-typed intents. If no operations are specified it equals to specify `ALL`, if no table is specified it means "all the tables for this databaseName".

### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
