### PR TITLE
Bugfix: avoid splitting target server name on intents of type Azure (and other non-k8s types)

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -53,6 +53,7 @@ require (
 
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect
+	github.com/Azure/azure-sdk-for-go-extensions v0.1.6 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -41,6 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/99designs/gqlgen v0.17.2/go.mod h1:K5fzLKwtph+FFgh9j7nFbRUdBKvTcGnsta51fsMTn3o=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.6 h1:EXGvDcj54u98XfaI/Cy65Ds6vNsIJeGKYf0eNLB1y4Q=
+github.com/Azure/azure-sdk-for-go-extensions v0.1.6/go.mod h1:27StPiXJp6Xzkq2AQL7gPK7VC0hgmCnUKlco1dO1jaM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 h1:lGlwhPtrX6EVml1hO0ivjkUxsSyl4dsiw9qcA1k/3IQ=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1/go.mod h1:RKUqNu35KJYcVG/fqTRqmuXJZYNhYkBrnC/hX7yGbTA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 h1:sO0/P7g68FrryJzljemN+6GTssUXdANk6aJ7T1ZxnsQ=

--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -323,6 +323,10 @@ func (in *Intent) GetTargetServerName() string {
 		return OtterizeInternetTargetName
 	}
 
+	if in.Type == IntentTypeAWS || in.Type == IntentTypeGCP || in.Type == IntentTypeAzure || in.Type == IntentTypeDatabase {
+		return in.Name
+	}
+
 	if in.IsTargetServerKubernetesService() {
 		name = strings.ReplaceAll(in.Name, "svc:", "") // Replace so all chars are valid in K8s label
 	} else {

--- a/src/shared/azureagent/policies.go
+++ b/src/shared/azureagent/policies.go
@@ -137,6 +137,9 @@ func (a *Agent) deleteRoleAssignmentsWithUnexpectedScopes(ctx context.Context, e
 func (a *Agent) DeleteRolePolicyFromIntents(ctx context.Context, intents otterizev1alpha3.ClientIntents) error {
 	userAssignedIdentity, err := a.findUserAssignedIdentity(ctx, intents.Namespace, intents.Spec.Service.Name)
 	if err != nil {
+		if errors.Is(err, ErrUserIdentityNotFound) {
+			return nil
+		}
 		return errors.Wrap(err)
 	}
 


### PR DESCRIPTION
### Description

In intents of type Azure (and other non-k8s types), we should never try to split the server "name" to name & namespace. 
This bug breaks intents with Azure resource names such as `/providers/Microsoft.Storage/storageAccounts/otterizetutorialazureiam/blobServices/default/containers/test`, as the name is split around the period when reporting to Otterize cloud. 

Additionally, fixed a bug where if the intents operator attempts to handle a deleted `ClientIntents` resource whose workload identity no longer exists, it fails to reconcile it. 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
