### PR TITLE
Report errors group one by one instead of all together

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -98,7 +98,7 @@ func (r *Reconciler) InjectRecorder(recorder record.EventRecorder) {
 }
 
 // ReconcileEffectivePolicies Gets current state of effective policies and returns number of network policies
-func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy) (int, error) {
+func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy) (int, []error) {
 	currentPolicies := goset.NewSet[types.NamespacedName]()
 	errorList := make([]error, 0)
 	for _, ep := range eps {
@@ -112,13 +112,13 @@ func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effec
 		}
 	}
 	if len(errorList) > 0 {
-		return 0, errors.Wrap(goerrors.Join(errorList...))
+		return 0, errorList
 	}
 
 	// remove policies that doesn't exist in the policy list
 	err := r.removeNetworkPoliciesThatShouldNotExist(ctx, currentPolicies)
 	if err != nil {
-		return currentPolicies.Len(), errors.Wrap(err)
+		return currentPolicies.Len(), []error{errors.Wrap(err)}
 	}
 
 	if currentPolicies.Len() != 0 {

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -16,7 +16,7 @@ import (
 )
 
 type reconciler interface {
-	ReconcileEffectivePolicies(ctx context.Context, eps []ServiceEffectivePolicy) (int, error)
+	ReconcileEffectivePolicies(ctx context.Context, eps []ServiceEffectivePolicy) (int, []error)
 	InjectRecorder(recorder record.EventRecorder)
 }
 
@@ -56,8 +56,8 @@ func (g *GroupReconciler) Reconcile(ctx context.Context) error {
 	logrus.Infof("Reconciling %d effectivePolicies", len(eps))
 	for _, epReconciler := range g.reconcilers {
 		logrus.Infof("Starting cycle for %T", epReconciler)
-		_, err := epReconciler.ReconcileEffectivePolicies(ctx, eps)
-		if err != nil {
+		_, errs := epReconciler.ReconcileEffectivePolicies(ctx, eps)
+		for _, err := range errs {
 			errorList = append(errorList, errors.Wrap(err))
 		}
 	}

--- a/src/shared/logrus_bugsnag/logrus.go
+++ b/src/shared/logrus_bugsnag/logrus.go
@@ -51,35 +51,36 @@ type ErrorList interface {
 // Fire forwards an error to Bugsnag. Given a logrus.Entry, it extracts the
 // "error" field (or the Message if the error isn't present) and sends it off.
 func (hook *bugsnagHook) Fire(entry *logrus.Entry) error {
-	errFromLog := bugsnagerrors.New(entry.Message, 1).Err
-	if err, ok := entry.Data[errorLogKey].(error); ok {
-		errFromLog = err
-		// don't delete error as it's a standard logrus field and other hooks may make use of it
-
-		bugsnagErr, ok := errFromLog.(*bugsnagerrors.Error)
-		if ok {
-			// Check if the underlying error field contains a list, usually created by calling to go stdlib errors.Join
-			errList, ok := bugsnagErr.Err.(ErrorList)
-			if ok {
-				for _, errToNotify := range errList.Unwrap() {
-					err := bugsnag.Notify(errToNotify)
-					if err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-		}
-	}
-
-	err := hook.notifyErr(entry, errFromLog)
+	errorsList := getErrors(entry)
+	err := hook.notifyErr(entry, errorsList)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (hook *bugsnagHook) notifyErr(entry *logrus.Entry, notifyErr error) error {
+func getErrors(entry *logrus.Entry) []error {
+	errFromMessage := bugsnagerrors.New(entry.Message, 1).Err
+	errFromLog, ok := entry.Data[errorLogKey].(error)
+	if !ok {
+		return []error{errFromMessage}
+	}
+	// don't delete error key from entry as it's a standard logrus field and other hooks may make use of it
+
+	bugsnagErr, ok := errFromLog.(*bugsnagerrors.Error)
+	if !ok {
+		return []error{errFromLog}
+	}
+
+	// Check if the underlying error field contains a list, usually created by calling to go stdlib errors.Join
+	errList, ok := bugsnagErr.Err.(ErrorList)
+	if !ok {
+		return []error{bugsnagErr}
+	}
+	return errList.Unwrap()
+}
+
+func (hook *bugsnagHook) notifyErr(entry *logrus.Entry, errList []error) error {
 	bugsnagRawData := make([]any, 0)
 
 	metadata := bugsnag.MetaData{}
@@ -92,10 +93,12 @@ func (hook *bugsnagHook) notifyErr(entry *logrus.Entry, notifyErr error) error {
 
 	bugsnagRawData = append(bugsnagRawData, metadata)
 
-	errWithStack := errors.WrapWithSkip(notifyErr, skipStackFrames)
-	bugsnagErr := bugsnag.Notify(errWithStack, bugsnagRawData...)
-	if bugsnagErr != nil {
-		return ErrBugsnagSendFailed{bugsnagErr}
+	for _, notifyErr := range errList {
+		errWithStack := errors.WrapWithSkip(notifyErr, skipStackFrames)
+		bugsnagErr := bugsnag.Notify(errWithStack, bugsnagRawData...)
+		if bugsnagErr != nil {
+			return ErrBugsnagSendFailed{bugsnagErr}
+		}
 	}
 
 	return nil

--- a/src/shared/logrus_bugsnag/logrus.go
+++ b/src/shared/logrus_bugsnag/logrus.go
@@ -44,14 +44,42 @@ func NewBugsnagHook() (*bugsnagHook, error) {
 const skipStackFrames = 3
 const errorLogKey = "error"
 
+type ErrorList interface {
+	Unwrap() []error
+}
+
 // Fire forwards an error to Bugsnag. Given a logrus.Entry, it extracts the
 // "error" field (or the Message if the error isn't present) and sends it off.
 func (hook *bugsnagHook) Fire(entry *logrus.Entry) error {
-	notifyErr := bugsnagerrors.New(entry.Message, 1).Err
+	errFromLog := bugsnagerrors.New(entry.Message, 1).Err
 	if err, ok := entry.Data[errorLogKey].(error); ok {
-		notifyErr = err
+		errFromLog = err
 		// don't delete error as it's a standard logrus field and other hooks may make use of it
+
+		bugsnagErr, ok := errFromLog.(*bugsnagerrors.Error)
+		if ok {
+			// Check if the underlying error field contains a list, usually created by calling to go stdlib errors.Join
+			errList, ok := bugsnagErr.Err.(ErrorList)
+			if ok {
+				for _, errToNotify := range errList.Unwrap() {
+					err := bugsnag.Notify(errToNotify)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			}
+		}
 	}
+
+	err := hook.notifyErr(entry, errFromLog)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (hook *bugsnagHook) notifyErr(entry *logrus.Entry, notifyErr error) error {
 	bugsnagRawData := make([]any, 0)
 
 	metadata := bugsnag.MetaData{}


### PR DESCRIPTION
### Description

When using Go standard library errors groups with Bugsnag API, the errors are reported as one error with the stack trace of call to `errors.Join` instead of the stack trace of the errors. This PR notify Bugsnag with each error, individually.

### Testing

Due to the infrastructure nature of this change, it can be tested by running the code locally and tracking the errors reported
