### PR TITLE
Expect ACL logs when reconciler is re-queued

### DIFF
--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -386,11 +386,18 @@ func (s *KafkaACLReconcilerTestSuite) TestKafkaACLEnforcementGloballyDisabled() 
 func (s *KafkaACLReconcilerTestSuite) reconcile(namespacedName types.NamespacedName) {
 	res := ctrl.Result{Requeue: true}
 	var err error
+	firstRun := true
 
 	for res.Requeue {
+		if !firstRun {
+			// List ACL is called when the reconciler is re-queued for log purposes
+			s.mockKafkaAdmin.EXPECT().ListAcls(gomock.Any()).Return([]sarama.ResourceAcls{}, nil).Times(1)
+		}
 		res, err = s.Reconciler.Reconcile(context.Background(), ctrl.Request{
 			NamespacedName: namespacedName,
 		})
+
+		firstRun = false
 	}
 
 	s.Require().NoError(err)


### PR DESCRIPTION
### Description

Due to limitations of TestENV platform, the reconciler is expected to have re-queue once in a while during tests. This is also a valid behavior in real-life since Kubernetes is an "eventual consistent" system. The ACL admin logs existing ACLs almost every time the reconciler is called. 

This cause few tests to be flaky. In the rare cases a re-queue is triggered, the call to logs isn't expected in `gomock` SDK and the test fail with no reason. So we should expect this call in any test expect those where the test flow should never reach the ACL log function.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
