### PR TITLE
Improvement: untag AWS roles and policies only if configuration has changed

### DIFF
--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -73,7 +73,7 @@ func (a *Agent) CreateOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 				return nil, errors.Wrap(err)
 			}
 		}
-		if !useSoftDeleteStrategy {
+		if !useSoftDeleteStrategy && HasSoftDeleteStrategyTagSet(role.Tags) {
 			err = a.UnsetRoleSoftDeleteStrategyTag(ctx, role)
 			if err != nil {
 				return nil, errors.Wrap(err)

--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -58,6 +58,7 @@ func Init(componentName string, version string, apiKey string) {
 		AppType:         componentName,
 		ProjectPackages: []string{"main*", "github.com/otterize/**"},
 		Logger:          noopLogger{},
+		PanicHandler:    func() {},
 	}
 	bugsnag.Configure(conf)
 


### PR DESCRIPTION
Previously, the operator would always attempt to untag. This resulted in a no-op.