### PR TITLE
Use panic for error on init

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -159,17 +159,17 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
-		logrus.WithError(err).Fatal(err, "unable to start manager")
+		logrus.WithError(err).Panic(err, "unable to start manager")
 	}
 	signalHandlerCtx := ctrl.SetupSignalHandler()
 
 	metadataClient, err := metadata.NewForConfig(ctrl.GetConfigOrDie())
 	if err != nil {
-		logrus.WithError(err).Fatal("unable to create metadata client")
+		logrus.WithError(err).Panic("unable to create metadata client")
 	}
 	mapping, err := mgr.GetRESTMapper().RESTMapping(schema.GroupKind{Group: "", Kind: "Namespace"}, "v1")
 	if err != nil {
-		logrus.WithError(err).Fatal("unable to create Kubernetes API REST mapping")
+		logrus.WithError(err).Panic("unable to create Kubernetes API REST mapping")
 	}
 	kubeSystemUID := ""
 	kubeSystemNs, err := metadataClient.Resource(mapping.Resource).Get(signalHandlerCtx, "kube-system", metav1.GetOptions{})
@@ -184,7 +184,7 @@ func main() {
 
 	directClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {
-		logrus.WithError(err).Fatal("unable to create kubernetes API client")
+		logrus.WithError(err).Panic("unable to create kubernetes API client")
 	}
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
@@ -206,21 +206,21 @@ func main() {
 	if viper.GetBool(operatorconfig.EnableAWSPolicyKey) {
 		awsIntentsAgent, err := awsagent.NewAWSAgent(signalHandlerCtx)
 		if err != nil {
-			logrus.WithError(err).Fatal("could not initialize AWS agent")
+			logrus.WithError(err).Panic("could not initialize AWS agent")
 		}
 		awsIntentsReconciler := intents_reconcilers.NewAWSIntentsReconciler(mgr.GetClient(), scheme, awsIntentsAgent, serviceidresolver.NewResolver(mgr.GetClient()))
 		additionalIntentsReconcilers = append(additionalIntentsReconcilers, awsIntentsReconciler)
 		awsPodWatcher := aws_pod_reconciler.NewAWSPodReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("intents-operator"), awsIntentsReconciler)
 		err = awsPodWatcher.SetupWithManager(mgr)
 		if err != nil {
-			logrus.WithError(err).Fatal("unable to register pod watcher")
+			logrus.WithError(err).Panic("unable to register pod watcher")
 		}
 	}
 	svcNetworkPolicyHandler := port_network_policy.NewPortNetworkPolicyReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState)
 	svcEgressNetworkPolicyHandler := port_egress_network_policy.NewPortEgressNetworkPolicyReconciler(mgr.GetClient(), scheme, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState)
 
 	if err = endpointReconciler.InitIngressReferencedServicesIndex(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init index for ingress")
+		logrus.WithError(err).Panic("unable to init index for ingress")
 	}
 
 	ingressReconciler := external_traffic.NewIngressReconciler(mgr.GetClient(), extNetpolHandler)
