### PR TITLE
Fix multiplatform release publish

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -32,12 +32,18 @@ jobs:
         with:
           driver-opts: network=host
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: otterize
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build operator release image with tag as version
         uses: docker/build-push-action@v2
         with:
           context: src/
           file: src/release.Dockerfile
-          tags: ${{ env.REGISTRY }}/intents-operator:${{ github.ref_name }}
+          tags: otterize/intents-operator:${{ github.ref_name }},otterize/intents-operator:latest
           push: true
           network: host
           platforms: linux/amd64,linux/arm64
@@ -46,21 +52,6 @@ jobs:
           build-args: |
             "VERSION=${{ github.ref_name }}"
             "SOURCE_IMAGE=${{ env.REGISTRY }}/intents-operator:${{ github.sha }}"
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: otterize
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-
-      - name: Push to Docker Hub
-        run: |-
-          docker pull ${{ env.REGISTRY }}/intents-operator:${{ github.ref_name }}
-          docker tag ${{ env.REGISTRY }}/intents-operator:${{ github.ref_name }} otterize/intents-operator:${{ github.ref_name }}
-          docker tag ${{ env.REGISTRY }}/intents-operator:${{ github.ref_name }} otterize/intents-operator:latest
-          docker push otterize/intents-operator:${{ github.ref_name }}
-          docker push otterize/intents-operator:latest
 
   commit-latest-build-tag-to-helm-chart:
     name: Commit Latest Build Tag


### PR DESCRIPTION
### Description

Previously, we would `docker tag` and `docker push`, which does not work with multiplatform. This now uses `docker buildx` to push.