### PR TITLE
Fix bug where AWS IAM roles were not deleted upon pod termination

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.0
+          version: v1.55.2
 
           # Optional: working directory, useful for monorepos
           working-directory: src

--- a/src/operator/controllers/intents_reconcilers/aws_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/aws_reconciler.go
@@ -56,7 +56,7 @@ func (r *AWSIntentsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	if intents.DeletionTimestamp != nil {
 		logger.Debug("Intents deleted, deleting IAM role policy for this service")
 
-		err := r.awsAgent.DeleteRolePolicy(ctx, req.Namespace, intents.Spec.Service.Name)
+		err := r.awsAgent.DeleteRolePolicyFromIntents(ctx, intents)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/src/shared/awsagent/agent.go
+++ b/src/shared/awsagent/agent.go
@@ -20,9 +20,26 @@ import (
 	"strings"
 )
 
+type IAMClient interface {
+	ListAttachedRolePolicies(ctx context.Context, i *iam.ListAttachedRolePoliciesInput, opts ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	DeleteRole(ctx context.Context, i *iam.DeleteRoleInput, opts ...func(*iam.Options)) (*iam.DeleteRoleOutput, error)
+	CreateRole(ctx context.Context, i *iam.CreateRoleInput, opts ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+	GetRole(ctx context.Context, i *iam.GetRoleInput, opts ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	GetPolicy(ctx context.Context, i *iam.GetPolicyInput, opts ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	ListEntitiesForPolicy(ctx context.Context, i *iam.ListEntitiesForPolicyInput, opts ...func(*iam.Options)) (*iam.ListEntitiesForPolicyOutput, error)
+	DetachRolePolicy(ctx context.Context, i *iam.DetachRolePolicyInput, opts ...func(*iam.Options)) (*iam.DetachRolePolicyOutput, error)
+	ListPolicyVersions(ctx context.Context, i *iam.ListPolicyVersionsInput, opts ...func(*iam.Options)) (*iam.ListPolicyVersionsOutput, error)
+	DeletePolicyVersion(ctx context.Context, i *iam.DeletePolicyVersionInput, opts ...func(*iam.Options)) (*iam.DeletePolicyVersionOutput, error)
+	DeletePolicy(ctx context.Context, i *iam.DeletePolicyInput, opts ...func(*iam.Options)) (*iam.DeletePolicyOutput, error)
+	PutRolePolicy(ctx context.Context, i *iam.PutRolePolicyInput, opts ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+	CreatePolicy(ctx context.Context, i *iam.CreatePolicyInput, opts ...func(*iam.Options)) (*iam.CreatePolicyOutput, error)
+	CreatePolicyVersion(ctx context.Context, i *iam.CreatePolicyVersionInput, opts ...func(*iam.Options)) (*iam.CreatePolicyVersionOutput, error)
+	TagPolicy(ctx context.Context, i *iam.TagPolicyInput, opts ...func(*iam.Options)) (*iam.TagPolicyOutput, error)
+	AttachRolePolicy(ctx context.Context, i *iam.AttachRolePolicyInput, opts ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error)
+}
+
 type Agent struct {
-	stsClient   *sts.Client
-	iamClient   *iam.Client
+	iamClient   IAMClient
 	accountID   string
 	oidcURL     string
 	clusterName string
@@ -57,7 +74,6 @@ func NewAWSAgent(
 	}
 
 	return &Agent{
-		stsClient:   stsClient,
 		iamClient:   iamClient,
 		accountID:   *callerIdent.Account,
 		oidcURL:     strings.Split(OIDCURL, "://")[1],

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -316,23 +316,3 @@ func (a *Agent) generatePolicyName(ns, intentsServiceName string) string {
 func (a *Agent) generatePolicyArn(policyName string) string {
 	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", a.accountID, policyName)
 }
-
-func (a *Agent) aageneratePolicyName(namespace string, policyName string) string {
-	fullName := fmt.Sprintf("otr-%s.%s@%s", namespace, policyName, a.clusterName)
-
-	var truncatedName string
-	if len(fullName) >= (maxTruncatedLength) {
-		truncatedName = fullName[:maxTruncatedLength]
-	} else {
-		truncatedName = fullName
-	}
-
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(fullName)))
-	hash = hash[:truncatedHashLength]
-
-	return fmt.Sprintf("%s-%s", truncatedName, hash)
-}
-
-func (a *Agent) aageneratePolicyArn(namespace string, policyName string) string {
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", a.accountID, a.generatePolicyName(namespace, policyName))
-}

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -9,11 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
-func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, policyName string, statements []StatementEntry) error {
+func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, intentsServiceName string, statements []StatementEntry) error {
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
 
 	if err != nil {
@@ -24,14 +25,14 @@ func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName
 		return fmt.Errorf("role not found: %s", a.generateRoleName(namespace, accountName))
 	}
 
-	policyArn := a.generatePolicyArn(namespace, policyName)
+	policyArn := a.generatePolicyArn(a.generatePolicyName(namespace, intentsServiceName))
 
 	policyOutput, err := a.iamClient.GetPolicy(ctx, &iam.GetPolicyInput{
 		PolicyArn: aws.String(policyArn),
 	})
 	if err != nil {
 		if isNoSuchEntityException(err) {
-			_, err := a.createPolicy(ctx, role, namespace, policyName, statements)
+			_, err := a.createPolicy(ctx, role, namespace, intentsServiceName, statements)
 
 			return err
 		}
@@ -57,9 +58,13 @@ func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName
 	return nil
 }
 
-func (a *Agent) DeleteRolePolicy(ctx context.Context, namespace, policyName string) error {
+func (a *Agent) DeleteRolePolicyFromIntents(ctx context.Context, intents v1alpha3.ClientIntents) error {
+	return a.DeleteRolePolicy(ctx, a.generatePolicyName(intents.Namespace, intents.Spec.Service.Name))
+}
+
+func (a *Agent) DeleteRolePolicy(ctx context.Context, policyName string) error {
 	output, err := a.iamClient.GetPolicy(ctx, &iam.GetPolicyInput{
-		PolicyArn: aws.String(a.generatePolicyArn(namespace, policyName)),
+		PolicyArn: aws.String(a.generatePolicyArn(policyName)),
 	})
 
 	if err != nil {
@@ -160,8 +165,8 @@ func (a *Agent) SetRolePolicy(ctx context.Context, namespace, accountName string
 	return nil
 }
 
-func (a *Agent) createPolicy(ctx context.Context, role *types.Role, namespace, policyName string, statements []StatementEntry) (*types.Policy, error) {
-	fullPolicyName := generatePolicyName(namespace, policyName)
+func (a *Agent) createPolicy(ctx context.Context, role *types.Role, namespace string, intentsServiceName string, statements []StatementEntry) (*types.Policy, error) {
+	fullPolicyName := a.generatePolicyName(namespace, intentsServiceName)
 	policyDoc, policyHash, err := generatePolicyDocument(statements)
 
 	if err != nil {
@@ -174,7 +179,7 @@ func (a *Agent) createPolicy(ctx context.Context, role *types.Role, namespace, p
 		Tags: []types.Tag{
 			{
 				Key:   aws.String(policyNameTagKey),
-				Value: aws.String(policyName),
+				Value: aws.String(intentsServiceName),
 			},
 			{
 				Key:   aws.String(policyNamespaceTagKey),
@@ -303,11 +308,31 @@ func generatePolicyDocument(statements []StatementEntry) (string, string, error)
 	return string(serialized), fmt.Sprintf("%x", sum), nil
 }
 
-func generatePolicyName(ns, policyName string) string {
-	return fmt.Sprintf("otterize-policy-%s-%s", ns, policyName)
+func (a *Agent) generatePolicyName(ns, intentsServiceName string) string {
+	return fmt.Sprintf("otterize-policy-%s-%s", ns, intentsServiceName)
 
 }
 
-func (a *Agent) generatePolicyArn(ns, policyName string) string {
-	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", a.accountID, generatePolicyName(ns, policyName))
+func (a *Agent) generatePolicyArn(policyName string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", a.accountID, policyName)
+}
+
+func (a *Agent) aageneratePolicyName(namespace string, policyName string) string {
+	fullName := fmt.Sprintf("otr-%s.%s@%s", namespace, policyName, a.clusterName)
+
+	var truncatedName string
+	if len(fullName) >= (maxTruncatedLength) {
+		truncatedName = fullName[:maxTruncatedLength]
+	} else {
+		truncatedName = fullName
+	}
+
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(fullName)))
+	hash = hash[:truncatedHashLength]
+
+	return fmt.Sprintf("%s-%s", truncatedName, hash)
+}
+
+func (a *Agent) aageneratePolicyArn(namespace string, policyName string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:policy/%s", a.accountID, a.generatePolicyName(namespace, policyName))
 }


### PR DESCRIPTION
### Description
DeleteOtterizeIAMRole did not check tags correctly, and skipped roles that it did create, while it was supposed to only skip roles not created by it.

### References

Related: https://github.com/otterize/credentials-operator/pull/97

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
