### PR TITLE
Fix bug: Generate policy with no pod selector for service without pod instead of returning error

### DIFF
--- a/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
@@ -298,6 +298,9 @@ func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(
 	formattedClient := otterizev1alpha3.GetFormattedOtterizeIdentity(intentsObj.GetServiceName(), intentsObj.Namespace)
 	formattedTargetServer := otterizev1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObj.Namespace))
 	podSelector := r.buildPodLabelSelectorFromIntents(intentsObj)
+	if svc.Spec.Selector == nil {
+		return nil, fmt.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
+	}
 	svcPodSelector := metav1.LabelSelector{MatchLabels: svc.Spec.Selector}
 	netpol := &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy_test.go
@@ -136,6 +136,70 @@ func (s *NetworkPolicyReconcilerTestSuite) networkPolicyTemplate(
 	return netpol
 }
 
+func (s *NetworkPolicyReconcilerTestSuite) TestErrorWhenKubernetesServiceWithNoPods() {
+	clientIntentsName := "client-intents"
+	serviceName := "test-client"
+	serverNamespace := testNamespace
+
+	namespacedName := types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      clientIntentsName,
+	}
+	req := ctrl.Request{
+		NamespacedName: namespacedName,
+	}
+
+	serverName := "svc:test-server"
+	serverCall := fmt.Sprintf("%s.%s", serverName, serverNamespace)
+	intentsSpec := &otterizev1alpha3.IntentsSpec{
+		Service: otterizev1alpha3.Service{Name: serviceName},
+		Calls: []otterizev1alpha3.Intent{
+			{
+				Name: serverCall,
+			},
+		},
+	}
+
+	// Initial call to get the ClientIntents object when reconciler starts
+	emptyIntents := &otterizev1alpha3.ClientIntents{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyIntents)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, intents *otterizev1alpha3.ClientIntents, options ...client.ListOption) error {
+			intents.Spec = intentsSpec
+			return nil
+		})
+
+	serverStrippedSVCPrefix := strings.ReplaceAll(serverName, "svc:", "")
+	kubernetesSvcNamespacedName := types.NamespacedName{
+		Namespace: serverNamespace,
+		Name:      serverStrippedSVCPrefix,
+	}
+	svcObject := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverStrippedSVCPrefix,
+			Namespace: serverNamespace,
+		},
+
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.IntOrString{
+					IntVal: int32(443),
+				},
+			}},
+		},
+	}
+
+	s.Client.EXPECT().Get(gomock.Any(), kubernetesSvcNamespacedName, gomock.AssignableToTypeOf(&svcObject)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, service *corev1.Service, options ...client.ListOption) error {
+			svcObject.DeepCopyInto(service)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Error(err)
+	s.Empty(res)
+	s.ExpectEvent(consts.ReasonCreatingEgressNetworkPoliciesFailed)
+}
+
 func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyKubernetesService() {
 	clientIntentsName := "client-intents"
 	policyName := "svc-egress-to-test-server.test-namespace-from-test-client"

--- a/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
@@ -417,6 +417,9 @@ func (r *PortNetworkPolicyReconciler) buildNetworkPolicyObjectForIntent(
 	targetNamespace := intent.GetTargetServerNamespace(intentsObjNamespace)
 	// The intent's target server made of name + namespace + hash
 	formattedTargetServer := otterizev1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), targetNamespace)
+	if svc.Spec.Selector == nil {
+		return nil, fmt.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
+	}
 	podSelector := metav1.LabelSelector{MatchLabels: svc.Spec.Selector}
 
 	netpol := &v1.NetworkPolicy{

--- a/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy_test.go
@@ -249,6 +249,70 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyKubernetesServ
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
 
+func (s *NetworkPolicyReconcilerTestSuite) TestErrorWhenKubernetesServiceWithNoPods() {
+	clientIntentsName := "client-intents"
+	serviceName := "test-client"
+	serverNamespace := testNamespace
+
+	namespacedName := types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      clientIntentsName,
+	}
+	req := ctrl.Request{
+		NamespacedName: namespacedName,
+	}
+
+	serverName := "svc:test-server"
+	serverCall := fmt.Sprintf("%s.%s", serverName, serverNamespace)
+	intentsSpec := &otterizev1alpha3.IntentsSpec{
+		Service: otterizev1alpha3.Service{Name: serviceName},
+		Calls: []otterizev1alpha3.Intent{
+			{
+				Name: serverCall,
+			},
+		},
+	}
+
+	// Initial call to get the ClientIntents object when reconciler starts
+	emptyIntents := &otterizev1alpha3.ClientIntents{}
+	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.Eq(emptyIntents)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, intents *otterizev1alpha3.ClientIntents, options ...client.ListOption) error {
+			intents.Spec = intentsSpec
+			return nil
+		})
+
+	serverStrippedSVCPrefix := strings.ReplaceAll(serverName, "svc:", "")
+	kubernetesSvcNamespacedName := types.NamespacedName{
+		Namespace: serverNamespace,
+		Name:      serverStrippedSVCPrefix,
+	}
+	svcObject := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverStrippedSVCPrefix,
+			Namespace: serverNamespace,
+		},
+
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{
+				TargetPort: intstr.IntOrString{
+					IntVal: int32(443),
+				},
+			}},
+		},
+	}
+
+	s.Client.EXPECT().Get(gomock.Any(), kubernetesSvcNamespacedName, gomock.AssignableToTypeOf(&svcObject)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, service *corev1.Service, options ...client.ListOption) error {
+			svcObject.DeepCopyInto(service)
+			return nil
+		})
+
+	res, err := s.Reconciler.Reconcile(context.Background(), req)
+	s.Error(err)
+	s.Empty(res)
+	s.ExpectEvent(consts.ReasonCreatingNetworkPoliciesFailed)
+}
+
 func (s *NetworkPolicyReconcilerTestSuite) addExpectedKubernetesServiceCall(serverName string, port int, selector map[string]string) *corev1.Service {
 	serverStrippedSVCPrefix := strings.ReplaceAll(serverName, "svc:", "")
 	kubernetesSvcNamespacedName := types.NamespacedName{


### PR DESCRIPTION
### Description

The operator doesn't support intents for services without pods, so intents to those services should result in error and should not generate intents

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
