### PR TITLE
Bugfix: intents operator CLI flags parsing out of main scope breaks credentials-operator dependency

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -104,6 +104,7 @@ func MustGetEnvVar(name string) string {
 }
 
 func main() {
+	operatorconfig.InitCLIFlags()
 	logrus.SetFormatter(&logrus.JSONFormatter{
 		TimestampFormat: time.RFC3339,
 	})

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -87,8 +87,6 @@ func init() {
 	viper.SetDefault(DebugLogKey, DebugLogDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
-
-	InitCLIFlags()
 }
 
 func InitCLIFlags() {


### PR DESCRIPTION
### Description
Bugfix: intents operator CLI flags parsing out of main scope breaks credentials-operator dependency

### References

Introduced by this commit: https://github.com/otterize/intents-operator/commit/19b08b3e14b7bbdf4b5d1bbef9b95ab32ee7f7fb
