### PR TITLE
Auto-expand Azure intents scope with operator-provided subscription ID & resource group

### DIFF
--- a/src/shared/azureagent/policies.go
+++ b/src/shared/azureagent/policies.go
@@ -2,16 +2,40 @@ package azureagent
 
 import (
 	"context"
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
+	"strings"
 )
 
 func (a *Agent) IntentType() otterizev1alpha3.IntentType {
 	return otterizev1alpha3.IntentTypeAzure
+}
+
+func (a *Agent) getIntentScope(intent otterizev1alpha3.Intent) (string, error) {
+	name := intent.Name
+	if !strings.HasPrefix(name, "/") {
+		return "", errors.Errorf("expected intent name to start with /, got %s", name)
+	}
+
+	if strings.HasPrefix(name, "/subscriptions/") {
+		// the name is already a full scope
+		return name, nil
+	}
+
+	if strings.HasPrefix(name, "/resourceGroups/") {
+		// append the subscription ID to the scope
+		fullScope := fmt.Sprintf("/subscriptions/%s%s", a.conf.SubscriptionID, name)
+		return fullScope, nil
+	}
+
+	// append both the subscription ID and the resource group to the scope
+	fullScope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s%s", a.conf.SubscriptionID, a.conf.ResourceGroup, name)
+	return fullScope, nil
 }
 
 func (a *Agent) AddRolePolicyFromIntents(ctx context.Context, namespace string, accountName string, intentsServiceName string, intents []otterizev1alpha3.Intent) error {
@@ -29,8 +53,14 @@ func (a *Agent) AddRolePolicyFromIntents(ctx context.Context, namespace string, 
 		return *roleAssignment.Properties.Scope
 	})
 
+	var expectedScopes []string
 	for _, intent := range intents {
-		scope := intent.Name
+		scope, err := a.getIntentScope(intent)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		expectedScopes = append(expectedScopes, scope)
+
 		roleNames := intent.AzureRoles
 		existingRoleAssignmentsForScope := existingRoleAssignmentsByScope[scope]
 
@@ -39,9 +69,6 @@ func (a *Agent) AddRolePolicyFromIntents(ctx context.Context, namespace string, 
 		}
 	}
 
-	expectedScopes := lo.Map(intents, func(intent otterizev1alpha3.Intent, _ int) string {
-		return intent.Name
-	})
 	if err := a.deleteRoleAssignmentsWithUnexpectedScopes(ctx, expectedScopes, existingRoleAssignments); err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/shared/azureagent/policies_test.go
+++ b/src/shared/azureagent/policies_test.go
@@ -1,0 +1,84 @@
+package azureagent
+
+import (
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type AzureAgentPoliciesSuite struct {
+	suite.Suite
+}
+
+func (s *AzureAgentPoliciesSuite) TestGetIntentScopeAppendSubscriptionID() {
+	// Arrange
+	agent := &Agent{
+		conf: Config{
+			SubscriptionID: "subscription-id",
+		},
+	}
+	intent := otterizev1alpha3.Intent{
+		Name: "/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/storage-account-name",
+	}
+
+	// Act
+	scope, err := agent.getIntentScope(intent)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Equal("/subscriptions/subscription-id/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/storage-account-name", scope)
+}
+
+func (s *AzureAgentPoliciesSuite) TestGetIntentScopeAppendSubscriptionIDAndResourceGroup() {
+	// Arrange
+	agent := &Agent{
+		conf: Config{
+			SubscriptionID: "subscription-id",
+			ResourceGroup:  "resource-group-name",
+		},
+	}
+	intent := otterizev1alpha3.Intent{
+		Name: "/providers/Microsoft.Storage/storageAccounts/storage-account-name",
+	}
+
+	// Act
+	scope, err := agent.getIntentScope(intent)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Equal("/subscriptions/subscription-id/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/storage-account-name", scope)
+}
+
+func (s *AzureAgentPoliciesSuite) TestGetIntentScopeFullScope() {
+	// Arrange
+	agent := &Agent{}
+	intent := otterizev1alpha3.Intent{
+		Name: "/subscriptions/subscription-id/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/storage-account-name",
+	}
+
+	// Act
+	scope, err := agent.getIntentScope(intent)
+
+	// Assert
+	s.Require().NoError(err)
+	s.Equal("/subscriptions/subscription-id/resourceGroups/resource-group-name/providers/Microsoft.Storage/storageAccounts/storage-account-name", scope)
+}
+
+func (s *AzureAgentPoliciesSuite) TestGetIntentScopeError() {
+	// Arrange
+	agent := &Agent{}
+	intent := otterizev1alpha3.Intent{
+		Name: "invalid-scope",
+	}
+
+	// Act
+	scope, err := agent.getIntentScope(intent)
+
+	// Assert
+	s.Require().Error(err)
+	s.Empty(scope)
+}
+
+func TestAzureAgentPoliciesSuite(t *testing.T) {
+	suite.Run(t, new(AzureAgentPoliciesSuite))
+}


### PR DESCRIPTION
### Description
On Azure intents, allow providing partial scope name, omitting the subscription ID and resource group. 
The intents-operator will automatically detect partial scopes and expand them to include the subscription ID & resource group provided to the operator upon installation. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
