### PR TITLE
Fix CI/CD e2e test to ignore the status part of the ClientIntents resource

### DIFF
--- a/.github/workflows/intents-spec.yaml
+++ b/.github/workflows/intents-spec.yaml
@@ -3,3 +3,4 @@ spec:
   - name: server
   service:
     name: client
+status:

--- a/.github/workflows/netpol-e2e-test.yaml
+++ b/.github/workflows/netpol-e2e-test.yaml
@@ -126,7 +126,7 @@ jobs:
           kubectl apply -f https://docs.otterize.com/code-examples/automate-network-policies/intents.yaml
           
           echo "Validate intents spec format"
-          kubectl get clientintents.k8s.otterize.com -n otterize-tutorial-npol client -o yaml | awk '/spec:/,EOF' | diff -s - .github/workflows/intents-spec.yaml
+          kubectl get clientintents.k8s.otterize.com -n otterize-tutorial-npol client -o yaml | sed -n '/spec:/,/status:/p' | diff -s - .github/workflows/intents-spec.yaml
 
           # should work because there is an applied intent
           echo check client log


### PR DESCRIPTION
### Description

Fix the operator CI/CD e2e to ignore the section of ClientIntents status.

### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
