### PR TITLE
Set permission boundary for new AWS intents roles

### DIFF
--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -82,7 +82,8 @@ func (a *Agent) CreateOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 					Value: aws.String(a.clusterName),
 				},
 			},
-			Description: aws.String(iamRoleDescription),
+			Description:         aws.String(iamRoleDescription),
+			PermissionsBoundary: aws.String(fmt.Sprintf("arn:aws:iam::%s:policy/%s-limit-iam-permission-boundary", a.accountID, a.clusterName)),
 		})
 
 		if createRoleError != nil {


### PR DESCRIPTION
### Description

Sets a "permission boundary" for AWS roles. Permission boundaries are an additional limit on IAM roles. They are used to ensure roles, created by credential-operator for example, do not have excessive permissions.

References:
https://github.com/otterize/intents-operator/pull/337