### PR TITLE
Avoid labeling pods if network policy creation is disabled

### DIFF
--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -164,6 +164,11 @@ func (p *PodWatcher) updateServerSideCar(ctx context.Context, pod v1.Pod, servic
 }
 
 func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request, serviceID serviceidentity.ServiceIdentity, pod v1.Pod) error {
+	if !viper.GetBool(operatorconfig.EnableNetworkPolicyKey) {
+		logrus.Debug("Not labeling new pod since network policy creation is disabled")
+		return nil
+	}
+
 	// Intents were deleted and the pod was updated by the operator, skip reconciliation
 	_, ok := pod.Annotations[otterizev1alpha3.AllIntentsRemovedAnnotation]
 	if ok {


### PR DESCRIPTION
Prior to this PR, the intents operator would always label pods, even if network policies are not being managed by the intents operator.