### PR TITLE
Add RBAC read permissions of `batch/jobs` and `batch/cronjobs` for Otterize service id resolving

### DIFF
--- a/src/operator/config/rbac/role.yaml
+++ b/src/operator/config/rbac/role.yaml
@@ -84,6 +84,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - k8s.otterize.com
   resources:
   - clientintents

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -19,6 +19,7 @@ import (
 var ErrPodNotFound = errors.New("pod not found")
 
 //+kubebuilder:rbac:groups="apps",resources=deployments;replicasets;daemonsets;statefulsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch
 
 type ServiceResolver interface {
 	GetPodAnnotatedName(ctx context.Context, podName string, podNamespace string) (string, bool, error)


### PR DESCRIPTION

### Description

Until this PR if one chose to install Otterize with `--set global.allowGetAllResources` set to `false`,  Otterize failed to resolve the root owner of pods created by jobs and cronJobs. In this PR I added the relevant kubebuilder magic to the `serviceidresolver` package, and generated new clusterRoles. 

