### PR TITLE
Fixed a case where already installed Otterize deployments stoped overwrite their conversion-webhooks certificates

### DIFF
--- a/src/operator/config/rbac/role.yaml
+++ b/src/operator/config/rbac/role.yaml
@@ -61,6 +61,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/src/operator/controllers/validating_webhook_configurations_controller.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller.go
@@ -36,7 +36,7 @@ type ValidatingWebhookConfigsReconciler struct {
 	certPEM []byte
 }
 
-//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;update;patch;list
+//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;update;patch;list;watch
 
 func NewValidatingWebhookConfigsReconciler(
 	client client.Client,

--- a/src/operator/otterizecrds/ensure.go
+++ b/src/operator/otterizecrds/ensure.go
@@ -90,7 +90,7 @@ func GetCRDDefinitionByName(name string) (*apiextensionsv1.CustomResourceDefinit
 	case "protectedservices.k8s.otterize.com":
 		err = yaml.Unmarshal(protectedServiceCRDContents, &crd)
 	case "kafkaserverconfigs.k8s.otterize.com":
-		err = yaml.Unmarshal(protectedServiceCRDContents, &crd)
+		err = yaml.Unmarshal(KafkaServerConfigContents, &crd)
 	default:
 		return nil, fmt.Errorf("unknown CRD name: %s", name)
 	}

--- a/src/operator/otterizecrds/ensure.go
+++ b/src/operator/otterizecrds/ensure.go
@@ -63,7 +63,7 @@ func ensureCRD(ctx context.Context, k8sClient client.Client, operatorNamespace s
 		updatedCRD.ObjectMeta.Labels = map[string]string{filters.LabelKey: filters.LabelValue}
 		err = k8sClient.Patch(ctx, updatedCRD, client.MergeFrom(&crd))
 		if err != nil {
-			return fmt.Errorf("could not Patch ClientIntents CRD: %w", err)
+			return fmt.Errorf("could not Patch %s CRD: %w", crd.Name, err)
 		}
 	}
 

--- a/src/shared/filters/filters.go
+++ b/src/shared/filters/filters.go
@@ -5,12 +5,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const labelKey = "app.kubernetes.io/part-of"
-const labelValue = "otterize"
+const LabelKey = "app.kubernetes.io/part-of"
+const LabelValue = "otterize"
 
 var filterByOtterizeLabel = func(obj client.Object) bool {
-	existingValue, ok := obj.GetLabels()[labelKey]
-	return ok && existingValue == labelValue
+	existingValue, ok := obj.GetLabels()[LabelKey]
+	return ok && existingValue == LabelValue
 }
 
 // FilterByOtterizeLabelPredicate Filter only resources that are part of Otterize

--- a/src/shared/filters/filters_test.go
+++ b/src/shared/filters/filters_test.go
@@ -14,7 +14,7 @@ func TestFilterByOtterizeLabel(t *testing.T) {
 	assert.False(t, result)
 
 	// Set the label value to "Otterize"
-	labels := map[string]string{labelKey: labelValue}
+	labels := map[string]string{LabelKey: LabelValue}
 	obj.SetLabels(labels)
 
 	result = filterByOtterizeLabel(obj)


### PR DESCRIPTION
### Description

Ensure the existence of `app.kubernetes.io/part-of=otterize` label on Otterize managed `CustomResourceDefinitions`.

### References

https://github.com/otterize/intents-operator/pull/338

