### PR TITLE
Fix bug when not reporting deletion of all client intents in namespace

### DIFF
--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
@@ -64,10 +64,6 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 
-	if len(intentsInput) == 0 {
-		return ctrl.Result{}, nil
-	}
-
 	timeoutCtx, cancel := context.WithTimeout(ctx, viper.GetDuration(otterizecloudclient.CloudClientTimeoutKey))
 	defer cancel()
 

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -163,6 +163,7 @@ type AzureInfo {
 	subscriptionId: String!
 	resourceGroup: String!
 	aksClusterName: String!
+	namespace: String!
 }
 
 input AzureInfoInput {
@@ -171,6 +172,7 @@ input AzureInfoInput {
 	subscriptionId: String!
 	resourceGroup: String!
 	aksClusterName: String!
+	namespace: String!
 }
 
 type AzureResource {
@@ -953,7 +955,7 @@ type Mutation {
 	): Boolean!
 """Create a new Kubernetes integration"""
 	createKubernetesIntegration(
-		environmentId: ID
+		environmentId: ID!
 		name: String!
 	): Integration
 """Create a new AWS integration"""
@@ -1117,14 +1119,6 @@ type Mutation {
 		userTutorialId: ID!
 		tutorialName: TutorialName!
 		step: String!
-	): Boolean!
-	notifyQuestLogStepAdvanced(
-		id: ID!
-		step: QuestLogStep!
-	): Boolean!
-	notifyQuestLogStepSeenAdvanced(
-		id: ID!
-		step: QuestLogStep!
 	): Boolean!
 }
 
@@ -1307,20 +1301,6 @@ type Query {
 	): User!
 }
 
-enum QuestLogStep {
-"""Connect cluster"""
-	CONNECT_CLUSTER
-"""Get to know your network map"""
-	EXPLORE_NETWORK_MAP_ADD_NS_FILTER
-	EXPLORE_NETWORK_MAP_ADD_SVC_FILTER
-	EXPLORE_NETWORK_MAP_CLEAR_FILTERS
-"""Declare intents"""
-	DECLARE_INTENTS_CLICK_ON_SERVICE
-	DECLARE_INTENTS_DOWNLOAD_YAML
-	DECLARE_INTENTS_DO_APPLY
-	COMPLETED
-}
-
 enum RowDiff {
 	ADDED
 	REMOVED
@@ -1500,8 +1480,6 @@ type User {
 	authProviderUserId: String!
 	tutorials: [UserTutorial!]
 	activeTutorial: UserTutorial!
-	questLogStep: QuestLogStep!
-	questLogStepSeen: QuestLogStep!
 }
 
 type UserAndPassword {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -163,6 +163,7 @@ type AzureInfo {
 	subscriptionId: String!
 	resourceGroup: String!
 	aksClusterName: String!
+	namespace: String!
 }
 
 input AzureInfoInput {
@@ -171,6 +172,7 @@ input AzureInfoInput {
 	subscriptionId: String!
 	resourceGroup: String!
 	aksClusterName: String!
+	namespace: String!
 }
 
 type AzureResource {
@@ -953,7 +955,7 @@ type Mutation {
 	): Boolean!
 """Create a new Kubernetes integration"""
 	createKubernetesIntegration(
-		environmentId: ID
+		environmentId: ID!
 		name: String!
 	): Integration
 """Create a new AWS integration"""
@@ -1117,14 +1119,6 @@ type Mutation {
 		userTutorialId: ID!
 		tutorialName: TutorialName!
 		step: String!
-	): Boolean!
-	notifyQuestLogStepAdvanced(
-		id: ID!
-		step: QuestLogStep!
-	): Boolean!
-	notifyQuestLogStepSeenAdvanced(
-		id: ID!
-		step: QuestLogStep!
 	): Boolean!
 }
 
@@ -1307,20 +1301,6 @@ type Query {
 	): User!
 }
 
-enum QuestLogStep {
-"""Connect cluster"""
-	CONNECT_CLUSTER
-"""Get to know your network map"""
-	EXPLORE_NETWORK_MAP_ADD_NS_FILTER
-	EXPLORE_NETWORK_MAP_ADD_SVC_FILTER
-	EXPLORE_NETWORK_MAP_CLEAR_FILTERS
-"""Declare intents"""
-	DECLARE_INTENTS_CLICK_ON_SERVICE
-	DECLARE_INTENTS_DOWNLOAD_YAML
-	DECLARE_INTENTS_DO_APPLY
-	COMPLETED
-}
-
 enum RowDiff {
 	ADDED
 	REMOVED
@@ -1500,8 +1480,6 @@ type User {
 	authProviderUserId: String!
 	tutorials: [UserTutorial!]
 	activeTutorial: UserTutorial!
-	questLogStep: QuestLogStep!
-	questLogStepSeen: QuestLogStep!
 }
 
 type UserAndPassword {


### PR DESCRIPTION
### Description

When reporting deletion of ClientIntents, the operator must report empty input if there are no more intents in the namespace. During the work on DNS intents there a was temporary flag for filtering out DNS intents. To avoid their report I add avoiding the report when no input, which was clearly a mistake back then, but it's really not necessary now.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality
