### PR TITLE
Fix a case where intents to services with a namedPort created network policies without port specification

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
@@ -95,7 +95,7 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 		})
 
 	serviceSelector := map[string]string{"app": "test-server"}
-	svc := s.addExpectedKubernetesServiceCall("test-server", serverNamespace, 80, serviceSelector)
+	svc := s.addExpectedKubernetesServiceCall("test-server", serverNamespace, intstr.IntOrString{IntVal: 80}, serviceSelector)
 
 	egressRules := []v1.NetworkPolicyEgressRule{
 		{To: []v1.NetworkPolicyPeer{{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,7 +96,7 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 		})
 
 	serviceSelector := map[string]string{"app": "test-server"}
-	svc := s.addExpectedKubernetesServiceCall("test-server", serverNamespace, intstr.IntOrString{IntVal: 80}, serviceSelector)
+	svc := s.addExpectedKubernetesServiceCall("test-server", serverNamespace, []corev1.ServicePort{{TargetPort: intstr.IntOrString{IntVal: 80}}}, serviceSelector)
 
 	egressRules := []v1.NetworkPolicyEgressRule{
 		{To: []v1.NetworkPolicyPeer{{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
@@ -77,20 +77,17 @@ func getEgressRuleBasedOnServicePodSelector(svc *corev1.Service) v1.NetworkPolic
 		},
 	}
 
-	portToProtocol := make(map[int]corev1.Protocol)
+	portToProtocol := make(map[intstr.IntOrString]corev1.Protocol)
 	// Gather all target ports (target ports in the pod the service proxies to)
 	for _, port := range svc.Spec.Ports {
-		if port.TargetPort.StrVal != "" {
-			continue
-		}
-		portToProtocol[port.TargetPort.IntValue()] = port.Protocol
+		portToProtocol[port.TargetPort] = port.Protocol
 	}
 
 	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
 	// Create a list of network policy ports
 	for port, protocol := range portToProtocol {
 		netpolPort := v1.NetworkPolicyPort{
-			Port: &intstr.IntOrString{IntVal: int32(port)},
+			Port: lo.ToPtr(port),
 		}
 		if len(protocol) != 0 {
 			netpolPort.Protocol = lo.ToPtr(protocol)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
@@ -77,20 +77,14 @@ func getEgressRuleBasedOnServicePodSelector(svc *corev1.Service) v1.NetworkPolic
 		},
 	}
 
-	portToProtocol := make(map[intstr.IntOrString]corev1.Protocol)
-	// Gather all target ports (target ports in the pod the service proxies to)
-	for _, port := range svc.Spec.Ports {
-		portToProtocol[port.TargetPort] = port.Protocol
-	}
-
-	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
 	// Create a list of network policy ports
-	for port, protocol := range portToProtocol {
+	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
+	for _, port := range svc.Spec.Ports {
 		netpolPort := v1.NetworkPolicyPort{
-			Port: lo.ToPtr(port),
+			Port: lo.ToPtr(port.TargetPort),
 		}
-		if len(protocol) != 0 {
-			netpolPort.Protocol = lo.ToPtr(protocol)
+		if len(port.Protocol) != 0 {
+			netpolPort.Protocol = lo.ToPtr(port.Protocol)
 		}
 		networkPolicyPorts = append(networkPolicyPorts, netpolPort)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy.go
@@ -36,19 +36,16 @@ func (r *PortNetworkPolicyReconciler) buildIngressRulesFromEffectivePolicy(ep ef
 	ingressRules := make([]v1.NetworkPolicyIngressRule, 0)
 	fromNamespaces := goset.NewSet[string]()
 
-	portToProtocol := make(map[int]corev1.Protocol)
+	portToProtocol := make(map[intstr.IntOrString]corev1.Protocol)
 	for _, port := range svc.Spec.Ports {
-		if port.TargetPort.StrVal != "" {
-			continue
-		}
-		portToProtocol[port.TargetPort.IntValue()] = port.Protocol
+		portToProtocol[port.TargetPort] = port.Protocol
 	}
 
 	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
 	// Create a list of network policy ports
 	for port, protocol := range portToProtocol {
 		netpolPort := v1.NetworkPolicyPort{
-			Port: &intstr.IntOrString{IntVal: int32(port)},
+			Port: lo.ToPtr(port),
 		}
 		if len(protocol) != 0 {
 			netpolPort.Protocol = lo.ToPtr(protocol)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy.go
@@ -15,7 +15,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,19 +35,14 @@ func (r *PortNetworkPolicyReconciler) buildIngressRulesFromEffectivePolicy(ep ef
 	ingressRules := make([]v1.NetworkPolicyIngressRule, 0)
 	fromNamespaces := goset.NewSet[string]()
 
-	portToProtocol := make(map[intstr.IntOrString]corev1.Protocol)
-	for _, port := range svc.Spec.Ports {
-		portToProtocol[port.TargetPort] = port.Protocol
-	}
-
-	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
 	// Create a list of network policy ports
-	for port, protocol := range portToProtocol {
+	networkPolicyPorts := make([]v1.NetworkPolicyPort, 0)
+	for _, port := range svc.Spec.Ports {
 		netpolPort := v1.NetworkPolicyPort{
-			Port: lo.ToPtr(port),
+			Port: lo.ToPtr(port.TargetPort),
 		}
-		if len(protocol) != 0 {
-			netpolPort.Protocol = lo.ToPtr(protocol)
+		if len(port.Protocol) != 0 {
+			netpolPort.Protocol = lo.ToPtr(port.Protocol)
 		}
 		networkPolicyPorts = append(networkPolicyPorts, netpolPort)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -150,7 +150,7 @@ func (s *RulesBuilderTestSuiteBase) expectGetAllEffectivePolicies(clientIntents 
 	}).AnyTimes()
 }
 
-func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName string, serviceNamespace string, port int, selector map[string]string) *corev1.Service {
+func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName string, serviceNamespace string, port intstr.IntOrString, selector map[string]string) *corev1.Service {
 	serverStrippedSVCPrefix := strings.ReplaceAll(serviceName, "svc:", "")
 	kubernetesSvcNamespacedName := types.NamespacedName{
 		Namespace: serviceNamespace,
@@ -165,9 +165,7 @@ func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName
 		Spec: corev1.ServiceSpec{
 			Selector: selector,
 			Ports: []corev1.ServicePort{{
-				TargetPort: intstr.IntOrString{
-					IntVal: int32(port),
-				},
+				TargetPort: port,
 			}},
 		},
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,7 +149,7 @@ func (s *RulesBuilderTestSuiteBase) expectGetAllEffectivePolicies(clientIntents 
 	}).AnyTimes()
 }
 
-func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName string, serviceNamespace string, port intstr.IntOrString, selector map[string]string) *corev1.Service {
+func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName string, serviceNamespace string, ports []corev1.ServicePort, selector map[string]string) *corev1.Service {
 	serverStrippedSVCPrefix := strings.ReplaceAll(serviceName, "svc:", "")
 	kubernetesSvcNamespacedName := types.NamespacedName{
 		Namespace: serviceNamespace,
@@ -164,9 +163,7 @@ func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName
 
 		Spec: corev1.ServiceSpec{
 			Selector: selector,
-			Ports: []corev1.ServicePort{{
-				TargetPort: port,
-			}},
+			Ports:    ports,
 		},
 	}
 


### PR DESCRIPTION
Fix a case where intents to services with a namedPort created network policies without port specification

### Description

Fix a case where intents to services with a namedPort created network policies without port specification


### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
