### PR TITLE
Convert some remaining error logs into errors with stack traces to improve error reporting

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -262,6 +262,7 @@ func (r *IntentsReconciler) getIntentsToProtectedService(protectedService *otter
 	)
 	if err != nil {
 		logrus.Errorf("Failed to list client intents for client %s: %v", fullServerName, err)
+		// Intentionally no return - we are not able to return errors in this flow currently
 	}
 
 	intentsToReconcile = append(intentsToReconcile, intentsToServer.Items...)

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -147,6 +147,7 @@ func (r *KafkaServerConfigReconciler) getKSCsForProtectedService(ctx context.Con
 	)
 	if err != nil {
 		logrus.Errorf("Failed to list KSCs for server %s: %v", protectedService.Spec.Name, err)
+		// Intentionally no return - we are not able to return errors in this flow currently
 	}
 
 	kscsToReconcile = append(kscsToReconcile, kafkaServerConfigs.Items...)

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -223,8 +223,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 	if hasUpdates {
 		err = p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
 		if err != nil {
-			logrus.Errorf("Failed updating Otterize labels for pod %s in namespace %s", pod.Name, pod.Namespace)
-			return errors.Wrap(err)
+			return errors.Errorf("failed updating Otterize labels for pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
 		}
 	}
 	return nil

--- a/src/shared/telemetries/basicbatch/batcher.go
+++ b/src/shared/telemetries/basicbatch/batcher.go
@@ -51,7 +51,11 @@ func (b *Batcher[T]) runForever() {
 	defer func() {
 		r := recover()
 		if r != nil {
-			logrus.Error("recovered from panic in batcher")
+			logger := logrus.WithField("panic", r)
+			if rErr, ok := r.(error); ok {
+				logger = logger.WithError(rErr)
+			}
+			logger.Error("recovered from panic in batcher: %r")
 		}
 	}()
 	defer errorreporter.AutoNotify()

--- a/src/shared/telemetries/telemetrysender/sender.go
+++ b/src/shared/telemetries/telemetrysender/sender.go
@@ -7,7 +7,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/telemetries/basicbatch"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesconfig"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"net/http"
 	"time"
@@ -34,7 +33,7 @@ func newGqlClient() graphql.Client {
 func batchSendTelemetries(ctx context.Context, telemetriesClient graphql.Client, telemetries []telemetriesgql.TelemetryInput) error {
 	_, err := telemetriesgql.SendTelemetries(ctx, telemetriesClient, telemetries)
 	if err != nil {
-		logrus.Errorf("failed batch sending telemetries: %s", err)
+		return errors.Errorf("failed batch sending telemetries: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Prior to this PR, some errors would be reported without parameters or stack, or reported twice - once by being logged manually, and once because the error was returned. This PR corrects that.