### PR TITLE
Fix bug: Operator generates Istio policy for service intents instead of ignoring

### DIFF
--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -317,7 +317,7 @@ func (c *PolicyManagerImpl) createOrUpdatePolicies(
 	updatedPolicies := goset.NewSet[PolicyID]()
 	createdAnyPolicies := false
 	for _, intent := range clientIntents.GetCallsList() {
-		if intent.Type != "" && intent.Type != v1alpha3.IntentTypeHTTP {
+		if intent.Type != "" && intent.Type != v1alpha3.IntentTypeHTTP || intent.IsTargetServerKubernetesService() {
 			continue
 		}
 		shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(

--- a/src/operator/controllers/istiopolicy/policy_manager_test.go
+++ b/src/operator/controllers/istiopolicy/policy_manager_test.go
@@ -195,7 +195,7 @@ func (s *PolicyManagerTestSuite) TestCreateIstioEnforcementDisabledNoProtectedSe
 	s.ExpectEvent(consts.ReasonIstioPolicyCreationDisabled)
 }
 
-func (s *PolicyManagerTestSuite) TestCreateIstioDisabledK8sServiceIntents() {
+func (s *PolicyManagerTestSuite) TestCreateIstioIgnoreK8sServiceIntents() {
 	s.admin.enableIstioPolicyCreation = false
 	clientName := "test-client"
 	serverName := "svc:otterservice.otternamespace"

--- a/src/operator/controllers/istiopolicy/policy_manager_test.go
+++ b/src/operator/controllers/istiopolicy/policy_manager_test.go
@@ -195,6 +195,41 @@ func (s *PolicyManagerTestSuite) TestCreateIstioEnforcementDisabledNoProtectedSe
 	s.ExpectEvent(consts.ReasonIstioPolicyCreationDisabled)
 }
 
+func (s *PolicyManagerTestSuite) TestCreateIstioDisabledK8sServiceIntents() {
+	s.admin.enableIstioPolicyCreation = false
+	clientName := "test-client"
+	serverName := "svc:otterservice.otternamespace"
+	policyName := "authorization-policy-to-test-server-from-test-client.test-namespace"
+	clientIntentsNamespace := "test-namespace"
+
+	intents := &v1alpha3.ClientIntents{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      policyName,
+			Namespace: clientIntentsNamespace,
+			Labels: map[string]string{
+				v1alpha2.OtterizeServerLabelKey:           "test-server-test-namespace-8ddecb",
+				v1alpha2.OtterizeIstioClientAnnotationKey: "test-client-test-namespace-537e87",
+			},
+		},
+		Spec: &v1alpha3.IntentsSpec{
+			Service: v1alpha3.Service{
+				Name: clientName,
+			},
+			Calls: []v1alpha3.Intent{
+				{
+					Name: serverName,
+				},
+			},
+		},
+	}
+	clientServiceAccountName := "test-client-sa"
+
+	s.Client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(client.MatchingLabels{})).Return(nil)
+
+	err := s.admin.Create(context.Background(), intents, clientServiceAccountName)
+	s.NoError(err)
+}
+
 func (s *PolicyManagerTestSuite) TestCreateProtectedServiceIstioEnforcementDisabled() {
 	s.admin.enableIstioPolicyCreation = false
 	clientName := "test-client"


### PR DESCRIPTION
### Description

Istio policy enforcement doesn't support k8s service intents (a.k.a. servers with prefix `svc:`) and should be ignored just like ingress network policy.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
