### PR TITLE
Bugfix: ignore error 404 NOT_FOUND on attempting to delete user assigned identities

### DIFF
--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -101,13 +101,13 @@ func (a *Agent) deleteUserAssignedIdentity(ctx context.Context, namespace string
 
 	logger.WithField("federatedIdentity", federatedIdentityCredentialsName).Debug("deleting federated identity credentials")
 	_, err := a.federatedIdentityCredentialsClient.Delete(ctx, a.conf.ResourceGroup, userAssignedIdentityName, federatedIdentityCredentialsName, nil)
-	if err != nil {
+	if err != nil && !azureerrors.IsNotFoundErr(err) {
 		return errors.Wrap(err)
 	}
 
 	logger.WithField("identity", userAssignedIdentityName).Debug("deleting user assigned identity")
 	_, err = a.userAssignedIdentitiesClient.Delete(ctx, a.conf.ResourceGroup, userAssignedIdentityName, nil)
-	if err != nil {
+	if err != nil && !azureerrors.IsNotFoundErr(err) {
 		return errors.Wrap(err)
 	}
 


### PR DESCRIPTION
### Description
This PR fixes a bug in Otterize's credentials-operator, whereby when attempting to delete user assigned identities & federated identity credentials, the operator may hit an 404 (not found) error. This is part of the normal operator flow, and should not be reported as an error. 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
