### PR TITLE
Introduce a new type: `serviceEffectivePolicy` as a better abstraction than ClientIntents for reconciliation. Implement `EffectivePolicyReconciler` for ingress network policies.

### DIFF
--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -294,6 +294,17 @@ func (in *Intent) IsTargetTheKubernetesAPIServer(objectNamespace string) bool {
 		in.GetTargetServerNamespace(objectNamespace) == KubernetesAPIServerNamespace
 }
 
+func (in *Intent) IsTargetInCluster() bool {
+	if in.Type == "" || in.Type == IntentTypeHTTP || in.Type == IntentTypeKafka {
+		return true
+	}
+	return false
+}
+
+func (in *Intent) IsTargetOutOfCluster() bool {
+	return !in.IsTargetInCluster()
+}
+
 // GetTargetServerName returns server's service name, without namespace, or the Kubernetes service without the `svc:` prefix
 func (in *Intent) GetTargetServerName() string {
 	var name string

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -23,14 +23,12 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/database"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/egress_network_policy"
-	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/ingress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/internet_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_egress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/protected_services"
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/otterize/intents-operator/src/shared/initonce"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -70,17 +68,14 @@ type EnforcementConfig struct {
 
 // IntentsReconciler reconciles a Intents object
 type IntentsReconciler struct {
-	group                   *reconcilergroup.Group
-	client                  client.Client
-	initOnce                initonce.InitOnce
-	networkPolicyReconciler *ingress_network_policy.NetworkPolicyReconciler
+	group  *reconcilergroup.Group
+	client client.Client
 }
 
 func NewIntentsReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	kafkaServerStore kafkaacls.ServersStore,
-	networkPolicyReconciler *ingress_network_policy.NetworkPolicyReconciler,
 	portNetpolReconciler *port_network_policy.PortNetworkPolicyReconciler,
 	egressNetpolReconciler *egress_network_policy.EgressNetworkPolicyReconciler,
 	portEgressNetpolReconciler *port_egress_network_policy.PortEgressNetworkPolicyReconciler,
@@ -98,7 +93,6 @@ func NewIntentsReconciler(
 		intents_reconcilers.NewPodLabelReconciler(client, scheme),
 		intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState, operatorPodName, operatorPodNamespace, serviceIdResolver),
 		intents_reconcilers.NewIstioPolicyReconciler(client, scheme, restrictToNamespaces, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementDefaultState),
-		networkPolicyReconciler,
 	}
 	reconcilers = append(reconcilers, additionalReconcilers...)
 	reconcilersGroup := reconcilergroup.NewGroup(
@@ -114,9 +108,8 @@ func NewIntentsReconciler(
 	reconcilersGroup.AddToGroup(portNetpolReconciler)
 
 	intentsReconciler := &IntentsReconciler{
-		group:                   reconcilersGroup,
-		client:                  client,
-		networkPolicyReconciler: networkPolicyReconciler,
+		group:  reconcilersGroup,
+		client: client,
 	}
 
 	if telemetriesconfig.IsUsageTelemetryEnabled() {
@@ -155,16 +148,9 @@ func NewIntentsReconciler(
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *IntentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.initOnce.Do(func() error {
-		return r.intentsReconcilerInit(ctx)
-	})
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err)
-	}
-
 	intents := &otterizev1alpha3.ClientIntents{}
 
-	err = r.client.Get(ctx, req.NamespacedName, intents)
+	err := r.client.Get(ctx, req.NamespacedName, intents)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -198,10 +184,6 @@ func (r *IntentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return result, nil
-}
-
-func (r *IntentsReconciler) intentsReconcilerInit(ctx context.Context) error {
-	return r.networkPolicyReconciler.CleanAllNamespaces(ctx)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/src/operator/controllers/intents_controller_test.go
+++ b/src/operator/controllers/intents_controller_test.go
@@ -31,7 +31,6 @@ func (s *IntentsControllerTestSuite) SetupTest() {
 		nil,
 		nil,
 		nil,
-		nil,
 		EnforcementConfig{},
 		nil,
 		"",

--- a/src/operator/controllers/intents_reconcilers/consts/consts.go
+++ b/src/operator/controllers/intents_reconcilers/consts/consts.go
@@ -6,6 +6,7 @@ const (
 	ReasonNetworkPolicyCreationDisabled                 = "NetworkPolicyCreationDisabled"
 	ReasonGettingNetworkPolicyFailed                    = "GettingNetworkPolicyFailed"
 	ReasonRemovingNetworkPolicyFailed                   = "RemovingNetworkPolicyFailed"
+	ReasonReconcilingNetworkPolicyFailed                = "ReconcilingNetworkPolicyFailed"
 	ReasonNamespaceNotAllowed                           = "NamespaceNotAllowed"
 	ReasonCreatingNetworkPoliciesFailed                 = "CreatingNetworkPoliciesFailed"
 	ReasonCreatedNetworkPolicies                        = "CreatedNetworkPolicies"

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -8,8 +8,10 @@ import (
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers"
 	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
+	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/ingress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/pod_reconcilers"
+	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/stretchr/testify/assert"
@@ -31,10 +33,10 @@ import (
 
 type ExternalNetworkPolicyReconcilerTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
-	IngressReconciler       *external_traffic.IngressReconciler
-	endpointReconciler      external_traffic.EndpointsReconciler
-	NetworkPolicyReconciler *ingress_network_policy.NetworkPolicyReconciler
-	podWatcher              *pod_reconcilers.PodWatcher
+	IngressReconciler                *external_traffic.IngressReconciler
+	endpointReconciler               external_traffic.EndpointsReconciler
+	EffectivePolicyIntentsReconciler *intents_reconcilers.ServiceEffectivePolicyIntentsReconciler
+	podWatcher                       *pod_reconcilers.PodWatcher
 }
 
 func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupSuite() {
@@ -62,9 +64,11 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize)
-	s.NetworkPolicyReconciler = ingress_network_policy.NewNetworkPolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, true, true, allowexternaltraffic.IfBlockedByOtterize)
+	epNetpolReconciler := ingress_network_policy.NewIngressNetpolEffectivePolicyReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, true, true, allowexternaltraffic.IfBlockedByOtterize)
+	epReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, epNetpolReconciler)
+	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, epReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
-	s.NetworkPolicyReconciler.InjectRecorder(recorder)
+	s.EffectivePolicyIntentsReconciler.InjectRecorder(recorder)
 
 	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.endpointReconciler.InjectRecorder(recorder)
@@ -92,7 +96,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 	})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -146,7 +150,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -202,7 +206,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -259,7 +263,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	})
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
-		res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+		res, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: s.TestNamespace,
 				Name:      intents.Name,
