### PR TITLE
Support error reporting default configuration on non-Helm installations

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -97,7 +97,7 @@ func MustGetEnvVar(name string) string {
 
 func main() {
 	operatorconfig.InitCLIFlags()
-	errorreporter.Init("intents-operator", version.Version())
+	errorreporter.Init("intents-operator", version.Version(), viper.GetString(operatorconfig.TelemetryErrorsAPIKeyKey))
 
 	metricsAddr := viper.GetString(operatorconfig.MetricsAddrKey)
 	probeAddr := viper.GetString(operatorconfig.ProbeAddrKey)

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -53,6 +53,8 @@ const (
 	EKSClusterNameOverrideKey                   = "eks-cluster-name-override"
 	PrometheusMetricsPortKey                    = "metrics-port"
 	PrometheusMetricsPortDefault                = 2112
+	TelemetryErrorsAPIKeyKey                    = "telemetry-errors-api-key"
+	TelemetryErrorsAPIKeyDefault                = "60a78208a2b4fe714ef9fb3d3fdc0714"
 )
 
 func init() {
@@ -69,6 +71,7 @@ func init() {
 	viper.SetDefault(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault)
 	viper.SetDefault(EnableAWSPolicyKey, EnableAWSPolicyDefault)
 	viper.SetDefault(PrometheusMetricsPortKey, PrometheusMetricsPortDefault)
+	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -68,7 +68,7 @@ func init() {
 	viper.SetDefault(DisableWebhookServerKey, DisableWebhookServerDefault)
 	viper.SetDefault(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault)
 	viper.SetDefault(EnableAWSPolicyKey, EnableAWSPolicyDefault)
-	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault))
+	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/telemetries/errorreporter/errorrerporter.go
+++ b/src/shared/telemetries/errorreporter/errorrerporter.go
@@ -20,7 +20,7 @@ func addComponentInfoToBugsnagEvent(componentType string, event *bugsnag.Event) 
 	event.MetaData.Add("component", "cloudClientId", componentinfo.GlobalCloudClientId())
 }
 
-func Init(componentName string, version string) {
+func Init(componentName string, version string, apiKey string) {
 	if !telemetriesconfig.IsErrorsTelemetryEnabled() {
 		logrus.Info("error reporting disabled")
 		return
@@ -33,7 +33,6 @@ func Init(componentName string, version string) {
 
 	errorsServerAddress := viper.GetString(telemetriesconfig.TelemetryErrorsAddressKey)
 	releaseStage := viper.GetString(telemetriesconfig.TelemetryErrorsStageKey)
-	apiKey := viper.GetString(telemetriesconfig.TelemetryErrorsAPIKeyKey)
 
 	conf := bugsnag.Configuration{
 		Endpoints: bugsnag.Endpoints{

--- a/src/shared/telemetries/telemetriesconfig/config.go
+++ b/src/shared/telemetries/telemetriesconfig/config.go
@@ -28,8 +28,6 @@ const (
 	TelemetryErrorsStageDefault    = "production"
 	TelemetryErrorsAddressKey      = "telemetry-errors-address"
 	TelemetryErrorsAddressDefault  = "https://app.otterize.com/api/errors"
-	TelemetryErrorsAPIKeyKey       = "telemetry-errors-api-key"
-	TelemetryErrorsAPIKeyDefault   = ""
 	EnvPrefix                      = "OTTERIZE"
 )
 
@@ -45,7 +43,6 @@ func init() {
 	viper.SetDefault(TelemetryErrorsEnabledKey, TelemetryErrorEnabledDefault)
 	viper.SetDefault(TelemetryErrorsStageKey, TelemetryErrorsStageDefault)
 	viper.SetDefault(TelemetryErrorsAddressKey, TelemetryErrorsAddressDefault)
-	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/telemetries/telemetriesconfig/config.go
+++ b/src/shared/telemetries/telemetriesconfig/config.go
@@ -10,9 +10,9 @@ const (
 	TimeoutKey                     = "telemetry-client-timeout"
 	CloudClientTimeoutDefault      = "30s"
 	TelemetryEnabledKey            = "telemetry-enabled"
-	TelemetryEnabledDefault        = false
+	TelemetryEnabledDefault        = true
 	TelemetryUsageEnabledKey       = "telemetry-usage-enabled"
-	TelemetryUsageEnabledDefault   = false
+	TelemetryUsageEnabledDefault   = true
 	TelemetryMaxBatchSizeKey       = "telemetry-max-batch-size"
 	TelemetryMaxBatchSizeDefault   = 100
 	TelemetryIntervalKey           = "telemetry-interval-seconds"
@@ -23,7 +23,7 @@ const (
 	TelemetryActiveIntervalKey     = "telemetry-active-interval-duration"
 	TelemetryActiveIntervalDefault = "2m"
 	TelemetryErrorsEnabledKey      = "telemetry-errors-enabled"
-	TelemetryErrorEnabledDefault   = false
+	TelemetryErrorEnabledDefault   = true
 	TelemetryErrorsStageKey        = "telemetry-errors-stage"
 	TelemetryErrorsStageDefault    = "production"
 	TelemetryErrorsAddressKey      = "telemetry-errors-address"


### PR DESCRIPTION
### Description

Make errors API key a per-component configuration and update config to support non-helm installation.

### Testing

This is a configuration check and can be tested manually

### Checklist

There is no documentation change required for this PR since it's aligned with existing statement on docs
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
