### PR TITLE
Change `enableDatabaseReconciler` flag name to `enableDatabaseCredentialsCreation`

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -61,7 +61,7 @@ type EnforcementConfig struct {
 	EnableNetworkPolicy                  bool
 	EnableKafkaACL                       bool
 	EnableIstioPolicy                    bool
-	EnableDatabaseReconciler             bool
+	EnableDatabaseCredentials            bool
 	EnableEgressNetworkPolicyReconcilers bool
 	EnableAWSPolicy                      bool
 }
@@ -127,7 +127,7 @@ func NewIntentsReconciler(
 		intentsReconciler.group.AddToGroup(otterizeCloudReconciler)
 	}
 
-	if enforcementConfig.EnableDatabaseReconciler {
+	if enforcementConfig.EnableDatabaseCredentials {
 		databaseReconciler := database.NewDatabaseReconciler(client, scheme, otterizeClient)
 		intentsReconciler.group.AddToGroup(databaseReconciler)
 	}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -109,7 +109,7 @@ func main() {
 		EnableNetworkPolicy:                  viper.GetBool(operatorconfig.EnableNetworkPolicyKey),
 		EnableKafkaACL:                       viper.GetBool(operatorconfig.EnableKafkaACLKey),
 		EnableIstioPolicy:                    viper.GetBool(operatorconfig.EnableIstioPolicyKey),
-		EnableDatabaseReconciler:             viper.GetBool(operatorconfig.EnableDatabaseReconciler),
+		EnableDatabaseCredentials:            viper.GetBool(operatorconfig.EnableDatabaseCredentials),
 		EnableEgressNetworkPolicyReconcilers: viper.GetBool(operatorconfig.EnableEgressNetworkPolicyReconcilersKey),
 		EnableAWSPolicy:                      viper.GetBool(operatorconfig.EnableAWSPolicyKey),
 	}

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -40,8 +40,8 @@ const (
 	IntentsOperatorPodNameKey                   = "pod-name"
 	IntentsOperatorPodNamespaceKey              = "pod-namespace"
 	EnvPrefix                                   = "OTTERIZE"
-	EnableDatabaseReconciler                    = "enable-database-reconciler" // Whether to enable the new database reconciler
-	EnableDatabaseReconcilerDefault             = true
+	EnableDatabaseCredentials                   = "enable-database-credentials-creation" // Whether to enable the new database reconciler
+	EnableDatabaseCredentialsDefault            = true
 	RetryDelayTimeKey                           = "retry-delay-time" // Default retry delay time for retrying failed requests
 	RetryDelayTimeDefault                       = 5 * time.Second
 	DebugLogKey                                 = "debug" // Whether to enable debug logging
@@ -92,7 +92,7 @@ func InitCLIFlags() {
 	pflag.Bool(telemetriesconfig.TelemetryEnabledKey, telemetriesconfig.TelemetryEnabledDefault, "When set to false, all telemetries are disabled")
 	pflag.Bool(telemetriesconfig.TelemetryUsageEnabledKey, telemetriesconfig.TelemetryUsageEnabledDefault, "Whether usage telemetry should be enabled")
 	pflag.Bool(telemetriesconfig.TelemetryErrorsEnabledKey, telemetriesconfig.TelemetryErrorEnabledDefault, "Whether errors telemetry should be enabled")
-	pflag.Bool(EnableDatabaseReconciler, EnableDatabaseReconcilerDefault, "Enable the database reconciler")
+	pflag.Bool(EnableDatabaseCredentials, EnableDatabaseCredentialsDefault, "Enable the database reconciler")
 	pflag.Bool(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault, "Experimental - enable the generation of egress network policies alongside ingress network policies")
 	pflag.Duration(RetryDelayTimeKey, RetryDelayTimeDefault, "Default retry delay time for retrying failed requests")
 	pflag.Bool(EnableAWSPolicyKey, EnableAWSPolicyDefault, "Enable the AWS IAM reconciler")


### PR DESCRIPTION
### Description
Change the flag name so it's consistent with the other reconcilers flags.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs - https://github.com/otterize/docs/pull/183