@@ -272,7 +276,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	})
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
-		res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+		res, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: s.TestNamespace,
 				Name:      intents.Name,
@@ -300,7 +304,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	}})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -309,7 +313,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	s.Require().NoError(err)
 	s.Require().Empty(res)
 
-	res2, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res2, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: secondaryNamespace,
 			Name:      secondIntents.Name,
@@ -365,7 +369,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 		assert.NotNil(intentsDeleted.DeletionTimestamp)
 	})
 
-	res, err = s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -394,7 +398,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForNod
 	})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,
@@ -449,7 +453,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 	})
 	s.Require().NoError(err)
 
-	res, err := s.NetworkPolicyReconciler.Reconcile(context.Background(), ctrl.Request{
+	res, err := s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: s.TestNamespace,
 			Name:      intents.Name,

--- a/src/operator/controllers/intents_reconcilers/ingress_network_policy/ingress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/ingress_network_policy/ingress_network_policy.go
@@ -2,10 +2,13 @@ package ingress_network_policy
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/protected_services"
+	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/prometheus"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
@@ -14,16 +17,13 @@ import (
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetrysender"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"reflect"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,7 +32,7 @@ type externalNetpolHandler interface {
 	HandleBeforeAccessPolicyRemoval(ctx context.Context, accessPolicy *v1.NetworkPolicy) error
 }
 
-type NetworkPolicyReconciler struct {
+type IngressNetpolEffectivePolicyReconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
 	extNetpolHandler            externalNetpolHandler
@@ -43,7 +43,7 @@ type NetworkPolicyReconciler struct {
 	injectablerecorder.InjectableRecorder
 }
 
-func NewNetworkPolicyReconciler(
+func NewIngressNetpolEffectivePolicyReconciler(
 	c client.Client,
 	s *runtime.Scheme,
 	extNetpolHandler externalNetpolHandler,
@@ -51,8 +51,8 @@ func NewNetworkPolicyReconciler(
 	enableNetworkPolicyCreation bool,
 	enforcementDefaultState bool,
 	allowExternalTraffic allowexternaltraffic.Enum,
-) *NetworkPolicyReconciler {
-	return &NetworkPolicyReconciler{
+) *IngressNetpolEffectivePolicyReconciler {
+	return &IngressNetpolEffectivePolicyReconciler{
 		Client:                      c,
 		Scheme:                      s,
 		extNetpolHandler:            extNetpolHandler,
@@ -63,117 +63,96 @@ func NewNetworkPolicyReconciler(
 	}
 }
 
-func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	intents := &otterizev1alpha3.ClientIntents{}
-	err := r.Get(ctx, req.NamespacedName, intents)
-	if k8serrors.IsNotFound(err) {
-		return ctrl.Result{}, nil
-	}
-
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err)
-	}
-
-	if intents.Spec == nil {
-		return ctrl.Result{}, nil
-	}
-
-	logrus.Infof("Reconciling network policies for service %s in namespace %s",
-		intents.Spec.Service.Name, req.Namespace)
-
-	// Object is deleted, handle finalizer and network policy clean up
-	if !intents.DeletionTimestamp.IsZero() {
-		err := r.cleanPolicies(ctx, intents)
+// ReconcileEffectivePolicies Gets current state of effective policies and returns number of network policies
+func (r *IngressNetpolEffectivePolicyReconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy) (int, error) {
+	currentPolicies := goset.NewSet[types.NamespacedName]()
+	errorList := make([]error, 0)
+	for _, ep := range eps {
+		netpols, err := r.applyServiceEffectivePolicy(ctx, ep)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-			r.RecordWarningEventf(intents, consts.ReasonRemovingNetworkPolicyFailed, "could not remove network policies: %s", err.Error())
-			return ctrl.Result{}, errors.Wrap(err)
+			errorList = append(errorList, errors.Wrap(err))
+			continue
 		}
-		return ctrl.Result{}, nil
+		currentPolicies.Add(netpols...)
+	}
+	if len(errorList) > 0 {
+		return 0, errors.Wrap(goerrors.Join(errorList...))
 	}
 
-	createdNetpols := 0
-	for _, intent := range intents.GetCallsList() {
-		if intent.Type != "" && intent.Type != otterizev1alpha3.IntentTypeHTTP && intent.Type != otterizev1alpha3.IntentTypeKafka {
+	// remove policies that doesn't exist in the policy list
+	err := r.removeNetworkPoliciesThatShouldNotExist(ctx, currentPolicies)
+	if err != nil {
+		return currentPolicies.Len(), errors.Wrap(err)
+	}
+
+	if currentPolicies.Len() != 0 {
+		telemetrysender.SendIntentOperator(telemetriesgql.EventTypeNetworkPoliciesCreated, currentPolicies.Len())
+	}
+	return currentPolicies.Len(), nil
+}
+
+// applyServiceEffectivePolicy - reconcile ingress netpols for a service. returns the list of policies' namespaced names
+func (r *IngressNetpolEffectivePolicyReconciler) applyServiceEffectivePolicy(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy) ([]types.NamespacedName, error) {
+	shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx, r.Client, ep.Service.Name, ep.Service.Namespace, r.enforcementDefaultState)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	networkPolicies := make([]types.NamespacedName, 0)
+	for _, intentCall := range ep.CalledBy {
+		if !shouldCreatePolicy {
+			logrus.Infof("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
+			intentCall.ObjectEventRecorder.RecordNormalEventf(consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally and called service '%s' is not explicitly protected using a ProtectedService resource, network policy creation skipped", ep.Service.Name)
 			continue
 		}
-		if intent.IsTargetServerKubernetesService() {
+		if !r.enableNetworkPolicyCreation {
+			logrus.Infof("Network policy creation is disabled, skipping network policy creation for server %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
+			intentCall.ObjectEventRecorder.RecordNormalEvent(consts.ReasonNetworkPolicyCreationDisabled, "Network policy creation is disabled, creation skipped")
 			continue
 		}
-		targetNamespace := intent.GetTargetServerNamespace(req.Namespace)
-		if len(r.RestrictToNamespaces) != 0 && !lo.Contains(r.RestrictToNamespaces, targetNamespace) {
+		if len(r.RestrictToNamespaces) != 0 && !lo.Contains(r.RestrictToNamespaces, ep.Service.Namespace) {
 			// Namespace is not in list of namespaces we're allowed to act in, so drop it.
-			r.RecordWarningEventf(intents, consts.ReasonNamespaceNotAllowed, "namespace %s was specified in intent, but is not allowed by configuration", targetNamespace)
+			intentCall.ObjectEventRecorder.RecordWarningEventf(consts.ReasonNamespaceNotAllowed, "namespace %s was specified in intent, but is not allowed by configuration", ep.Service.Namespace)
 			continue
 		}
-		createdPolicies, err := r.handleNetworkPolicyCreation(ctx, intents, intent, req.Namespace)
+
+		logrus.Debugf("Server %s in namespace %s is in protected list: %t", ep.Service.Name, ep.Service.Namespace, shouldCreatePolicy)
+
+		policyName := fmt.Sprintf(otterizev1alpha3.OtterizeNetworkPolicyNameTemplate, intentCall.IntendedCall.GetTargetServerName(), intentCall.Service.Namespace)
+		existingPolicy := &v1.NetworkPolicy{}
+		newPolicy := r.buildNetworkPolicyObjectForIntent(intentCall.IntendedCall, policyName, intentCall.Service.Namespace)
+		err = r.Get(ctx, types.NamespacedName{
+			Name:      policyName,
+			Namespace: ep.Service.Namespace},
+			existingPolicy)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			r.RecordWarningEventf(existingPolicy, consts.ReasonGettingNetworkPolicyFailed, "failed to get network policy: %s", err.Error())
+			return networkPolicies, errors.Wrap(err)
+		}
+
+		if k8serrors.IsNotFound(err) {
+			err = r.createNetworkPolicy(ctx, intentCall.Service.Namespace, intentCall.IntendedCall, newPolicy)
+			if err != nil {
+				return networkPolicies, errors.Wrap(err)
+			}
+			networkPolicies = append(networkPolicies, types.NamespacedName{Name: newPolicy.Name, Namespace: newPolicy.Namespace})
+			prometheus.IncrementNetpolCreated(1)
+			intentCall.ObjectEventRecorder.RecordNormalEventf(consts.ReasonCreatedNetworkPolicies, "NetworkPolicy created for %s", intentCall.IntendedCall.GetTargetServerName())
+			continue
+		}
+		changed, err := r.updateExistingPolicy(ctx, existingPolicy, newPolicy)
 		if err != nil {
-			r.RecordWarningEventf(intents, consts.ReasonCreatingNetworkPoliciesFailed, "could not create network policies: %s", err.Error())
-			return ctrl.Result{}, errors.Wrap(err)
+			return networkPolicies, errors.Wrap(err)
 		}
-		if createdPolicies {
-			createdNetpols += 1
+		if changed {
+			intentCall.ObjectEventRecorder.RecordNormalEventf(consts.ReasonCreatedNetworkPolicies, "NetworkPolicy created for %s", intentCall.IntendedCall.GetTargetServerName())
 		}
+		networkPolicies = append(networkPolicies, types.NamespacedName{Name: newPolicy.Name, Namespace: newPolicy.Namespace})
 	}
-
-	err = r.removeOrphanNetworkPolicies(ctx)
-	if err != nil {
-		r.RecordWarningEventf(intents, consts.ReasonRemovingNetworkPolicyFailed, "failed to remove network policies: %s", err.Error())
-		return ctrl.Result{}, errors.Wrap(err)
-	}
-
-	if createdNetpols != 0 {
-		callsCount := len(intents.GetCallsList())
-		r.RecordNormalEventf(intents, consts.ReasonCreatedNetworkPolicies, "NetworkPolicy reconcile complete, reconciled %d servers", callsCount)
-		telemetrysender.SendIntentOperator(telemetriesgql.EventTypeNetworkPoliciesCreated, createdNetpols)
-		prometheus.IncrementNetpolCreated(createdNetpols)
-	}
-	return ctrl.Result{}, nil
+	return networkPolicies, nil
 }
 
-func (r *NetworkPolicyReconciler) handleNetworkPolicyCreation(
-	ctx context.Context, intentsObj *otterizev1alpha3.ClientIntents, intent otterizev1alpha3.Intent, intentsObjNamespace string) (bool, error) {
-
-	shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx, r.Client, intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObjNamespace), r.enforcementDefaultState)
-	if err != nil {
-		return false, errors.Wrap(err)
-	}
-
-	if !shouldCreatePolicy {
-		logrus.Infof("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObjNamespace))
-		r.RecordNormalEventf(intentsObj, consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally and called service '%s' is not explicitly protected using a ProtectedService resource, network policy creation skipped", intent.Name)
-		return false, nil
-	}
-	if !r.enableNetworkPolicyCreation {
-		logrus.Infof("Network policy creation is disabled, skipping network policy creation for server %s in namespace %s", intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObjNamespace))
-		r.RecordNormalEvent(intentsObj, consts.ReasonNetworkPolicyCreationDisabled, "Network policy creation is disabled, creation skipped")
-		return false, nil
-	}
-
-	logrus.Debugf("Server %s in namespace %s is in protected list: %t", intent.GetTargetServerName(), intent.GetTargetServerNamespace(intentsObjNamespace), shouldCreatePolicy)
-
-	policyName := fmt.Sprintf(otterizev1alpha3.OtterizeNetworkPolicyNameTemplate, intent.GetTargetServerName(), intentsObjNamespace)
-	existingPolicy := &v1.NetworkPolicy{}
-	newPolicy := r.buildNetworkPolicyObjectForIntent(intent, policyName, intentsObjNamespace)
-	err = r.Get(ctx, types.NamespacedName{
-		Name:      policyName,
-		Namespace: intent.GetTargetServerNamespace(intentsObjNamespace)},
-		existingPolicy)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		r.RecordWarningEventf(existingPolicy, consts.ReasonGettingNetworkPolicyFailed, "failed to get network policy: %s", err.Error())
-		return false, errors.Wrap(err)
-	}
-
-	if k8serrors.IsNotFound(err) {
-		return true, r.CreateNetworkPolicy(ctx, intentsObjNamespace, intent, newPolicy)
-	}
-
-	return true, r.UpdateExistingPolicy(ctx, existingPolicy, newPolicy, intent, intentsObjNamespace)
-}
-
-func (r *NetworkPolicyReconciler) UpdateExistingPolicy(ctx context.Context, existingPolicy *v1.NetworkPolicy, newPolicy *v1.NetworkPolicy, intent otterizev1alpha3.Intent, intentsObjNamespace string) error {
+func (r *IngressNetpolEffectivePolicyReconciler) updateExistingPolicy(ctx context.Context, existingPolicy *v1.NetworkPolicy, newPolicy *v1.NetworkPolicy) (bool, error) {
 	if !reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) {
 		policyCopy := existingPolicy.DeepCopy()
 		policyCopy.Labels = newPolicy.Labels
@@ -182,14 +161,15 @@ func (r *NetworkPolicyReconciler) UpdateExistingPolicy(ctx context.Context, exis
 
 		err := r.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
 		if err != nil {
-			return errors.Wrap(err)
+			return true, errors.Wrap(err)
 		}
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
-func (r *NetworkPolicyReconciler) CreateNetworkPolicy(ctx context.Context, intentsObjNamespace string, intent otterizev1alpha3.Intent, newPolicy *v1.NetworkPolicy) error {
+func (r *IngressNetpolEffectivePolicyReconciler) createNetworkPolicy(ctx context.Context, intentsObjNamespace string, intent otterizev1alpha3.Intent, newPolicy *v1.NetworkPolicy) error {
 	logrus.Infof(
 		"Creating network policy to enable access from namespace %s to %s", intentsObjNamespace, intent.Name)
 	err := r.Create(ctx, newPolicy)
@@ -200,7 +180,7 @@ func (r *NetworkPolicyReconciler) CreateNetworkPolicy(ctx context.Context, inten
 	return r.reconcileEndpointsForPolicy(ctx, newPolicy)
 }
 
-func (r *NetworkPolicyReconciler) reconcileEndpointsForPolicy(ctx context.Context, newPolicy *v1.NetworkPolicy) error {
+func (r *IngressNetpolEffectivePolicyReconciler) reconcileEndpointsForPolicy(ctx context.Context, newPolicy *v1.NetworkPolicy) error {
 	selector, err := metav1.LabelSelectorAsSelector(&newPolicy.Spec.PodSelector)
 	if err != nil {
 		return errors.Wrap(err)
@@ -209,64 +189,7 @@ func (r *NetworkPolicyReconciler) reconcileEndpointsForPolicy(ctx context.Contex
 	return r.extNetpolHandler.HandlePodsByLabelSelector(ctx, newPolicy.Namespace, selector)
 }
 
-func (r *NetworkPolicyReconciler) cleanPolicies(
-	ctx context.Context, intents *otterizev1alpha3.ClientIntents) error {
-	logrus.Infof("Removing network policies for deleted intents for service: %s", intents.Spec.Service.Name)
-	for _, intent := range intents.GetCallsList() {
-		if intent.Type != "" && intent.Type != otterizev1alpha3.IntentTypeHTTP && intent.Type != otterizev1alpha3.IntentTypeKafka {
-			continue
-		}
-		err := r.handleIntentRemoval(ctx, intent, intents.Namespace)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-	}
-
-	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeNetworkPoliciesDeleted, len(intents.GetCallsList()))
-	prometheus.IncrementNetpolCreated(len(intents.GetCallsList()))
-
-	return nil
-}
-
-func (r *NetworkPolicyReconciler) handleIntentRemoval(
-	ctx context.Context,
-	intent otterizev1alpha3.Intent,
-	intentsObjNamespace string) error {
-
-	var intentsList otterizev1alpha3.ClientIntentsList
-	err := r.List(
-		ctx, &intentsList,
-		&client.MatchingFields{otterizev1alpha3.OtterizeTargetServerIndexField: intent.GetServerFullyQualifiedName(intentsObjNamespace)},
-		&client.ListOptions{Namespace: intentsObjNamespace})
-
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	if len(intentsList.Items) == 1 {
-		// We have only 1 intents resource that has this server as its target - and it's the current one
-		// We need to delete the network policy that allows access from this namespace, as there are no other
-		// clients in that namespace that need to access the target server
-		logrus.Infof("No other intents in the namespace reference target server: %s", intent.Name)
-		logrus.Infoln("Removing matching network policy for server")
-		if err = r.deleteNetworkPolicy(ctx, intent, intentsObjNamespace); err != nil {
-			return errors.Wrap(err)
-		}
-
-		labelSelector := r.buildPodLabelSelectorFromIntent(intent, intentsObjNamespace)
-		selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-		if err = r.extNetpolHandler.HandlePodsByLabelSelector(ctx, intent.GetTargetServerNamespace(intentsObjNamespace), selector); err != nil {
-			return errors.Wrap(err)
-		}
-
-	}
-	return nil
-}
-
-func (r *NetworkPolicyReconciler) removeOrphanNetworkPolicies(ctx context.Context) error {
+func (r *IngressNetpolEffectivePolicyReconciler) removeNetworkPoliciesThatShouldNotExist(ctx context.Context, netpolNamesThatShouldExist *goset.Set[types.NamespacedName]) error {
 	logrus.Info("Searching for orphaned network policies")
 	networkPolicyList := &v1.NetworkPolicyList{}
 	selector, err := matchAccessNetworkPolicy()
@@ -282,21 +205,9 @@ func (r *NetworkPolicyReconciler) removeOrphanNetworkPolicies(ctx context.Contex
 
 	logrus.Infof("Selector: %s found %d network policies", selector.String(), len(networkPolicyList.Items))
 	for _, networkPolicy := range networkPolicyList.Items {
-		// Get all client intents that reference this network policy
-		var intentsList otterizev1alpha3.ClientIntentsList
-		serverName := networkPolicy.Labels[otterizev1alpha3.OtterizeNetworkPolicy]
-		clientNamespace := networkPolicy.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[otterizev1alpha3.KubernetesStandardNamespaceNameLabelKey]
-		err = r.List(
-			ctx,
-			&intentsList,
-			&client.MatchingFields{otterizev1alpha3.OtterizeFormattedTargetServerIndexField: serverName},
-			&client.ListOptions{Namespace: clientNamespace},
-		)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-
-		if len(intentsList.Items) == 0 {
+		namespacedName := types.NamespacedName{Namespace: networkPolicy.Namespace, Name: networkPolicy.Name}
+		if !netpolNamesThatShouldExist.Contains(namespacedName) {
+			serverName := networkPolicy.Labels[otterizev1alpha3.OtterizeNetworkPolicy]
 			logrus.Infof("Removing orphaned network policy: %s server %s ns %s", networkPolicy.Name, serverName, networkPolicy.Namespace)
 			err = r.removeNetworkPolicy(ctx, networkPolicy)
 			if err != nil {
@@ -308,7 +219,7 @@ func (r *NetworkPolicyReconciler) removeOrphanNetworkPolicies(ctx context.Contex
 	return nil
 }
 
-func (r *NetworkPolicyReconciler) removeNetworkPolicy(ctx context.Context, networkPolicy v1.NetworkPolicy) error {
+func (r *IngressNetpolEffectivePolicyReconciler) removeNetworkPolicy(ctx context.Context, networkPolicy v1.NetworkPolicy) error {
 	err := r.extNetpolHandler.HandleBeforeAccessPolicyRemoval(ctx, &networkPolicy)
 	if err != nil {
 		return errors.Wrap(err)
@@ -340,88 +251,8 @@ func matchAccessNetworkPolicy() (labels.Selector, error) {
 	}})
 }
 
-func (r *NetworkPolicyReconciler) deleteNetworkPolicy(
-	ctx context.Context,
-	intent otterizev1alpha3.Intent,
-	intentsObjNamespace string) error {
-
-	policyName := fmt.Sprintf(otterizev1alpha3.OtterizeNetworkPolicyNameTemplate, intent.GetTargetServerName(), intentsObjNamespace)
-	policy := &v1.NetworkPolicy{}
-	err := r.Get(ctx, types.NamespacedName{Name: policyName, Namespace: intent.GetTargetServerNamespace(intentsObjNamespace)}, policy)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrap(err)
-	}
-
-	return r.removeNetworkPolicy(ctx, *policy)
-}
-
-func (r *NetworkPolicyReconciler) CleanPoliciesFromUnprotectedServices(ctx context.Context, namespace string) error {
-	selector, err := matchAccessNetworkPolicy()
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	policies := &v1.NetworkPolicyList{}
-	err = r.List(ctx, policies, &client.ListOptions{Namespace: namespace, LabelSelector: selector})
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	if len(policies.Items) == 0 {
-		return nil
-	}
-
-	var protectedServicesResources otterizev1alpha3.ProtectedServiceList
-	err = r.List(ctx, &protectedServicesResources, &client.ListOptions{Namespace: namespace})
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	protectedServersByNamespace := sets.Set[string]{}
-	for _, protectedService := range protectedServicesResources.Items {
-		// skip protected services that are in deletion process
-		if !protectedService.DeletionTimestamp.IsZero() {
-			continue
-		}
-		serverName := otterizev1alpha3.GetFormattedOtterizeIdentity(protectedService.Spec.Name, namespace)
-		protectedServersByNamespace.Insert(serverName)
-	}
-
-	for _, networkPolicy := range policies.Items {
-		serverName := networkPolicy.Labels[otterizev1alpha3.OtterizeNetworkPolicy]
-		if !protectedServersByNamespace.Has(serverName) {
-			err = r.removeNetworkPolicy(ctx, networkPolicy)
-			if err != nil {
-				return errors.Wrap(err)
-			}
-		}
-	}
-
-	return nil
-}
-
-func (r *NetworkPolicyReconciler) CleanAllNamespaces(ctx context.Context) error {
-	namespaces := corev1.NamespaceList{}
-	err := r.List(ctx, &namespaces)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-
-	for _, namespace := range namespaces.Items {
-		err = r.CleanPoliciesFromUnprotectedServices(ctx, namespace.Name)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-	}
-
-	return nil
-}
-
 // buildNetworkPolicyObjectForIntent builds the network policy that represents the intent from the parameter
-func (r *NetworkPolicyReconciler) buildNetworkPolicyObjectForIntent(
+func (r *IngressNetpolEffectivePolicyReconciler) buildNetworkPolicyObjectForIntent(
 	intent otterizev1alpha3.Intent, policyName, intentsObjNamespace string) *v1.NetworkPolicy {
 	targetNamespace := intent.GetTargetServerNamespace(intentsObjNamespace)
 	// The intent's target server made of name + namespace + hash
@@ -461,7 +292,7 @@ func (r *NetworkPolicyReconciler) buildNetworkPolicyObjectForIntent(
 	}
 }
 
-func (r *NetworkPolicyReconciler) buildPodLabelSelectorFromIntent(intent otterizev1alpha3.Intent, intentsObjNamespace string) metav1.LabelSelector {
+func (r *IngressNetpolEffectivePolicyReconciler) buildPodLabelSelectorFromIntent(intent otterizev1alpha3.Intent, intentsObjNamespace string) metav1.LabelSelector {
 	targetNamespace := intent.GetTargetServerNamespace(intentsObjNamespace)
 	// The intent's target server made of name + namespace + hash
 	formattedTargetServer := otterizev1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), targetNamespace)

--- a/src/operator/controllers/intents_reconcilers/service_effective_policy_intents_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/service_effective_policy_intents_reconciler.go
@@ -1,0 +1,48 @@
+package intents_reconcilers
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ServiceEffectivePolicyIntentsReconciler struct {
+	client.Client
+	Scheme                           *runtime.Scheme
+	serviceEffectivePolicyReconciler *effectivepolicy.GroupReconciler
+	injectablerecorder.InjectableRecorder
+}
+
+func NewServiceEffectiveIntentsReconciler(
+	client client.Client,
+	scheme *runtime.Scheme,
+	serviceEffectivePolicySyncer *effectivepolicy.GroupReconciler) *ServiceEffectivePolicyIntentsReconciler {
+
+	return &ServiceEffectivePolicyIntentsReconciler{
+		Client:                           client,
+		Scheme:                           scheme,
+		serviceEffectivePolicyReconciler: serviceEffectivePolicySyncer,
+	}
+}
+
+func (r *ServiceEffectivePolicyIntentsReconciler) Reconcile(ctx context.Context, _ reconcile.Request) (ctrl.Result, error) {
+	err := r.serviceEffectivePolicyReconciler.Reconcile(ctx)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ServiceEffectivePolicyIntentsReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+	if r.serviceEffectivePolicyReconciler != nil {
+		r.serviceEffectivePolicyReconciler.InjectRecorder(recorder)
+	}
+}

--- a/src/operator/controllers/protectedservices_controller.go
+++ b/src/operator/controllers/protectedservices_controller.go
@@ -58,7 +58,7 @@ func NewProtectedServiceReconciler(
 	extNetpolHandler protected_service_reconcilers.ExternalNepolHandler,
 	enforcementDefaultState bool,
 	netpolEnforcementEnabled bool,
-	networkPolicyHandler protected_service_reconcilers.NetworkPolicyHandler,
+	effectivePolicySyncer protected_service_reconcilers.EffectivePolicyReconcilerGroup,
 ) *ProtectedServiceReconciler {
 	group := reconcilergroup.NewGroup(
 		protectedServicesGroupName,
@@ -75,7 +75,7 @@ func NewProtectedServiceReconciler(
 	}
 
 	if !enforcementDefaultState || !netpolEnforcementEnabled {
-		policyCleaner := protected_service_reconcilers.NewPolicyCleanerReconciler(client, networkPolicyHandler)
+		policyCleaner := protected_service_reconcilers.NewPolicyCleanerReconciler(client, effectivePolicySyncer)
 		group.AddToGroup(policyCleaner)
 	}
 

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -77,6 +77,13 @@ func (g *GroupReconciler) getAllServiceEffectivePolicies(ctx context.Context) ([
 		services.Add(service)
 		serviceToIntent[service] = clientIntent
 		for _, intentCall := range clientIntent.GetCallsList() {
+			if intentCall.IsTargetOutOfCluster() {
+				continue
+			}
+			if intentCall.IsTargetServerKubernetesService() {
+				continue
+			}
+
 			services.Add(serviceidentity.ServiceIdentity{Name: intentCall.GetTargetServerName(), Namespace: intentCall.GetTargetServerNamespace(clientIntent.Namespace)})
 		}
 	}

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -1,0 +1,142 @@
+package effectivepolicy
+
+import (
+	"context"
+	goerrors "errors"
+	"github.com/amit7itz/goset"
+	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type reconciler interface {
+	ReconcileEffectivePolicies(ctx context.Context, eps []ServiceEffectivePolicy) (int, error)
+	InjectRecorder(recorder record.EventRecorder)
+}
+
+type GroupReconciler struct {
+	client.Client
+	Scheme      *runtime.Scheme
+	reconcilers []reconciler
+	injectablerecorder.InjectableRecorder
+}
+
+func NewGroupReconciler(k8sClient client.Client, scheme *runtime.Scheme, reconcilers ...reconciler) *GroupReconciler {
+	return &GroupReconciler{
+		Client:      k8sClient,
+		Scheme:      scheme,
+		reconcilers: reconcilers,
+	}
+}
+
+func (g *GroupReconciler) AddReconciler(reconciler reconciler) {
+	g.reconcilers = append(g.reconcilers, reconciler)
+}
+
+func (g *GroupReconciler) InjectRecorder(recorder record.EventRecorder) {
+	g.Recorder = recorder
+	for _, r := range g.reconcilers {
+		r.InjectRecorder(recorder)
+	}
+}
+
+func (g *GroupReconciler) Reconcile(ctx context.Context) error {
+	eps, err := g.getAllServiceEffectivePolicies(ctx)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	errorList := make([]error, 0)
+	for _, epReconciler := range g.reconcilers {
+		_, err := epReconciler.ReconcileEffectivePolicies(ctx, eps)
+		if err != nil {
+			errorList = append(errorList, errors.Wrap(err))
+		}
+	}
+	return goerrors.Join(errorList...)
+}
+
+func (g *GroupReconciler) getAllServiceEffectivePolicies(ctx context.Context) ([]ServiceEffectivePolicy, error) {
+	var intentsList v1alpha3.ClientIntentsList
+
+	err := g.Client.List(ctx, &intentsList)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceToIntent := make(map[serviceidentity.ServiceIdentity]v1alpha3.ClientIntents)
+	// Extract all services from intents
+	services := goset.NewSet[serviceidentity.ServiceIdentity]()
+	for _, clientIntent := range intentsList.Items {
+		service := serviceidentity.ServiceIdentity{Name: clientIntent.Spec.Service.Name, Namespace: clientIntent.Namespace}
+		services.Add(service)
+		serviceToIntent[service] = clientIntent
+		for _, intentCall := range clientIntent.GetCallsList() {
+			services.Add(serviceidentity.ServiceIdentity{Name: intentCall.GetTargetServerName(), Namespace: intentCall.GetTargetServerNamespace(clientIntent.Namespace)})
+		}
+	}
+
+	// Build SEP for every service
+	epSlice := make([]ServiceEffectivePolicy, 0)
+	for _, service := range services.Items() {
+		ep, err := g.buildServiceEffectivePolicy(ctx, service)
+		if err != nil {
+			return nil, err
+		}
+		if intent, ok := serviceToIntent[service]; ok {
+			ep.ClientIntent = lo.ToPtr(intent)
+		}
+		epSlice = append(epSlice, ep)
+	}
+
+	return epSlice, nil
+}
+
+func (g *GroupReconciler) buildServiceEffectivePolicy(ctx context.Context, service serviceidentity.ServiceIdentity) (ServiceEffectivePolicy, error) {
+	relevantClientIntents, err := g.getClientIntentsByServer(ctx, service)
+	if err != nil {
+		return ServiceEffectivePolicy{}, errors.Wrap(err)
+	}
+	ep := ServiceEffectivePolicy{Service: service}
+	for _, clientIntent := range relevantClientIntents {
+		if !clientIntent.DeletionTimestamp.IsZero() {
+			continue
+		}
+		clientService := serviceidentity.ServiceIdentity{Name: clientIntent.Spec.Service.Name, Namespace: clientIntent.Namespace}
+		intendedCalls := getCallsListByServer(service, clientIntent)
+		for _, intendedCall := range intendedCalls {
+			objEventRecorder := injectablerecorder.NewObjectEventRecorder(&g.InjectableRecorder, lo.ToPtr(clientIntent))
+			ep.CalledBy = append(ep.CalledBy, ClientCall{Service: clientService, IntendedCall: intendedCall, ObjectEventRecorder: objEventRecorder})
+		}
+	}
+	return ep, nil
+}
+
+func (g *GroupReconciler) getClientIntentsByServer(ctx context.Context, server serviceidentity.ServiceIdentity) ([]v1alpha3.ClientIntents, error) {
+	var intentsList v1alpha3.ClientIntentsList
+	matchFields := client.MatchingFields{v1alpha3.OtterizeFormattedTargetServerIndexField: v1alpha3.GetFormattedOtterizeIdentity(server.Name, server.Namespace)}
+	err := g.Client.List(
+		ctx, &intentsList,
+		&matchFields,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return intentsList.Items, nil
+}
+
+func getCallsListByServer(server serviceidentity.ServiceIdentity, clientIntent v1alpha3.ClientIntents) []v1alpha3.Intent {
+	calls := make([]v1alpha3.Intent, 0)
+	for _, intent := range clientIntent.GetCallsList() {
+		if intent.GetTargetServerName() == server.Name && intent.GetTargetServerNamespace(clientIntent.Namespace) == server.Namespace {
+			calls = append(calls, intent)
+		}
+	}
+	return calls
+}

--- a/src/operator/effectivepolicy/types.go
+++ b/src/operator/effectivepolicy/types.go
@@ -1,0 +1,19 @@
+package effectivepolicy
+
+import (
+	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
+)
+
+type ClientCall struct {
+	Service             serviceidentity.ServiceIdentity
+	IntendedCall        v1alpha3.Intent
+	ObjectEventRecorder *injectablerecorder.ObjectEventRecorder
+}
+
+type ServiceEffectivePolicy struct {
+	Service      serviceidentity.ServiceIdentity
+	CalledBy     []ClientCall
+	ClientIntent *v1alpha3.ClientIntents
+}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_egress_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/port_network_policy"
 	"github.com/otterize/intents-operator/src/operator/controllers/pod_reconcilers"
+	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/operator/otterizecrds"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
 	"github.com/otterize/intents-operator/src/shared/awsagent"
@@ -192,7 +193,7 @@ func main() {
 	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), allowExternalTraffic)
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), extNetpolHandler)
 	externalPolicySvcReconciler := external_traffic.NewServiceReconciler(mgr.GetClient(), extNetpolHandler)
-	networkPolicyHandler := ingress_network_policy.NewNetworkPolicyReconciler(
+	epNetpolReconciler := ingress_network_policy.NewIngressNetpolEffectivePolicyReconciler(
 		mgr.GetClient(),
 		scheme,
 		extNetpolHandler,
@@ -201,8 +202,12 @@ func main() {
 		enforcementConfig.EnforcementDefaultState,
 		allowExternalTraffic,
 	)
-	egressNetworkPolicyHandler := egress_network_policy.NewEgressNetworkPolicyReconciler(mgr.GetClient(), scheme, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState)
+
 	additionalIntentsReconcilers := make([]reconcilergroup.ReconcilerWithEvents, 0)
+	epGrouReconciler := effectivepolicy.NewGroupReconciler(mgr.GetClient(), scheme, epNetpolReconciler)
+	epIntentsReconciler := intents_reconcilers.NewServiceEffectiveIntentsReconciler(mgr.GetClient(), scheme, epGrouReconciler)
+	additionalIntentsReconcilers = append(additionalIntentsReconcilers, epIntentsReconciler)
+	egressNetworkPolicyHandler := egress_network_policy.NewEgressNetworkPolicyReconciler(mgr.GetClient(), scheme, watchedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState)
 	if viper.GetBool(operatorconfig.EnableAWSPolicyKey) {
 		awsIntentsAgent, err := awsagent.NewAWSAgent(signalHandlerCtx)
 		if err != nil {
@@ -307,7 +312,6 @@ func main() {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		kafkaServersStore,
-		networkPolicyHandler,
 		svcNetworkPolicyHandler,
 		egressNetworkPolicyHandler,
 		svcEgressNetworkPolicyHandler,
@@ -374,7 +378,7 @@ func main() {
 		extNetpolHandler,
 		enforcementConfig.EnforcementDefaultState,
 		enforcementConfig.EnableNetworkPolicy,
-		networkPolicyHandler,
+		epGrouReconciler,
 	)
 
 	err = protectedServicesReconciler.SetupWithManager(mgr)

--- a/src/shared/injectablerecorder/objectrecorder.go
+++ b/src/shared/injectablerecorder/objectrecorder.go
@@ -1,0 +1,36 @@
+package injectablerecorder
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+type ObjectEventRecorder struct {
+	recorder *InjectableRecorder
+	object   runtime.Object
+}
+
+func NewObjectEventRecorder(recorder *InjectableRecorder, object runtime.Object) *ObjectEventRecorder {
+	return &ObjectEventRecorder{recorder: recorder, object: object}
+}
+
+// RecordWarningEvent - reason: This should be a short, machine understandable string that gives the reason
+// for the transition into the object's current status.
+func (r *ObjectEventRecorder) RecordWarningEvent(reason string, message string) {
+	r.recorder.RecordWarningEvent(r.object, reason, message)
+}
+
+// RecordWarningEventf - reason: This should be a short, machine understandable string that gives the reason
+// for the transition into the object's current status.
+func (r *ObjectEventRecorder) RecordWarningEventf(reason string, message string, args ...interface{}) {
+	r.recorder.RecordWarningEventf(r.object, reason, message, args...)
+}
+
+// RecordNormalEvent - reason: This should be a short, machine understandable string that gives the reason
+// for the transition into the object's current status.
+func (r *ObjectEventRecorder) RecordNormalEvent(reason string, message string) {
+	r.recorder.RecordNormalEvent(r.object, reason, message)
+}
+
+// RecordNormalEventf - reason: This should be a short, machine understandable string that gives the reason
+// for the transition into the object's current status.
+func (r *ObjectEventRecorder) RecordNormalEventf(reason string, message string, args ...interface{}) {
+	r.recorder.RecordNormalEventf(r.object, reason, message, args...)
+}

--- a/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
+++ b/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
@@ -3,7 +3,8 @@ package serviceidentity
 import "sigs.k8s.io/controller-runtime/pkg/client"
 
 type ServiceIdentity struct {
-	Name string
+	Name      string
+	Namespace string
 	// OwnerObject used to resolve the service name. May be nil if service name was resolved using annotation.
 	OwnerObject client.Object
 }

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -74,7 +74,7 @@ func (r *Resolver) ResolvePodToServiceIdentity(ctx context.Context, pod *corev1.
 	// So, for example, a deployment named "my-deployment.5.2.0" will be seen by Otterize as "my-deployment_5_2_0"
 	otterizeServiceName := strings.ReplaceAll(resourceName, ".", "_")
 
-	return serviceidentity.ServiceIdentity{Name: otterizeServiceName, OwnerObject: ownerObj}, nil
+	return serviceidentity.ServiceIdentity{Name: otterizeServiceName, Namespace: pod.Namespace, OwnerObject: ownerObj}, nil
 }
 
 // GetOwnerObject recursively iterates over the pod's owner reference hierarchy until reaching a root owner reference


### PR DESCRIPTION
### Description

This pull request introduces two new abstractions: `ServiceEffectivePolicy` and `ServerEffectivePolicyGroupReconciler`. These abstractions are designed to help reconcile input resources (such as intents, pods, and protected services) to output policies (such as network policies for Ingress, Kafka ACLs, and Postgres). 

The `ServiceEffectivePolicy` type is created, and an `EffectivePolicyReconciler` is implemented specifically for Ingress network policies.

### Testing

I modified the existing tests of ingress policies (and external netpols) according to the changes.  

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
