### PR TITLE
Rename create-azure-role-assignment label to create-azure-workload-identity for compatibility with other IAM providers

### DIFF
--- a/src/shared/azureagent/credentials.go
+++ b/src/shared/azureagent/credentials.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// AzureApplyOnPodLabel is used to mark pods that should be processed by the Azure agent to create an associated Azure identity & role assignment
-	AzureApplyOnPodLabel = "credentials-operator.otterize.com/create-azure-role-assignment"
+	AzureApplyOnPodLabel = "credentials-operator.otterize.com/create-azure-workload-identity"
 
 	// ServiceManagedByAzureAgentLabel is used to mark service accounts that are managed by the Azure agent
 	ServiceManagedByAzureAgentLabel = "credentials-operator.otterize.com/managed-by-azure-agent"

--- a/src/shared/azureagent/credentials.go
+++ b/src/shared/azureagent/credentials.go
@@ -15,9 +15,6 @@ const (
 	// ServiceManagedByAzureAgentLabel is used to mark service accounts that are managed by the Azure agent
 	ServiceManagedByAzureAgentLabel = "credentials-operator.otterize.com/managed-by-azure-agent"
 
-	// AzureUseWorkloadIdentityLabel is used by the azure workload identity mechanism to mark pods that should use workload identity
-	AzureUseWorkloadIdentityLabel = "azure.workload.identity/use"
-
 	// AzureWorkloadIdentityClientIdAnnotation is used by the azure workload identity mechanism to link between service accounts and user assigned identities
 	AzureWorkloadIdentityClientIdAnnotation = "azure.workload.identity/client-id"
 


### PR DESCRIPTION
### Description
Rename create-azure-role-assignment label to create-azure-workload-identity for compatibility with other IAM providers

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