@@ -235,7 +235,7 @@ func main() {
 
 		netpolUploader := external_traffic.NewNetworkPolicyUploaderReconciler(mgr.GetClient(), mgr.GetScheme(), otterizeCloudClient)
 		if err = netpolUploader.SetupWithManager(mgr); err != nil {
-			logrus.WithError(err).Fatal("unable to initialize NetworkPolicy reconciler")
+			logrus.WithError(err).Panic("unable to initialize NetworkPolicy reconciler")
 		}
 	} else {
 		logrus.Info("Not configured for cloud integration")
@@ -250,55 +250,55 @@ func main() {
 		certBundle, err :=
 			webhooks.GenerateSelfSignedCertificate("intents-operator-webhook-service", podNamespace)
 		if err != nil {
-			logrus.WithError(err).Fatal("unable to create self signed certs for webhook")
+			logrus.WithError(err).Panic("unable to create self signed certs for webhook")
 		}
 		err = webhooks.WriteCertToFiles(certBundle)
 		if err != nil {
-			logrus.WithError(err).Fatal("failed writing certs to file system")
+			logrus.WithError(err).Panic("failed writing certs to file system")
 		}
 
 		err = otterizecrds.Ensure(signalHandlerCtx, directClient, podNamespace)
 		if err != nil {
-			logrus.WithError(err).Fatal("unable to ensure otterize CRDs")
+			logrus.WithError(err).Panic("unable to ensure otterize CRDs")
 		}
 
 		err = webhooks.UpdateValidationWebHookCA(signalHandlerCtx,
 			"otterize-validating-webhook-configuration", certBundle.CertPem)
 		if err != nil {
-			logrus.WithError(err).Fatal("updating validation webhook certificate failed")
+			logrus.WithError(err).Panic("updating validation webhook certificate failed")
 		}
 		err = webhooks.UpdateConversionWebhookCAs(signalHandlerCtx, directClient, certBundle.CertPem)
 		if err != nil {
-			logrus.WithError(err).Fatal("updating conversion webhook certificate failed")
+			logrus.WithError(err).Panic("updating conversion webhook certificate failed")
 		}
 	}
 
 	if !disableWebhookServer {
 		intentsValidator := webhooks.NewIntentsValidatorV1alpha2(mgr.GetClient())
 		if err = (&otterizev1alpha2.ClientIntents{}).SetupWebhookWithManager(mgr, intentsValidator); err != nil {
-			logrus.WithError(err).Fatal(err, "unable to create webhook for v1alpha2", "webhook", "ClientIntents")
+			logrus.WithError(err).Panic(err, "unable to create webhook for v1alpha2", "webhook", "ClientIntents")
 		}
 		intentsValidatorV1alpha3 := webhooks.NewIntentsValidatorV1alpha3(mgr.GetClient())
 		if err = (&otterizev1alpha3.ClientIntents{}).SetupWebhookWithManager(mgr, intentsValidatorV1alpha3); err != nil {
-			logrus.WithError(err).Fatal(err, "unable to create webhook v1alpha3", "webhook", "ClientIntents")
+			logrus.WithError(err).Panic(err, "unable to create webhook v1alpha3", "webhook", "ClientIntents")
 		}
 
 		protectedServiceValidator := webhooks.NewProtectedServiceValidatorV1alpha2(mgr.GetClient())
 		if err = (&otterizev1alpha2.ProtectedService{}).SetupWebhookWithManager(mgr, protectedServiceValidator); err != nil {
-			logrus.WithError(err).Fatal("unable to create webhook v1alpha2", "webhook", "ProtectedService")
+			logrus.WithError(err).Panic("unable to create webhook v1alpha2", "webhook", "ProtectedService")
 		}
 
 		protectedServiceValidatorV1alpha3 := webhooks.NewProtectedServiceValidatorV1alpha3(mgr.GetClient())
 		if err = (&otterizev1alpha3.ProtectedService{}).SetupWebhookWithManager(mgr, protectedServiceValidatorV1alpha3); err != nil {
-			logrus.WithError(err).Fatal("unable to create webhook v1alpha3", "webhook", "ProtectedService")
+			logrus.WithError(err).Panic("unable to create webhook v1alpha3", "webhook", "ProtectedService")
 		}
 
 		if err = (&otterizev1alpha2.KafkaServerConfig{}).SetupWebhookWithManager(mgr); err != nil {
-			logrus.WithError(err).Fatal("unable to create webhook v1alpha2", "webhook", "KafkaServerConfig")
+			logrus.WithError(err).Panic("unable to create webhook v1alpha2", "webhook", "KafkaServerConfig")
 		}
 
 		if err = (&otterizev1alpha3.KafkaServerConfig{}).SetupWebhookWithManager(mgr); err != nil {
-			logrus.WithError(err).Fatal("unable to create webhook v1alpha3", "webhook", "KafkaServerConfig")
+			logrus.WithError(err).Panic("unable to create webhook v1alpha3", "webhook", "KafkaServerConfig")
 		}
 
 	}
@@ -320,33 +320,33 @@ func main() {
 	)
 
 	if err = ingressReconciler.InitNetworkPoliciesByIngressNameIndex(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init index for ingress")
+		logrus.WithError(err).Panic("unable to init index for ingress")
 	}
 	if err = intentsReconciler.InitIntentsServerIndices(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init indices")
+		logrus.WithError(err).Panic("unable to init indices")
 	}
 
 	if err = intentsReconciler.InitEndpointsPodNamesIndex(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init indices")
+		logrus.WithError(err).Panic("unable to init indices")
 	}
 
 	if err = intentsReconciler.InitProtectedServiceIndexField(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init protected service index")
+		logrus.WithError(err).Panic("unable to init protected service index")
 	}
 
 	if err = intentsReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "Intents")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "Intents")
 	}
 	if err = endpointReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "Endpoints")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "Endpoints")
 	}
 
 	if err = externalPolicySvcReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "Endpoints")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "Endpoints")
 	}
 
 	if err = ingressReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "Ingress")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "Ingress")
 	}
 
 	kafkaServerConfigReconciler := controllers.NewKafkaServerConfigReconciler(
@@ -360,11 +360,11 @@ func main() {
 	)
 
 	if err = kafkaServerConfigReconciler.SetupWithManager(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "KafkaServerConfig")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "KafkaServerConfig")
 	}
 
 	if err = kafkaServerConfigReconciler.InitKafkaServerConfigIndices(mgr); err != nil {
-		logrus.WithError(err).Fatal("unable to init indices for KafkaServerConfig")
+		logrus.WithError(err).Panic("unable to init indices for KafkaServerConfig")
 	}
 
 	protectedServicesReconciler := controllers.NewProtectedServiceReconciler(
@@ -379,7 +379,7 @@ func main() {
 
 	err = protectedServicesReconciler.SetupWithManager(mgr)
 	if err != nil {
-		logrus.WithError(err).Fatal("unable to create controller", "controller", "ProtectedServices")
+		logrus.WithError(err).Panic("unable to create controller", "controller", "ProtectedServices")
 	}
 
 	podWatcher := pod_reconcilers.NewPodWatcher(mgr.GetClient(), mgr.GetEventRecorderFor("intents-operator"), watchedNamespaces, enforcementConfig.EnforcementDefaultState, enforcementConfig.EnableIstioPolicy)
@@ -420,10 +420,10 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 	if err := mgr.AddHealthzCheck("healthz", healthChecker); err != nil {
-		logrus.WithError(err).Fatal("unable to set up health check")
+		logrus.WithError(err).Panic("unable to set up health check")
 	}
 	if err := mgr.AddReadyzCheck("readyz", readyChecker); err != nil {
-		logrus.WithError(err).Fatal("unable to set up ready check")
+		logrus.WithError(err).Panic("unable to set up ready check")
 	}
 
 	logrus.Info("starting manager")
@@ -431,7 +431,7 @@ func main() {
 	telemetrysender.IntentsOperatorRunActiveReporter(signalHandlerCtx)
 
 	if err := mgr.Start(signalHandlerCtx); err != nil {
-		logrus.WithError(err).Fatal("problem running manager")
+		logrus.WithError(err).Panic("problem running manager")
 	}
 }
 


### PR DESCRIPTION
### Description

Until this PR, initialization errors where logged as `logrus.Fatal` and were followed by a call to `os.Exit`. Since the bugsnag-logrus hook report errors asynchronously, in many cases the process was killed before the error was sent.

This PR turn all errors on init to panic exception, since the panic handler report the error synchronously.