### PR TITLE
Support applying intents to API server "kubernetes" service, even when it doesn't have a pod

### DIFF
--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -80,6 +80,8 @@ const (
 	OtterizeEgressNetworkPolicyTarget                    = "intents.otterize.com/egress-network-policy-target"
 	OtterizeInternetNetworkPolicy                        = "intents.otterize.com/egress-internet-network-policy"
 	OtterizeInternetTargetName                           = "internet"
+	KubernetesAPIServerName                              = "kubernetes"
+	KubernetesAPIServerNamespace                         = "default"
 )
 
 // +kubebuilder:validation:Enum=http;kafka;database;aws;internet
@@ -280,6 +282,11 @@ func (in *Intent) GetTargetServerNamespace(intentsObjNamespace string) string {
 
 func (in *Intent) IsTargetServerKubernetesService() bool {
 	return strings.HasPrefix(in.Name, "svc:")
+}
+
+func (in *Intent) IsTargetTheKubernetesAPIServer(objectNamespace string) bool {
+	return in.GetTargetServerName() == KubernetesAPIServerName &&
+		in.GetTargetServerNamespace(objectNamespace) == KubernetesAPIServerNamespace
 }
 
 // GetTargetServerName returns server's service name, without namespace, or the Kubernetes service without the `svc:` prefix

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -222,7 +222,8 @@ func (r *IntentsReconciler) getIntentsToAPIServerService() []otterizev1alpha3.Cl
 		&client.MatchingFields{otterizev1alpha3.OtterizeTargetServerIndexField: fullServerName},
 	)
 	if err != nil {
-		logrus.Errorf("Failed to list client intents for client %s: %v", fullServerName, err)
+		logrus.WithError(err).Errorf("Failed to list client intents for client %s", fullServerName)
+		return nil
 	}
 	logrus.Infof("Enqueueing client intents %v for api server", intentsToServer.Items)
 

--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
@@ -88,6 +88,13 @@ func (r *OtterizeCloudReconciler) convertK8sServicesToOtterizeIdentities(
 				callList = append(callList, intent)
 				continue
 			}
+			if intent.IsTargetTheKubernetesAPIServer(clientIntent.Namespace) {
+				intentCopy := intent.DeepCopy()
+				intentCopy.Name = intent.GetServerFullyQualifiedName(clientIntent.Namespace)
+				callList = append(callList, intent)
+				continue
+			}
+
 			svc := corev1.Service{}
 			kubernetesSvcName := intent.GetTargetServerName()
 			kubernetesSvcNamespace := intent.GetTargetServerNamespace(clientIntent.Namespace)

--- a/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
@@ -307,6 +307,7 @@ func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(c
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}
+	} else {
 		return nil, fmt.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
 	}
 

