### PR TITLE
Enable database reconciler by defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,44 @@ spec:
 
 Done! The pod can access AWS. Try the [AWS IAM tutorial](https://docs.otterize.com/quickstart/access-control/aws-iam-eks) to learn more.
 
+### Otterize for PostgreSQL
+Otterize automates PostgreSQL access management and secrets for your workloads, all in Kubernetes.
 
+Here is how:
+1. Annotate a pod, requesting a user and a password to be provisioned and bound to the pod.
+
+Annotate the pod with this annotation:
+
+`credentials-operator.otterize.com/user-password-secret-name: booking-service-secret`
+
+2. Declare your workload’s ClientIntents, specifying desired permissions.
+
+```yaml
+apiVersion: k8s.otterize.com/v1alpha3
+kind: ClientIntents
+metadata:
+  name: booking-service
+  namespace: flight-search
+spec:
+  service:
+    name: booking-service
+  calls:
+    - name: bookings
+      type: database
+      databaseResources:
+        - table: users
+          databaseName: bookings-db
+          operations:
+            - SELECT
+        - table: products
+          databaseName: bookings-db
+          operations:
+            - ALL
+```
+
+Otterize then creates a user and matching grants on the target database.
+
+Try the [Just-in-time PostgreSQL users & access](https://docs.otterize.com/quickstart/access-control/postgresql) to learn more.
 
 ### Kafka mTLS & ACLs
 The intents operator automatically creates, updates, and deletes ACLs in Kafka clusters running within your Kubernetes cluster. 

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
+	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/database"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/egress_network_policy"
-	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/exp"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/ingress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_egress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_network_policy"
@@ -128,7 +128,7 @@ func NewIntentsReconciler(
 	}
 
 	if enforcementConfig.EnableDatabaseReconciler {
-		databaseReconciler := exp.NewDatabaseReconciler(client, scheme, otterizeClient)
+		databaseReconciler := database.NewDatabaseReconciler(client, scheme, otterizeClient)
 		intentsReconciler.group.AddToGroup(databaseReconciler)
 	}
 

--- a/src/operator/controllers/intents_reconcilers/database/database.go
+++ b/src/operator/controllers/intents_reconcilers/database/database.go
@@ -1,4 +1,4 @@
-package exp
+package database
 
 import (
 	"context"

--- a/src/operator/controllers/intents_reconcilers/database/database_test.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_test.go
@@ -1,4 +1,4 @@
-package exp
+package database
 
 import (
 	"context"

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -41,7 +41,7 @@ const (
 	IntentsOperatorPodNamespaceKey              = "pod-namespace"
 	EnvPrefix                                   = "OTTERIZE"
 	EnableDatabaseReconciler                    = "enable-database-reconciler" // Whether to enable the new database reconciler
-	EnableDatabaseReconcilerDefault             = false
+	EnableDatabaseReconcilerDefault             = true
 	RetryDelayTimeKey                           = "retry-delay-time" // Default retry delay time for retrying failed requests
 	RetryDelayTimeDefault                       = 5 * time.Second
 	DebugLogKey                                 = "debug" // Whether to enable debug logging


### PR DESCRIPTION
### Description
In this PR I enabled the new database reconciler which was experimental and disabled by default until now.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs - https://github.com/otterize/docs/pull/183
