### PR TITLE
Support templating by $(AWS_REGION) & $(AWS_ACCOUNT_ID)

### DIFF
--- a/src/operator/controllers/intents_reconcilers/aws_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/aws_reconciler.go
@@ -112,22 +112,7 @@ func (r *AWSIntentsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		return ctrl.Result{}, nil
 	}
 
-	policy := awsagent.PolicyDocument{
-		Version: "2012-10-17",
-	}
-
-	for _, intent := range filteredIntents {
-		awsResource := intent.Name
-		actions := intent.AWSActions
-
-		policy.Statement = append(policy.Statement, awsagent.StatementEntry{
-			Effect:   "Allow",
-			Resource: awsResource,
-			Action:   actions,
-		})
-	}
-
-	err = r.awsAgent.AddRolePolicy(ctx, req.Namespace, serviceAccountName, intents.Spec.Service.Name, policy.Statement)
+	err = r.awsAgent.AddRolePolicyFromIntents(ctx, req.Namespace, serviceAccountName, intents.Spec.Service.Name, filteredIntents)
 	if err != nil {
 		r.RecordWarningEventf(&intents, consts.ReasonReconcilingAWSPoliciesFailed, "Failed to reconcile AWS policies due to error: %s", err.Error())
 		return ctrl.Result{}, errors.Wrap(err)

--- a/src/shared/awsagent/agent.go
+++ b/src/shared/awsagent/agent.go
@@ -79,6 +79,7 @@ type Agent struct {
 	iamClient                        IAMClient
 	markRolesAsUnusedInsteadOfDelete bool
 	rolesAnywhereClient              RolesAnywhereClient
+	region                           string
 	accountID                        string
 	oidcURL                          string
 	clusterName                      string
@@ -140,6 +141,7 @@ func NewAWSAgent(
 		iamClient:           iamClient,
 		rolesAnywhereClient: rolesAnywhereClient,
 		profileNameToId:     make(map[string]string),
+		region:              awsConfig.Region,
 	}
 
 	for _, option := range options {

--- a/src/shared/awsagent/policies_test.go
+++ b/src/shared/awsagent/policies_test.go
@@ -1,0 +1,27 @@
+package awsagent
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type AWSAgentPolicySuite struct {
+	suite.Suite
+}
+
+// Test templateResourceName
+func (s *AWSAgentPolicySuite) Test_templateResourceName() {
+	// Given
+	agent := &Agent{
+		region:    "test-region",
+		accountID: "test-accountid",
+	}
+	// When
+	resourceName := agent.templateResourceName("arn:aws:sqs:$(AWS_REGION):$(AWS_ACCOUNT_ID):queue1")
+	// Then
+	s.Equal("arn:aws:sqs:test-region:test-accountid:queue1", resourceName)
+}
+
+func TestRunAWSAgentPolicySuite(t *testing.T) {
+	suite.Run(t, new(AWSAgentPolicySuite))
+}


### PR DESCRIPTION
### Description
This PR adds support for templating AWS resource names by AWS region and AWS account ID. 
The `$(AWS_REGION)` & `$(AWS_ACCOUNT_ID)` templates on AWS resource names will be automatically replaced by the EKS cluster's region & account ID. 

Usage:
```yaml
apiVersion: k8s.otterize.com/v1alpha3
kind: ClientIntents
metadata:
  name: client
spec:
  service:
    name: client
  calls:
    - name: arn:aws:sqs:$(AWS_REGION):$(AWS_ACCOUNT_ID):queue1
      type: aws
      awsActions:
        - "sqs:*"
```

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