--- a/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_egress_network_policy/port_egress_network_policy.go
@@ -6,6 +6,7 @@ import (
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/prometheus"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
@@ -145,7 +146,7 @@ func (r *PortEgressNetworkPolicyReconciler) handleNetworkPolicyCreation(
 	}
 	existingPolicy := &v1.NetworkPolicy{}
 	policyName := fmt.Sprintf(otterizev1alpha3.OtterizeSvcEgressNetworkPolicyNameTemplate, intent.GetServerFullyQualifiedName(intentsObj.Namespace), intentsObj.GetServiceName())
-	newPolicy, err := r.buildNetworkPolicyObjectForIntents(&svc, intentsObj, intent, policyName)
+	newPolicy, err := r.buildNetworkPolicyObjectForIntents(ctx, &svc, intentsObj, intent, policyName)
 	if err != nil {
 		return false, err
 	}
@@ -292,16 +293,23 @@ func (r *PortEgressNetworkPolicyReconciler) deleteNetworkPolicy(
 }
 
 // buildNetworkPolicyObjectForIntents builds the network policy that represents the intent from the parameter
-func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(
-	svc *corev1.Service, intentsObj *otterizev1alpha3.ClientIntents, intent otterizev1alpha3.Intent, policyName string) (*v1.NetworkPolicy, error) {
+func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(ctx context.Context, svc *corev1.Service, intentsObj *otterizev1alpha3.ClientIntents, intent otterizev1alpha3.Intent, policyName string) (*v1.NetworkPolicy, error) {
 	// The intent's target server made of name + namespace + hash
 	formattedClient := otterizev1alpha3.GetFormattedOtterizeIdentity(intentsObj.GetServiceName(), intentsObj.Namespace)
 	formattedTargetServer := otterizev1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObj.Namespace))
-	podSelector := r.buildPodLabelSelectorFromIntents(intentsObj)
-	if svc.Spec.Selector == nil {
+	clientPodSelector := r.buildPodLabelSelectorFromIntents(intentsObj)
+	var egressRule v1.NetworkPolicyEgressRule
+	var err error
+	if svc.Spec.Selector != nil {
+		egressRule = getPodSelectorRule(svc, intentsObj, intent)
+	} else if intent.IsTargetTheKubernetesAPIServer(intentsObj.Namespace) {
+		egressRule, err = r.getIPRuleFromEndpoint(ctx, svc)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
 		return nil, fmt.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
 	}
-	svcPodSelector := metav1.LabelSelector{MatchLabels: svc.Spec.Selector}
+
 	netpol := &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyName,
@@ -317,18 +325,23 @@ func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(
 		},
 		Spec: v1.NetworkPolicySpec{
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
-			PodSelector: podSelector,
-			Egress: []v1.NetworkPolicyEgressRule{
-				{
-					To: []v1.NetworkPolicyPeer{
-						{
-							PodSelector: &svcPodSelector,
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									otterizev1alpha3.KubernetesStandardNamespaceNameLabelKey: intent.GetTargetServerNamespace(intentsObj.Namespace),
-								},
-							},
-						},
+			PodSelector: clientPodSelector,
+			Egress:      []v1.NetworkPolicyEgressRule{egressRule},
+		},
+	}
+
+	return netpol, nil
+}
+
+func getPodSelectorRule(svc *corev1.Service, intentsObj *otterizev1alpha3.ClientIntents, intent otterizev1alpha3.Intent) v1.NetworkPolicyEgressRule {
+	svcPodSelector := metav1.LabelSelector{MatchLabels: svc.Spec.Selector}
+	podSelectorEgressRule := v1.NetworkPolicyEgressRule{
+		To: []v1.NetworkPolicyPeer{
+			{
+				PodSelector: &svcPodSelector,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						otterizev1alpha3.KubernetesStandardNamespaceNameLabelKey: intent.GetTargetServerNamespace(intentsObj.Namespace),
 					},
 				},
 			},
@@ -356,10 +369,56 @@ func (r *PortEgressNetworkPolicyReconciler) buildNetworkPolicyObjectForIntents(
 		networkPolicyPorts = append(networkPolicyPorts, netpolPort)
 	}
 
-	// Add ports to network policy spec
-	netpol.Spec.Egress[0].Ports = networkPolicyPorts
+	podSelectorEgressRule.Ports = networkPolicyPorts
 
-	return netpol, nil
+	return podSelectorEgressRule
+}
+
+func (r *PortEgressNetworkPolicyReconciler) getIPRuleFromEndpoint(ctx context.Context, svc *corev1.Service) (v1.NetworkPolicyEgressRule, error) {
+	ipAddresses := make([]string, 0)
+	ports := make([]v1.NetworkPolicyPort, 0)
+
+	var endpoint corev1.Endpoints
+	err := r.Client.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, &endpoint)
+	if err != nil {
+		return v1.NetworkPolicyEgressRule{}, errors.Wrap(err)
+	}
+
+	if len(endpoint.Subsets) == 0 {
+		return v1.NetworkPolicyEgressRule{}, fmt.Errorf("no endpoints found for service %s/%s", svc.Namespace, svc.Name)
+	}
+
+	for _, subset := range endpoint.Subsets {
+		for _, address := range subset.Addresses {
+			ipAddresses = append(ipAddresses, address.IP)
+		}
+		for _, port := range subset.Ports {
+			ports = append(ports, v1.NetworkPolicyPort{
+				Port:     &intstr.IntOrString{IntVal: port.Port},
+				Protocol: lo.ToPtr(port.Protocol),
+			})
+		}
+	}
+
+	if len(ipAddresses) == 0 {
+		return v1.NetworkPolicyEgressRule{}, fmt.Errorf("no endpoints found for service %s/%s", svc.Namespace, svc.Name)
+	}
+
+	podSelectorEgressRule := v1.NetworkPolicyEgressRule{}
+	for _, ip := range ipAddresses {
+		podSelectorEgressRule.To = append(podSelectorEgressRule.To, v1.NetworkPolicyPeer{
+			IPBlock: &v1.IPBlock{
+				CIDR:   fmt.Sprintf("%s/32", ip),
+				Except: nil,
+			},
+		})
+	}
+
+	if len(ports) > 0 {
+		podSelectorEgressRule.Ports = ports
+	}
+
+	return podSelectorEgressRule, nil
 }
 
 func (r *PortEgressNetworkPolicyReconciler) buildPodLabelSelectorFromIntents(intentsObj *otterizev1alpha3.ClientIntents) metav1.LabelSelector {

--- a/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/port_network_policy/port_network_policy.go
@@ -99,6 +99,11 @@ func (r *PortNetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if !intent.IsTargetServerKubernetesService() {
 			continue
 		}
+		if intent.IsTargetTheKubernetesAPIServer(intents.Namespace) {
+			// Currently only egress is supported for the kubernetes API server
+			continue
+		}
+
 		targetNamespace := intent.GetTargetServerNamespace(req.Namespace)
 		if len(r.RestrictToNamespaces) != 0 && !lo.Contains(r.RestrictToNamespaces, targetNamespace) {
 			// Namespace is not in list of namespaces we're allowed to act in, so drop it.

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -106,7 +106,6 @@ type AccessGraphEdge {
 	client: Service!
 	server: Service!
 	discoveredIntents: [Intent!]!
-	externalTrafficDiscoveredIntents: [ExternalTrafficIntent!]!
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 }
@@ -283,11 +282,6 @@ enum DBPermissionChange {
 	DELETE
 }
 
-type DNSIPPair {
-	dnsName: String!
-	ips: [String!]
-}
-
 input DNSIPPairInput {
 	dnsName: String!
 	ips: [String!]
@@ -319,14 +313,14 @@ type DatabaseInfo {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentials!
-	logConsumerSettings: GCPCloudSQLConsumerSettings
+	visibility: DatabaseVisibilitySettings
 }
 
 input DatabaseInfoInput {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!
-	logConsumerSettings: GCPCloudSQLConsumerSettingsInput
+	visibility: DatabaseVisibilitySettingsInput
 }
 
 enum DatabaseOperation {
@@ -339,6 +333,20 @@ enum DatabaseOperation {
 
 enum DatabaseType {
 	POSTGRESQL
+}
+
+type DatabaseVisibilitySettings {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettings
+}
+
+input DatabaseVisibilitySettingsInput {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettingsInput
+}
+
+enum DatabaseVisibilitySource {
+	GCP_PUBSUB
 }
 
 input DiscoveredIntentInput {
@@ -440,13 +448,6 @@ input ExternalTrafficDiscoveredIntentInput {
 	intent: ExternalTrafficIntentInput!
 }
 
-type ExternalTrafficIntent {
-	id: ID!
-	server: Service!
-	client: Service!
-	target: DNSIPPair!
-}
-
 input ExternalTrafficIntentInput {
 	namespace: String!
 	clientName: String!
@@ -456,12 +457,12 @@ input ExternalTrafficIntentInput {
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
 
-type GCPCloudSQLConsumerSettings {
+type GCPPubSubLogConsumerSettings {
 	projectId: String!
 	topic: String!
 }
 
-input GCPCloudSQLConsumerSettingsInput {
+input GCPPubSubLogConsumerSettingsInput {
 	projectId: String!
 	topic: String!
 }
@@ -560,6 +561,7 @@ type Intent {
 	httpResources: [HTTPConfig!]
 	databaseResources: [DatabaseConfig!]
 	awsActions: [String!]
+	internet: InternetConfig
 	status: IntentStatus
 }
 
@@ -618,6 +620,12 @@ input IntentsOperatorConfigurationInput {
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
+}
+
+type InternetConfig {
+	dnsName: String!
+	ips: [String!]
+	ports: [Int!]
 }
 
 input InternetConfigInput {
@@ -1050,6 +1058,10 @@ type Query {
 		databaseInfo: DatabaseInfoInput!
 		integrationId: ID
 	): TestDatabaseConnectionResponse!
+"""Test database visibility connectivity"""
+	testDatabaseVisibilityConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
 """List user invites"""
 	invites(
 		email: String
@@ -1088,6 +1100,8 @@ type Query {
 	organization(
 		id: ID!
 	): Organization!
+"""Checks the availability of the API server"""
+	ping: Boolean!
 """Get service"""
 	service(
 		id: ID!
@@ -1173,6 +1187,7 @@ enum ServerProtectionStatusReason {
 	IGNORED_IN_CALCULATION
 	PROTECTED_BY_DATABASE_INTEGRATION
 	PROTECTED_BY_AWS_IAM_INTEGRATION
+	PROTECTED_BY_INTERNET_INTENTS
 }
 
 enum ServerProtectionStatusVerdict {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -106,7 +106,6 @@ type AccessGraphEdge {
 	client: Service!
 	server: Service!
 	discoveredIntents: [Intent!]!
-	externalTrafficDiscoveredIntents: [ExternalTrafficIntent!]!
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 }
@@ -283,11 +282,6 @@ enum DBPermissionChange {
 	DELETE
 }
 
-type DNSIPPair {
-	dnsName: String!
-	ips: [String!]
-}
-
 input DNSIPPairInput {
 	dnsName: String!
 	ips: [String!]
@@ -319,14 +313,14 @@ type DatabaseInfo {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentials!
-	logConsumerSettings: GCPCloudSQLConsumerSettings
+	visibility: DatabaseVisibilitySettings
 }
 
 input DatabaseInfoInput {
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!
-	logConsumerSettings: GCPCloudSQLConsumerSettingsInput
+	visibility: DatabaseVisibilitySettingsInput
 }
 
 enum DatabaseOperation {
@@ -339,6 +333,20 @@ enum DatabaseOperation {
 
 enum DatabaseType {
 	POSTGRESQL
+}
+
+type DatabaseVisibilitySettings {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettings
+}
+
+input DatabaseVisibilitySettingsInput {
+	source: DatabaseVisibilitySource
+	gcpPubSub: GCPPubSubLogConsumerSettingsInput
+}
+
+enum DatabaseVisibilitySource {
+	GCP_PUBSUB
 }
 
 input DiscoveredIntentInput {
@@ -440,13 +448,6 @@ input ExternalTrafficDiscoveredIntentInput {
 	intent: ExternalTrafficIntentInput!
 }
 
-type ExternalTrafficIntent {
-	id: ID!
-	server: Service!
-	client: Service!
-	target: DNSIPPair!
-}
-
 input ExternalTrafficIntentInput {
 	namespace: String!
 	clientName: String!
@@ -456,12 +457,12 @@ input ExternalTrafficIntentInput {
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
 
-type GCPCloudSQLConsumerSettings {
+type GCPPubSubLogConsumerSettings {
 	projectId: String!
 	topic: String!
 }
 
-input GCPCloudSQLConsumerSettingsInput {
+input GCPPubSubLogConsumerSettingsInput {
 	projectId: String!
 	topic: String!
 }
@@ -560,6 +561,7 @@ type Intent {
 	httpResources: [HTTPConfig!]
 	databaseResources: [DatabaseConfig!]
 	awsActions: [String!]
+	internet: InternetConfig
 	status: IntentStatus
 }
 
@@ -618,6 +620,12 @@ input IntentsOperatorConfigurationInput {
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
+}
+
+type InternetConfig {
+	dnsName: String!
+	ips: [String!]
+	ports: [Int!]
 }
 
 input InternetConfigInput {
@@ -1050,6 +1058,10 @@ type Query {
 		databaseInfo: DatabaseInfoInput!
 		integrationId: ID
 	): TestDatabaseConnectionResponse!
+"""Test database visibility connectivity"""
+	testDatabaseVisibilityConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
 """List user invites"""
 	invites(
 		email: String
@@ -1088,6 +1100,8 @@ type Query {
 	organization(
 		id: ID!
 	): Organization!
+"""Checks the availability of the API server"""
+	ping: Boolean!
 """Get service"""
 	service(
 		id: ID!
@@ -1173,6 +1187,7 @@ enum ServerProtectionStatusReason {
 	IGNORED_IN_CALCULATION
 	PROTECTED_BY_DATABASE_INTEGRATION
 	PROTECTED_BY_AWS_IAM_INTEGRATION
+	PROTECTED_BY_INTERNET_INTENTS
 }
 
 enum ServerProtectionStatusVerdict {


### PR DESCRIPTION
### Description

It's a common implementation to have the control plane API server service with no pod, just an endpoint mapped to a server outside of the cluster network. Since egress enforcement requires explicitly enabling access to the API server, this PR allow the user to declare intents to the service in the format: `svc:kubernetes.default`, and the result will be an egress network policy to the server IP address and port.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

Egress network policy is an experimental feature, full documentation will be available on official release.

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
