### PR TITLE
Fixed problem where custom Prometheus metrics would not be exposed alongside the standard controller-runtime metrics

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/google/uuid"
-	"github.com/labstack/echo-contrib/echoprometheus"
-	"github.com/labstack/echo/v4"
 	"github.com/otterize/intents-operator/src/operator/controllers/aws_pod_reconciler"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/egress_network_policy"
@@ -129,9 +127,6 @@ func main() {
 	if debugLogs {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-
-	metricsServer := echo.New()
-	metricsServer.GET("/metrics", echoprometheus.NewHandler())
 
 	options := ctrl.Options{
 		Scheme:                 scheme,

--- a/src/prometheus/metrics.go
+++ b/src/prometheus/metrics.go
@@ -3,30 +3,34 @@ package prometheus
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+func init() {
+}
+
 var (
-	intentsApplied = promauto.NewCounter(prometheus.CounterOpts{
+	intentsApplied = promauto.With(metrics.Registry).NewCounter(prometheus.CounterOpts{
 		Name: "clientintents_applied",
 		Help: "The total number of ClientIntents applied",
 	})
-	netpolCreated = promauto.NewCounter(prometheus.CounterOpts{
+	netpolCreated = promauto.With(metrics.Registry).NewCounter(prometheus.CounterOpts{
 		Name: "network_policies_created",
 		Help: "The total number of network policies created",
 	})
-	netpolDeleted = promauto.NewCounter(prometheus.CounterOpts{
+	netpolDeleted = promauto.With(metrics.Registry).NewCounter(prometheus.CounterOpts{
 		Name: "network_policies_deleted",
 		Help: "The total number of network policies deleted",
 	})
-	podsLabeledForAccess = promauto.NewCounter(prometheus.CounterOpts{
+	podsLabeledForAccess = promauto.With(metrics.Registry).NewCounter(prometheus.CounterOpts{
 		Name: "pods_labeled_for_network_policy",
 		Help: "The total number of pods labeled to participate in a network policy",
 	})
-	podsUnlabeledForAccess = promauto.NewCounter(prometheus.CounterOpts{
+	podsUnlabeledForAccess = promauto.With(metrics.Registry).NewCounter(prometheus.CounterOpts{
 		Name: "pods_unlabeled_for_network_policy",
 		Help: "The total number of pods unlabeled so they no longer participate in a network policy",
 	})
-	protectedServiceApplied = promauto.NewGauge(prometheus.GaugeOpts{
+	protectedServiceApplied = promauto.With(metrics.Registry).NewGauge(prometheus.GaugeOpts{
 		Name: "protected_services_applied",
 		Help: "The total number of ProtectedService resources applied",
 	})

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	MetricsAddrKey                              = "metrics-bind-address" // The address the metric endpoint binds to
-	MetricsAddrDefault                          = ":8180"
+	MetricsAddrDefault                          = ":2112"
 	ProbeAddrKey                                = "health-probe-bind-address" // The address the probe endpoint binds to
 	ProbeAddrDefault                            = ":8181"
 	EnableLeaderElectionKey                     = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
@@ -50,8 +50,6 @@ const (
 	EnableAWSPolicyKey                          = "enable-aws-iam-policy"
 	EnableAWSPolicyDefault                      = false
 	EKSClusterNameOverrideKey                   = "eks-cluster-name-override"
-	PrometheusMetricsPortKey                    = "metrics-port"
-	PrometheusMetricsPortDefault                = 2112
 )
 
 func init() {
@@ -67,7 +65,6 @@ func init() {
 	viper.SetDefault(DisableWebhookServerKey, DisableWebhookServerDefault)
 	viper.SetDefault(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault)
 	viper.SetDefault(EnableAWSPolicyKey, EnableAWSPolicyDefault)
-	viper.SetDefault(PrometheusMetricsPortKey, PrometheusMetricsPortDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
### Description

Fixed problem where custom Prometheus metrics would not be exposed alongside the standard controller-runtime metrics.

Unrelated fix discovered while debugging: the webhook health/ready checker made it so starting the intents-operator locally requires the webhook server to start, even if webhooks are disabled. The health and ready checker now use the webhook server only if webhooks are not disabled.

### Testing

Manually tested by querying the metrics endpoint.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
