### PR TITLE
Always use `serviceidentity.ServiceIdentity` when creating `otterizeFormattedIdentity` to avoid code duplications and potential bugs

### DIFF
--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -141,10 +141,6 @@ type IntentsSpec struct {
 
 type Service struct {
 	Name string `json:"name" yaml:"name"`
-	//+optional
-	Group string `json:"group" yaml:"group"`
-	//+optional
-	Kind string `json:"kind" yaml:"kind"`
 }
 
 type Intent struct {
@@ -345,11 +341,6 @@ func (in *Intent) GetTargetServerKind() string {
 	return ""
 }
 
-func (in *Intent) GetTargetServerGroup() string {
-	// TODO: Implement this
-	return ""
-}
-
 func (in *Intent) GetServerFullyQualifiedName(intentsObjNamespace string) string {
 	fullyQualifiedName := fmt.Sprintf("%s.%s", in.GetTargetServerName(), in.GetTargetServerNamespace(intentsObjNamespace))
 	return fullyQualifiedName
@@ -402,14 +393,6 @@ func (in *ClientIntents) GetServersWithoutSidecar() (sets.Set[string], error) {
 	}
 
 	return sets.New[string](serversList...), nil
-}
-
-func (in *ClientIntents) GetClientServiceKind() string {
-	return in.Spec.Service.Kind
-}
-
-func (in *ClientIntents) GetClientServiceGroup() string {
-	return in.Spec.Service.Group
 }
 
 func (in *ClientIntents) IsServerMissingSidecar(intent Intent) (bool, error) {

--- a/src/operator/api/v1alpha3/otterize_labels.go
+++ b/src/operator/api/v1alpha3/otterize_labels.go
@@ -1,6 +1,7 @@
 package v1alpha3
 
 import (
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	v1 "k8s.io/api/core/v1"
 	"strings"
 )
@@ -23,7 +24,7 @@ func IsMissingOtterizeAccessLabels(pod *v1.Pod, otterizeAccessLabels map[string]
 
 // UpdateOtterizeAccessLabels updates a pod's labels with Otterize labels representing their intents
 // The pod is also labeled with "otterize-client=<hashed-client-name>" to mark it as having intents or being the client-side of an egress netpol
-func UpdateOtterizeAccessLabels(pod *v1.Pod, serviceName string, otterizeAccessLabels map[string]string) *v1.Pod {
+func UpdateOtterizeAccessLabels(pod *v1.Pod, serviceIdentity serviceidentity.ServiceIdentity, otterizeAccessLabels map[string]string) *v1.Pod {
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
 	}
@@ -31,7 +32,7 @@ func UpdateOtterizeAccessLabels(pod *v1.Pod, serviceName string, otterizeAccessL
 	for k, v := range otterizeAccessLabels {
 		pod.Labels[k] = v
 	}
-	pod.Labels[OtterizeClientLabelKey] = GetFormattedOtterizeIdentity(serviceName, pod.Namespace)
+	pod.Labels[OtterizeClientLabelKey] = serviceIdentity.GetFormattedOtterizeIdentity()
 	return pod
 }
 

--- a/src/operator/api/v1alpha3/protectedservice_types.go
+++ b/src/operator/api/v1alpha3/protectedservice_types.go
@@ -23,6 +23,10 @@ import (
 // ProtectedServiceSpec defines the desired state of ProtectedService
 type ProtectedServiceSpec struct {
 	Name string `json:"name,omitempty"`
+	//+optional
+	Group string `json:"group" yaml:"group"`
+	//+optional
+	Kind string `json:"kind" yaml:"kind"`
 }
 
 // ProtectedServiceStatus defines the observed state of ProtectedService

--- a/src/operator/api/v1alpha3/protectedservice_types.go
+++ b/src/operator/api/v1alpha3/protectedservice_types.go
@@ -23,10 +23,6 @@ import (
 // ProtectedServiceSpec defines the desired state of ProtectedService
 type ProtectedServiceSpec struct {
 	Name string `json:"name,omitempty"`
-	//+optional
-	Group string `json:"group" yaml:"group"`
-	//+optional
-	Kind string `json:"kind" yaml:"kind"`
 }
 
 // ProtectedServiceStatus defines the observed state of ProtectedService

--- a/src/operator/api/v1alpha3/serviceidentity.go
+++ b/src/operator/api/v1alpha3/serviceidentity.go
@@ -6,8 +6,6 @@ func (in *ClientIntents) ToServiceIdentity() *serviceidentity.ServiceIdentity {
 	return &serviceidentity.ServiceIdentity{
 		Name:      in.Spec.Service.Name,
 		Namespace: in.Namespace,
-		Kind:      in.GetClientServiceKind(),
-		Group:     in.GetClientServiceGroup(),
 	}
 }
 
@@ -16,7 +14,6 @@ func (in *Intent) ToServiceIdentity(intentsObjNamespace string) *serviceidentity
 		Name:      in.GetTargetServerName(),
 		Namespace: in.GetTargetServerNamespace(intentsObjNamespace),
 		Kind:      in.GetTargetServerKind(),
-		Group:     in.GetTargetServerGroup(),
 	}
 }
 
@@ -24,7 +21,5 @@ func (in *ProtectedService) ToServiceIdentity() *serviceidentity.ServiceIdentity
 	return &serviceidentity.ServiceIdentity{
 		Name:      in.Spec.Name,
 		Namespace: in.Namespace,
-		Kind:      in.Spec.Kind,
-		Group:     in.Spec.Group,
 	}
 }

--- a/src/operator/api/v1alpha3/serviceidentity.go
+++ b/src/operator/api/v1alpha3/serviceidentity.go
@@ -1,0 +1,30 @@
+package v1alpha3
+
+import "github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
+
+func (in *ClientIntents) ToServiceIdentity() *serviceidentity.ServiceIdentity {
+	return &serviceidentity.ServiceIdentity{
+		Name:      in.Spec.Service.Name,
+		Namespace: in.Namespace,
+		Kind:      in.GetClientServiceKind(),
+		Group:     in.GetClientServiceGroup(),
+	}
+}
+
+func (in *Intent) ToServiceIdentity(intentsObjNamespace string) *serviceidentity.ServiceIdentity {
+	return &serviceidentity.ServiceIdentity{
+		Name:      in.GetTargetServerName(),
+		Namespace: in.GetTargetServerNamespace(intentsObjNamespace),
+		Kind:      in.GetTargetServerKind(),
+		Group:     in.GetTargetServerGroup(),
+	}
+}
+
+func (in *ProtectedService) ToServiceIdentity() *serviceidentity.ServiceIdentity {
+	return &serviceidentity.ServiceIdentity{
+		Name:      in.Spec.Name,
+		Namespace: in.Namespace,
+		Kind:      in.Spec.Kind,
+		Group:     in.Spec.Group,
+	}
+}

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -310,23 +310,6 @@ func (r *IntentsReconciler) InitIntentsServerIndices(mgr ctrl.Manager) error {
 		return errors.Wrap(err)
 	}
 
-	//err = mgr.GetCache().IndexField(
-	//	context.Background(),
-	//	&corev1.Pod{},
-	//	otterizev1alpha3.OtterizePodByOwnerKindAndNameIndexField,
-	//	func(object client.Object) []string {
-	//		pod := object.(*corev1.Pod)
-	//		owner, err := serviceidresolver.NewResolver(r.client).GetOwnerObject(context.Background(), pod)
-	//		if err != nil {
-	//			return nil
-	//		}
-	//		serviceId := serviceidentity.NewFromPodOwner(owner)
-	//		return []string{serviceId.String()}
-	//	})
-	//if err != nil {
-	//	return errors.Wrap(err)
-	//}
-
 	return nil
 }
 

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -28,7 +28,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
-	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesconfig"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
@@ -301,7 +300,7 @@ func (r *IntentsReconciler) InitIntentsServerIndices(mgr ctrl.Manager) error {
 					res = append(res, otterizev1alpha3.OtterizeInternetTargetName)
 					continue
 				}
-				service := serviceidentity.NewFromIntent(intent, intents.Namespace)
+				service := intent.ToServiceIdentity(intents.Namespace)
 				res = append(res, service.GetFormattedOtterizeIdentity())
 			}
 
@@ -310,6 +309,23 @@ func (r *IntentsReconciler) InitIntentsServerIndices(mgr ctrl.Manager) error {
 	if err != nil {
 		return errors.Wrap(err)
 	}
+
+	//err = mgr.GetCache().IndexField(
+	//	context.Background(),
+	//	&corev1.Pod{},
+	//	otterizev1alpha3.OtterizePodByOwnerKindAndNameIndexField,
+	//	func(object client.Object) []string {
+	//		pod := object.(*corev1.Pod)
+	//		owner, err := serviceidresolver.NewResolver(r.client).GetOwnerObject(context.Background(), pod)
+	//		if err != nil {
+	//			return nil
+	//		}
+	//		serviceId := serviceidentity.NewFromPodOwner(owner)
+	//		return []string{serviceId.String()}
+	//	})
+	//if err != nil {
+	//	return errors.Wrap(err)
+	//}
 
 	return nil
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/networking/v1"
@@ -35,9 +36,9 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 	serviceName := "test-client"
 	serverName := "test-server"
 	serverNamespace := testServerNamespace
-	formattedServer := otterizev1alpha3.GetFormattedOtterizeIdentity(serverName, serverNamespace)
-	formattedServerService := otterizev1alpha3.GetFormattedOtterizeIdentity("svc."+serverName, serverNamespace)
-	formattedClient := otterizev1alpha3.GetFormattedOtterizeIdentity(serviceName, testNamespace)
+	formattedServer := (&serviceidentity.ServiceIdentity{Name: serverName, Namespace: serverNamespace}).GetFormattedOtterizeIdentity()
+	formattedServerService := (&serviceidentity.ServiceIdentity{Name: serverName, Namespace: serverNamespace, Kind: serviceidentity.KindService}).GetFormattedOtterizeIdentity()
+	formattedClient := (&serviceidentity.ServiceIdentity{Name: serviceName, Namespace: testNamespace}).GetFormattedOtterizeIdentity()
 	namespacedName := types.NamespacedName{
 		Namespace: testNamespace,
 		Name:      "client-intents",

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy.go
@@ -28,17 +28,18 @@ func (r *EgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effectivep
 		if call.IsTargetServerKubernetesService() {
 			continue
 		}
+		targetServiceIdentity := call.ToServiceIdentity(ep.Service.Namespace)
 		egressRules = append(egressRules, v1.NetworkPolicyEgressRule{
 			To: []v1.NetworkPolicyPeer{
 				{
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							otterizev1alpha3.OtterizeServiceLabelKey: otterizev1alpha3.GetFormattedOtterizeIdentity(call.GetTargetServerName(), call.GetTargetServerNamespace(ep.Service.Namespace)),
+							otterizev1alpha3.OtterizeServiceLabelKey: targetServiceIdentity.GetFormattedOtterizeIdentity(),
 						},
 					},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							otterizev1alpha3.KubernetesStandardNamespaceNameLabelKey: call.GetTargetServerNamespace(ep.Service.Namespace),
+							otterizev1alpha3.KubernetesStandardNamespaceNameLabelKey: targetServiceIdentity.Namespace,
 						},
 					},
 				},

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -7,7 +7,6 @@ import (
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/networkpolicy"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
-	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -133,7 +132,7 @@ func (s *RulesBuilderTestSuiteBase) expectGetAllEffectivePolicies(clientIntents 
 	services := make(map[string][]otterizev1alpha3.ClientIntents)
 	for _, clientIntent := range clientIntents {
 		for _, intentCall := range clientIntent.GetCallsList() {
-			serverService := serviceidentity.NewFromIntent(intentCall, clientIntent.Namespace)
+			serverService := intentCall.ToServiceIdentity(clientIntent.Namespace)
 			services[serverService.GetFormattedOtterizeIdentity()] = append(services[serverService.GetFormattedOtterizeIdentity()], clientIntent)
 		}
 	}

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -153,8 +153,7 @@ func (p *PodWatcher) updateServerSideCar(ctx context.Context, pod v1.Pod, servic
 	}
 
 	for _, clientIntents := range intentsList.Items {
-		formattedTargetServer := otterizev1alpha3.GetFormattedOtterizeIdentity(serviceID.Name, pod.Namespace)
-		err = p.istioPolicyAdmin.UpdateServerSidecar(ctx, &clientIntents, formattedTargetServer, missingSideCar)
+		err = p.istioPolicyAdmin.UpdateServerSidecar(ctx, &clientIntents, serviceID.GetFormattedOtterizeIdentity(), missingSideCar)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -176,7 +175,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 		return nil
 	}
 
-	otterizeServerLabelValue := otterizev1alpha3.GetFormattedOtterizeIdentity(serviceID.Name, pod.Namespace)
+	otterizeServerLabelValue := serviceID.GetFormattedOtterizeIdentity()
 	updatedPod := pod.DeepCopy()
 	hasUpdates := false
 
@@ -220,7 +219,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 		}
 		if otterizev1alpha3.IsMissingOtterizeAccessLabels(&pod, otterizeAccessLabels) {
 			logrus.Infof("Updating Otterize access labels for %s", serviceID.Name)
-			updatedPod = otterizev1alpha3.UpdateOtterizeAccessLabels(updatedPod.DeepCopy(), serviceID.Name, otterizeAccessLabels)
+			updatedPod = otterizev1alpha3.UpdateOtterizeAccessLabels(updatedPod.DeepCopy(), serviceID, otterizeAccessLabels)
 			prometheus.IncrementPodsLabeledForNetworkPolicies(1)
 			hasUpdates = true
 		}

--- a/src/operator/controllers/pod_reconcilers/pods_test.go
+++ b/src/operator/controllers/pod_reconcilers/pods_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -70,8 +71,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) TestServerLabelAddedWithNilLabels()
 	serviceID, err := s.Reconciler.serviceIdResolver.ResolvePodToServiceIdentity(context.Background(), &pod)
 	s.Require().NoError(err)
 
-	thisPodIdentity := otterizev1alpha3.GetFormattedOtterizeIdentity(
-		serviceID.Name, s.TestNamespace)
+	thisPodIdentity := (&serviceidentity.ServiceIdentity{Name: serviceID.Name, Namespace: s.TestNamespace}).GetFormattedOtterizeIdentity()
 
 	_, err = s.AddIntents("test-intents", serviceID.Name, []otterizev1alpha3.Intent{{
 		Type: otterizev1alpha3.IntentTypeHTTP, Name: intentTargetServerName,
@@ -109,8 +109,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) TestServerLabelAddedWithNilLabels()
 	s.Require().NoError(err)
 	s.Require().Empty(res)
 
-	targetServerIdentity := otterizev1alpha3.GetFormattedOtterizeIdentity(
-		intentTargetServerName, s.TestNamespace)
+	targetServerIdentity := (&serviceidentity.ServiceIdentity{Name: intentTargetServerName, Namespace: s.TestNamespace}).GetFormattedOtterizeIdentity()
 	accessLabel := fmt.Sprintf(otterizev1alpha3.OtterizeAccessLabelKey, targetServerIdentity)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{
@@ -157,8 +156,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) TestClientAccessLabelAdded() {
 	serviceID, err := s.Reconciler.serviceIdResolver.ResolvePodToServiceIdentity(context.Background(), &pod)
 	s.Require().NoError(err)
 
-	thisPodIdentity := otterizev1alpha3.GetFormattedOtterizeIdentity(
-		serviceID.Name, s.TestNamespace)
+	thisPodIdentity := (&serviceidentity.ServiceIdentity{Name: serviceID.Name, Namespace: s.TestNamespace}).GetFormattedOtterizeIdentity()
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{
@@ -178,8 +176,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) TestClientAccessLabelAdded() {
 		},
 	})
 
-	targetServerIdentity := otterizev1alpha3.GetFormattedOtterizeIdentity(
-		intentTargetServerName, s.TestNamespace)
+	targetServerIdentity := (&serviceidentity.ServiceIdentity{Name: intentTargetServerName, Namespace: s.TestNamespace}).GetFormattedOtterizeIdentity()
 
 	accessLabel := fmt.Sprintf(otterizev1alpha3.OtterizeAccessLabelKey, targetServerIdentity)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {

--- a/src/operator/controllers/protected_service_reconcilers/default_deny.go
+++ b/src/operator/controllers/protected_service_reconcilers/default_deny.go
@@ -67,7 +67,8 @@ func (r *DefaultDenyReconciler) blockAccessToServices(ctx context.Context, prote
 			continue
 		}
 
-		formattedServerName := otterizev1alpha3.GetFormattedOtterizeIdentity(protectedService.Spec.Name, namespace)
+		serverServiceIdentity := protectedService.ToServiceIdentity()
+		formattedServerName := serverServiceIdentity.GetFormattedOtterizeIdentity()
 		policy := r.buildNetworkPolicyObjectForIntent(formattedServerName, protectedService.Spec.Name, namespace)
 		if r.netpolEnforcementEnabled {
 			serversToProtect[formattedServerName] = policy

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -79,14 +79,14 @@ func (g *GroupReconciler) getAllServiceEffectivePolicies(ctx context.Context) ([
 		if !clientIntent.DeletionTimestamp.IsZero() {
 			continue
 		}
-		service := serviceidentity.NewFromClientIntent(clientIntent)
+		service := *clientIntent.ToServiceIdentity()
 		services.Add(service)
 		serviceToIntent[service] = clientIntent
 		for _, intentCall := range clientIntent.GetCallsList() {
 			if !g.shouldCreateEffectivePolicyForIntentTargetServer(intentCall, clientIntent.Namespace) {
 				continue
 			}
-			services.Add(serviceidentity.NewFromIntent(intentCall, clientIntent.Namespace))
+			services.Add(*intentCall.ToServiceIdentity(clientIntent.Namespace))
 		}
 	}
 

--- a/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
+++ b/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
@@ -1,17 +1,24 @@
 package serviceidentity
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
-	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
+)
+
+const (
+	MaxOtterizeNameLength = 20
+	MaxNamespaceLength    = 20
 )
 
 type ServiceIdentity struct {
 	Name      string
 	Namespace string
 	Kind      string
+	Group     string
 	// OwnerObject used to resolve the service name. May be nil if service name was resolved using annotation.
 	OwnerObject client.Object
 }
@@ -20,9 +27,9 @@ const KindService = "Service"
 
 func (si *ServiceIdentity) GetFormattedOtterizeIdentity() string {
 	if si.Kind == KindService {
-		return v1alpha3.GetFormattedOtterizeIdentity("svc."+si.Name, si.Namespace)
+		return GetFormattedOtterizeIdentity("svc."+si.Name, si.Namespace)
 	}
-	return v1alpha3.GetFormattedOtterizeIdentity(si.Name, si.Namespace)
+	return GetFormattedOtterizeIdentity(si.Name, si.Namespace)
 }
 
 func (si *ServiceIdentity) GetName() string {
@@ -33,17 +40,58 @@ func (si *ServiceIdentity) GetNameWithKind() string {
 	return lo.Ternary(si.Kind == "", si.Name, fmt.Sprintf("%s-%s", si.Name, strings.ToLower(si.Kind)))
 }
 
-func NewFromIntent(intent v1alpha3.Intent, clientNamespace string) ServiceIdentity {
-	return ServiceIdentity{
-		Name:      intent.GetTargetServerName(),
-		Namespace: intent.GetTargetServerNamespace(clientNamespace),
-		Kind:      lo.Ternary(intent.IsTargetServerKubernetesService(), KindService, ""),
-	}
+func (si *ServiceIdentity) String() string {
+	return fmt.Sprintf("%s/%s/%s/%s", si.Group, si.Kind, si.Namespace, si.Name)
 }
 
-func NewFromClientIntent(clientIntent v1alpha3.ClientIntents) ServiceIdentity {
-	return ServiceIdentity{
-		Name:      clientIntent.Spec.Service.Name,
-		Namespace: clientIntent.Namespace,
+// GetFormattedOtterizeIdentity truncates names and namespaces to a 20 char len string (if required)
+// It also adds a short md5 hash of the full name+ns string and returns the formatted string
+// This is due to Kubernetes' limit on 63 char label keys/values
+func GetFormattedOtterizeIdentity(name, ns string) string {
+	// Get MD5 for full length "name-namespace" string
+	hash := md5.Sum([]byte(fmt.Sprintf("%s-%s", name, ns)))
+
+	// Truncate name and namespace to 20 chars each
+	if len(name) > MaxOtterizeNameLength {
+		name = name[:MaxOtterizeNameLength]
+	}
+
+	if len(ns) > MaxNamespaceLength {
+		ns = ns[:MaxNamespaceLength]
+	}
+	// A 6 char hash, even though truncated, leaves 2 ^ 48 combinations which should be enough
+	// for unique identities in a k8s cluster
+	hashSuffix := hex.EncodeToString(hash[:])[:6]
+
+	return fmt.Sprintf("%s-%s-%s", name, ns, hashSuffix)
+
+}
+
+func GetFormattedOtterizeIdentityWithGK(name, ns, group, kind string) string {
+	// Get MD5 for full length "name-namespace" string
+	hash := md5.Sum([]byte(fmt.Sprintf("%s-%s-%s-%s", name, ns, group, kind)))
+
+	// Truncate name and namespace to 20 chars each
+	if len(name) > MaxOtterizeNameLength {
+		name = name[:MaxOtterizeNameLength]
+	}
+
+	if len(ns) > MaxNamespaceLength {
+		ns = ns[:MaxNamespaceLength]
+	}
+	// A 6 char hash, even though truncated, leaves 2 ^ 48 combinations which should be enough
+	// for unique identities in a k8s cluster
+	hashSuffix := hex.EncodeToString(hash[:])[:6]
+
+	return fmt.Sprintf("%s-%s-%s", name, ns, hashSuffix)
+
+}
+
+func NewFromPodOwner(podOwner client.Object) *ServiceIdentity {
+	return &ServiceIdentity{
+		Name:      podOwner.GetName(),
+		Namespace: podOwner.GetNamespace(),
+		Kind:      podOwner.GetObjectKind().GroupVersionKind().Kind,
+		Group:     podOwner.GetObjectKind().GroupVersionKind().Group,
 	}
 }

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -117,9 +117,6 @@ func (r *Resolver) GetOwnerObject(ctx context.Context, pod *corev1.Pod) (client.
 }
 
 func (r *Resolver) ResolveClientIntentToPod(ctx context.Context, intent v1alpha3.ClientIntents) (corev1.Pod, error) {
-	//if intent.Spec.Service.Kind != "" {
-	//	serviceidentity.NewFromClientIntent(intent).String()
-	//}
 	podsList := &corev1.PodList{}
 	labelSelector, err := intent.BuildPodLabelSelector()
 	if err != nil {

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -117,6 +117,9 @@ func (r *Resolver) GetOwnerObject(ctx context.Context, pod *corev1.Pod) (client.
 }
 
 func (r *Resolver) ResolveClientIntentToPod(ctx context.Context, intent v1alpha3.ClientIntents) (corev1.Pod, error) {
+	//if intent.Spec.Service.Kind != "" {
+	//	serviceidentity.NewFromClientIntent(intent).String()
+	//}
 	podsList := &corev1.PodList{}
 	labelSelector, err := intent.BuildPodLabelSelector()
 	if err != nil {
@@ -144,11 +147,11 @@ func (r *Resolver) ResolveClientIntentToPod(ctx context.Context, intent v1alpha3
 func (r *Resolver) ResolveIntentServerToPod(ctx context.Context, intent v1alpha3.Intent, namespace string) (corev1.Pod, error) {
 	podsList := &corev1.PodList{}
 
-	formattedTargetServer := v1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), namespace)
+	targetServiceIdentity := intent.ToServiceIdentity(namespace)
 	err := r.client.List(
 		ctx,
 		podsList,
-		client.MatchingLabels{v1alpha3.OtterizeServiceLabelKey: formattedTargetServer},
+		client.MatchingLabels{v1alpha3.OtterizeServiceLabelKey: targetServiceIdentity.GetFormattedOtterizeIdentity()},
 		client.InNamespace(namespace),
 	)
 	if err != nil {


### PR DESCRIPTION
### Description

In the upcoming days, we will add the ability to specify resource kind in the `clientIntents`. This change will require changes to the `serviceIdentity`; as a result, it will also cause changes to the `otterizeFormattedIdentity`. 
To prepare for the above change, In this PR I refactored every `GetOtterizeFormattedIdentity` call, to use  `serviceidentity.ServiceIdentity` so we won't have more than one place dealing with it.

### Testing

The existing tests are good enough for this PR.