### PR TITLE
Report enforcement status to Otterize Cloud for AWS IAM, PostgreSQL, GCP and Azure

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -514,6 +514,10 @@ func uploadConfiguration(ctx context.Context, otterizeCloudClient operator_cloud
 		NetworkPolicyEnforcementEnabled:       config.EnableNetworkPolicy,
 		EgressNetworkPolicyEnforcementEnabled: config.EnableEgressNetworkPolicyReconcilers,
 		KafkaACLEnforcementEnabled:            config.EnableKafkaACL,
+		AwsIAMPolicyEnforcementEnabled:        config.EnableAWSPolicy,
+		GcpIAMPolicyEnforcementEnabled:        config.EnableGCPPolicy,
+		AzureIAMPolicyEnforcementEnabled:      config.EnableAzurePolicy,
+		DatabaseEnforcementEnabled:            config.EnableDatabasePolicy,
 		IstioPolicyEnforcementEnabled:         config.EnableIstioPolicy,
 		ProtectedServicesEnabled:              config.EnableNetworkPolicy, // in this version, protected services are enabled if network policy creation is enabled, regardless of enforcement default state
 	})


### PR DESCRIPTION
This PR adds reporting for the enforcement status for AWS IAM, PostgreSQL, GCP and Azure. This enforcement status is used to display the operator's state in Otterize Cloud, and to automatically display correct access status in the access graph.