### PR TITLE
Fix benign problem where Completed pods would log errors when labeling was attempted; fix benign problem where pods that were just terminated logged an error when the operator tried to label them; set a lot of Info logs to Debug level

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -64,7 +64,7 @@ func (r *NetworkPolicyHandler) createOrUpdateNetworkPolicy(
 
 	// No matching network policy found, create one
 	if k8serrors.IsNotFound(errGetExistingPolicy) {
-		logrus.Infof("Creating network policy to allow external traffic to %s (ns %s)", endpoints.GetName(), endpoints.GetNamespace())
+		logrus.Debugf("Creating network policy to allow external traffic to %s (ns %s)", endpoints.GetName(), endpoints.GetNamespace())
 		err := r.client.Create(ctx, newPolicy)
 		if err != nil {
 			r.RecordWarningEventf(owner, ReasonCreatingExternalTrafficPolicyFailed, "failed to create external traffic network policy: %s", err.Error())
@@ -438,7 +438,7 @@ func (r *NetworkPolicyHandler) handlePolicyDelete(ctx context.Context, policyNam
 		ownerObj.SetKind(ownerRef.Kind)
 		err := r.client.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: policyNamespace}, ownerObj)
 		if err != nil {
-			logrus.Infof("can't get the owner of %s. So no events will be recorded for the deletion", policyName)
+			logrus.Debugf("can't get the owner of %s. So no events will be recorded for the deletion", policyName)
 		}
 		owner = ownerObj
 	}

--- a/src/operator/controllers/iam_pod_reconciler/pods.go
+++ b/src/operator/controllers/iam_pod_reconciler/pods.go
@@ -44,7 +44,7 @@ func NewIAMPodReconciler(c client.Client, eventRecorder record.EventRecorder, ia
 
 func (p *IAMPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := logrus.WithField("namespace", req.Namespace).WithField("name", req.Name)
-	logger.Infof("Reconciling due to pod change")
+	logger.Debugf("Reconciling due to pod change")
 
 	pod := v1.Pod{}
 	err := p.Get(ctx, req.NamespacedName, &pod)
@@ -74,7 +74,7 @@ func (p *IAMPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 
-	logger.Infof("Found %d intents for service", len(intents.Items))
+	logger.Debugf("Found %d intents for service", len(intents.Items))
 
 	for _, intent := range intents.Items {
 		result, err := p.iamReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -212,7 +212,7 @@ func (r *IntentsReconciler) getIntentsToAPIServerService(ctx context.Context) []
 		logrus.WithError(err).Errorf("Failed to list client intents for client %s", fullServerName)
 		return nil
 	}
-	logrus.Infof("Enqueueing client intents %v for api server", intentsToServer.Items)
+	logrus.Debugf("Enqueueing client intents %v for api server", intentsToServer.Items)
 
 	intentsToReconcile = append(intentsToReconcile, intentsToServer.Items...)
 	return intentsToReconcile
@@ -220,7 +220,7 @@ func (r *IntentsReconciler) getIntentsToAPIServerService(ctx context.Context) []
 
 func (r *IntentsReconciler) mapProtectedServiceToClientIntents(ctx context.Context, obj client.Object) []reconcile.Request {
 	protectedService := obj.(*otterizev1alpha3.ProtectedService)
-	logrus.Infof("Enqueueing client intents for protected services %s", protectedService.Name)
+	logrus.Debugf("Enqueueing client intents for protected services %s", protectedService.Name)
 
 	intentsToReconcile := r.getIntentsToProtectedService(ctx, protectedService)
 	return r.mapIntentsToRequests(intentsToReconcile)

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -71,7 +71,7 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	logrus.Infof("Reconciling Istio authorization policies for service %s in namespace %s",
+	logrus.Debugf("Reconciling Istio authorization policies for service %s in namespace %s",
 		intents.Spec.Service.Name, req.Namespace)
 
 	if !intents.DeletionTimestamp.IsZero() {
@@ -119,7 +119,7 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if missingSideCar {
 		r.RecordWarningEvent(intents, istiopolicy.ReasonMissingSidecar, "Client pod missing sidecar, will not create policies")
-		logrus.Infof("Pod %s/%s does not have a sidecar, skipping Istio policy creation", pod.Namespace, pod.Name)
+		logrus.Debugf("Pod %s/%s does not have a sidecar, skipping Istio policy creation", pod.Namespace, pod.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -94,7 +94,7 @@ func (r *KafkaACLReconciler) applyACLs(ctx context.Context, intents *otterizev1a
 		}
 
 		if !shouldCreatePolicy {
-			logrus.Infof("Enforcement is disabled globally and server is not explicitly protected, skipping Kafka ACL creation for server %s in namespace %s", serverName.Name, serverName.Namespace)
+			logrus.Debugf("Enforcement is disabled globally and server is not explicitly protected, skipping Kafka ACL creation for server %s in namespace %s", serverName.Name, serverName.Namespace)
 			r.RecordNormalEventf(intents, consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally and called service '%s' is not explicitly protected using a ProtectedService resource, Kafka ACL creation skipped", serverName.Name)
 			// Intentionally no return - KafkaIntentsAdminImpl skips the creation, but still needs to do deletion.
 		}
@@ -226,7 +226,7 @@ func (r *KafkaACLReconciler) intentsObjectUnderDeletion(intents *otterizev1alpha
 }
 
 func (r *KafkaACLReconciler) handleIntentsDeletion(ctx context.Context, intents *otterizev1alpha3.ClientIntents, logger *logrus.Entry) (ctrl.Result, error) {
-	logger.Infof("Removing associated Acls")
+	logger.Debugf("Removing associated Acls")
 	if err := r.RemoveACLs(ctx, intents); err != nil {
 		r.RecordWarningEventf(intents, ReasonRemovingKafkaACLsFailed, "Could not remove Kafka ACLs: %s", err.Error())
 		return ctrl.Result{}, errors.Wrap(err)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -129,7 +129,7 @@ func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effec
 
 func (r *Reconciler) applyServiceEffectivePolicy(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy) (types.NamespacedName, bool, error) {
 	if !r.EnableNetworkPolicyCreation {
-		logrus.Infof("Network policy creation is disabled, skipping network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
+		logrus.Debugf("Network policy creation is disabled, skipping network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
 		if len(ep.Calls) > 0 && len(r.egressRuleBuilders) > 0 {
 			ep.ClientIntentsEventRecorder.RecordNormalEventf(consts.ReasonEgressNetworkPolicyCreationDisabled, "Network policy creation is disabled, creation skipped")
 		}
@@ -190,7 +190,7 @@ func (r *Reconciler) buildEgressRules(ctx context.Context, ep effectivepolicy.Se
 		return rules, false, nil
 	}
 	if !r.EnforcementDefaultState {
-		logrus.Infof("Enforcement is disabled globally skipping egress network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
+		logrus.Debugf("Enforcement is disabled globally skipping egress network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
 		ep.ClientIntentsEventRecorder.RecordNormalEventf(consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally, network policy creation skipped")
 		return rules, false, nil
 	}
@@ -221,7 +221,7 @@ func (r *Reconciler) buildIngressRules(ctx context.Context, ep effectivepolicy.S
 		return rules, false, errors.Wrap(err)
 	}
 	if !shouldCreatePolicy {
-		logrus.Infof("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
+		logrus.Debugf("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
 		ep.RecordOnClientsNormalEventf(consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally and called service '%s' is not explicitly protected using a ProtectedService resource, network policy creation skipped", ep.Service.Name)
 		return rules, false, nil
 	}
@@ -395,7 +395,7 @@ func (r *Reconciler) removeNetworkPoliciesThatShouldNotExist(ctx context.Context
 		namespacedName := types.NamespacedName{Namespace: networkPolicy.Namespace, Name: networkPolicy.Name}
 		if !netpolNamesThatShouldExist.Contains(namespacedName) {
 			serverName := networkPolicy.Labels[otterizev1alpha3.OtterizeNetworkPolicy]
-			logrus.Infof("Removing orphaned network policy: %s server %s ns %s", networkPolicy.Name, serverName, networkPolicy.Namespace)
+			logrus.Debugf("Removing orphaned network policy: %s server %s ns %s", networkPolicy.Name, serverName, networkPolicy.Namespace)
 			err = r.removeNetworkPolicy(ctx, networkPolicy)
 			if err != nil {
 				return errors.Wrap(err)

--- a/src/operator/controllers/intents_reconcilers/pods.go
+++ b/src/operator/controllers/intents_reconcilers/pods.go
@@ -81,7 +81,7 @@ func (r *PodLabelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	for _, pod := range podList.Items {
 		if otterizev1alpha3.IsMissingOtterizeAccessLabels(&pod, intentLabels) {
-			logrus.Infof("Updating %s pod labels with new intents", serviceName)
+			logrus.Debugf("Updating %s pod labels with new intents", serviceName)
 			updatedPod := otterizev1alpha3.UpdateOtterizeAccessLabels(pod.DeepCopy(), serviceName, intentLabels)
 			err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
 			if err != nil {
@@ -97,7 +97,7 @@ func (r *PodLabelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *PodLabelReconciler) removeLabelsFromPods(
 	ctx context.Context, intents *otterizev1alpha3.ClientIntents) error {
 
-	logrus.Infof("Unlabeling pods for Otterize service %s", intents.Spec.Service.Name)
+	logrus.Debugf("Unlabeling pods for Otterize service %s", intents.Spec.Service.Name)
 
 	labelSelector, err := intents.BuildPodLabelSelector()
 	if err != nil {

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -215,7 +215,7 @@ func (c *PolicyManagerImpl) saveServiceAccountName(ctx context.Context, clientIn
 		return errors.Wrap(err)
 	}
 
-	logrus.Infof("updating intent %s with service account name %s", clientIntents.Name, clientServiceAccount)
+	logrus.Debugf("updating intent %s with service account name %s", clientIntents.Name, clientServiceAccount)
 
 	return nil
 }
@@ -263,7 +263,7 @@ func (c *PolicyManagerImpl) updateSharedServiceAccountsInNamespace(ctx context.C
 }
 
 func (c *PolicyManagerImpl) updateServiceAccountSharedStatus(ctx context.Context, clientIntents []v1alpha3.ClientIntents, serviceAccount string) error {
-	logrus.Infof("Found %d intents with service account %s", len(clientIntents), serviceAccount)
+	logrus.Debugf("Found %d intents with service account %s", len(clientIntents), serviceAccount)
 	isServiceAccountShared := len(clientIntents) > 1
 	sharedAccountValue := lo.Ternary(isServiceAccountShared, "true", "false")
 
@@ -327,7 +327,7 @@ func (c *PolicyManagerImpl) createOrUpdatePolicies(
 		}
 
 		if !shouldCreatePolicy {
-			logrus.Infof("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", intent.GetTargetServerName(), intent.GetTargetServerNamespace(clientIntents.Namespace))
+			logrus.Debugf("Enforcement is disabled globally and server is not explicitly protected, skipping network policy creation for server %s in namespace %s", intent.GetTargetServerName(), intent.GetTargetServerNamespace(clientIntents.Namespace))
 			c.recorder.RecordNormalEventf(clientIntents, consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally and called service '%s' is not explicitly protected using a ProtectedService resource, network policy creation skipped", intent.Name)
 			continue
 		}
@@ -460,7 +460,7 @@ func (c *PolicyManagerImpl) generateAuthorizationPolicy(
 	clientServiceAccountName string,
 ) *v1beta1.AuthorizationPolicy {
 	policyName := c.getPolicyName(clientIntents, intent)
-	logrus.Infof("Creating Istio policy %s for intent %s", policyName, intent.GetTargetServerName())
+	logrus.Debugf("Creating Istio policy %s for intent %s", policyName, intent.GetTargetServerName())
 
 	serverNamespace := intent.GetTargetServerNamespace(clientIntents.Namespace)
 	formattedTargetServer := v1alpha3.GetFormattedOtterizeIdentity(intent.GetTargetServerName(), serverNamespace)

--- a/src/operator/controllers/kafkaserverconfig_controller.go
+++ b/src/operator/controllers/kafkaserverconfig_controller.go
@@ -124,7 +124,7 @@ func (r *KafkaServerConfigReconciler) InitKafkaServerConfigIndices(mgr ctrl.Mana
 
 func (r *KafkaServerConfigReconciler) mapProtectedServiceToKafkaServerConfig(ctx context.Context, obj client.Object) []reconcile.Request {
 	protectedService := obj.(*otterizev1alpha3.ProtectedService)
-	logrus.Infof("Enqueueing KafkaServerConfigs for protected service %s", protectedService.Name)
+	logrus.Debugf("Enqueueing KafkaServerConfigs for protected service %s", protectedService.Name)
 
 	kscsToReconcile := r.getKSCsForProtectedService(ctx, protectedService)
 	return lo.Map(kscsToReconcile, func(ksc otterizev1alpha3.KafkaServerConfig, _ int) reconcile.Request {

--- a/src/operator/controllers/pod_reconcilers/namespace.go
+++ b/src/operator/controllers/pod_reconcilers/namespace.go
@@ -27,7 +27,7 @@ func NewNamespaceWatcher(c client.Client) *NamespaceWatcher {
 }
 
 func (ns *NamespaceWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logrus.Infof("Reconciling due to namespace change: %s", req.Name)
+	logrus.Debugf("Reconciling due to namespace change: %s", req.Name)
 	namespace := &v1.Namespace{}
 	err := ns.Get(ctx, req.NamespacedName, namespace)
 	if k8serrors.IsNotFound(err) {

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -233,7 +233,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 
 	if hasUpdates {
 		err = p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
-		if err != nil {
+		if client.IgnoreNotFound(err) != nil {
 			return errors.Errorf("failed updating Otterize labels for pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
 		}
 	}

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -50,11 +50,16 @@ func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedN
 }
 
 func (p *PodWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logrus.Infof("Reconciling due to pod change: %s", req.Name)
+	logrus.Debugf("Reconciling due to pod change: %s", req.Name)
 	pod := v1.Pod{}
 	err := p.Get(ctx, req.NamespacedName, &pod)
 	if k8serrors.IsNotFound(err) {
 		logrus.Infoln("Pod was deleted")
+		return ctrl.Result{}, nil
+	}
+
+	if pod.Status.Phase != v1.PodPending && pod.Status.Phase != v1.PodRunning {
+		logrus.Debugf("Pod %s is not in a running state, skipping reconciliation", pod.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -172,7 +177,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 	// Intents were deleted and the pod was updated by the operator, skip reconciliation
 	_, ok := pod.Annotations[otterizev1alpha3.AllIntentsRemovedAnnotation]
 	if ok {
-		logrus.Infof("Skipping reconciliation for pod %s - pod is handled by intents-operator", req.Name)
+		logrus.Debugf("Skipping reconciliation for pod %s - pod is handled by intents-operator", req.Name)
 		return nil
 	}
 
@@ -184,7 +189,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 	// This is the pod selector used in network policies to grant access to this pod.
 	if !otterizev1alpha3.HasOtterizeServiceLabel(&pod, otterizeServerLabelValue) {
 		// Label pods as destination servers
-		logrus.Infof("Labeling pod %s with server identity %s", pod.Name, serviceID.Name)
+		logrus.Debugf("Labeling pod %s with server identity %s", pod.Name, serviceID.Name)
 		if updatedPod.Labels == nil {
 			updatedPod.Labels = make(map[string]string)
 		}
@@ -219,7 +224,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 			}
 		}
 		if otterizev1alpha3.IsMissingOtterizeAccessLabels(&pod, otterizeAccessLabels) {
-			logrus.Infof("Updating Otterize access labels for %s", serviceID.Name)
+			logrus.Debugf("Updating Otterize access labels for %s", serviceID.Name)
 			updatedPod = otterizev1alpha3.UpdateOtterizeAccessLabels(updatedPod.DeepCopy(), serviceID.Name, otterizeAccessLabels)
 			prometheus.IncrementPodsLabeledForNetworkPolicies(1)
 			hasUpdates = true
@@ -252,7 +257,7 @@ func (p *PodWatcher) createIstioPolicies(ctx context.Context, intents otterizev1
 	}
 
 	if missingSideCar {
-		logrus.Infof("Pod %s/%s does not have a sidecar, skipping Istio policy creation", pod.Namespace, pod.Name)
+		logrus.Debugf("Pod %s/%s does not have a sidecar, skipping Istio policy creation", pod.Namespace, pod.Name)
 		return nil
 	}
 

--- a/src/operator/controllers/protected_service_reconcilers/default_deny.go
+++ b/src/operator/controllers/protected_service_reconcilers/default_deny.go
@@ -97,7 +97,7 @@ func (r *DefaultDenyReconciler) blockAccessToServices(ctx context.Context, prote
 			if err != nil {
 				return errors.Wrap(err)
 			}
-			logrus.Infof("Deleted network policy %s", existingPolicy.Name)
+			logrus.Debugf("Deleted network policy %s", existingPolicy.Name)
 		}
 	}
 
@@ -106,7 +106,7 @@ func (r *DefaultDenyReconciler) blockAccessToServices(ctx context.Context, prote
 		if err != nil {
 			return errors.Wrap(err)
 		}
-		logrus.Infof("Created network policy %s", networkPolicy.Name)
+		logrus.Debugf("Created network policy %s", networkPolicy.Name)
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func (r *DefaultDenyReconciler) updateIfNeeded(
 		return errors.Wrap(err)
 	}
 
-	logrus.Infof("Updated network policy %s", existingPolicy.Name)
+	logrus.Debugf("Updated network policy %s", existingPolicy.Name)
 	return nil
 }
 
@@ -173,7 +173,7 @@ func (r *DefaultDenyReconciler) DeleteAllDefaultDeny(ctx context.Context, namesp
 		if err != nil {
 			return ctrl.Result{}, errors.Wrap(err)
 		}
-		logrus.Infof("Deleted network policy %s", existingPolicy.Name)
+		logrus.Debugf("Deleted network policy %s", existingPolicy.Name)
 	}
 
 	return ctrl.Result{}, nil

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -53,9 +53,9 @@ func (g *GroupReconciler) Reconcile(ctx context.Context) error {
 	}
 
 	errorList := make([]error, 0)
-	logrus.Infof("Reconciling %d effectivePolicies", len(eps))
+	logrus.Debugf("Reconciling %d effectivePolicies", len(eps))
 	for _, epReconciler := range g.reconcilers {
-		logrus.Infof("Starting cycle for %T", epReconciler)
+		logrus.Debugf("Starting cycle for %T", epReconciler)
 		_, err := epReconciler.ReconcileEffectivePolicies(ctx, eps)
 		if err != nil {
 			errorList = append(errorList, errors.Wrap(err))

--- a/src/shared/errors/errors.go
+++ b/src/shared/errors/errors.go
@@ -80,7 +80,10 @@ func wrapImpl(err error, skip int) error {
 	if err == nil {
 		return nil
 	}
-
+	// Don't re-wrap user errors that already have a stack
+	if _, ok := err.(interface{ Unwrap() error }).Unwrap().(*bugsnagerrors.Error); ok {
+		return err
+	}
 	return bugsnagerrors.New(err, skip+1)
 }
 

--- a/src/shared/errors/errors.go
+++ b/src/shared/errors/errors.go
@@ -80,10 +80,6 @@ func wrapImpl(err error, skip int) error {
 	if err == nil {
 		return nil
 	}
-	// Don't re-wrap user errors that already have a stack
-	if _, ok := err.(interface{ Unwrap() error }).Unwrap().(*bugsnagerrors.Error); ok {
-		return err
-	}
 	return bugsnagerrors.New(err, skip+1)
 }
 

--- a/src/shared/operator_cloud_client/cloud_api.go
+++ b/src/shared/operator_cloud_client/cloud_api.go
@@ -56,7 +56,7 @@ func (c *CloudClientImpl) ReportAppliedIntents(
 		return errors.Wrap(err)
 	}
 
-	logrus.Infof("New intents count for namespace %s: %d", *namespace, len(intents))
+	logrus.Debugf("New intents count for namespace %s: %d", *namespace, len(intents))
 	return nil
 }
 

--- a/src/shared/reconcilergroup/reconcilergroup.go
+++ b/src/shared/reconcilergroup/reconcilergroup.go
@@ -56,7 +56,7 @@ func (g *Group) AddToGroup(reconciler ReconcilerWithEvents) {
 func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var finalErr error
 	var finalRes ctrl.Result
-	logrus.Infof("## Starting reconciliation group cycle for %s", g.name)
+	logrus.Debugf("## Starting reconciliation group cycle for %s", g.name)
 
 	resourceObject := g.baseObject.DeepCopyObject().(client.Object)
 	err := g.client.Get(ctx, req.NamespacedName, resourceObject)
@@ -64,7 +64,7 @@ func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, e
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 	if k8serrors.IsNotFound(err) {
-		logrus.Infof("Resource %s not found, skipping reconciliation", req.NamespacedName)
+		logrus.Debugf("Resource %s not found, skipping reconciliation", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -143,7 +143,7 @@ func (g *Group) removeFinalizer(ctx context.Context, resource client.Object) err
 
 func (g *Group) runGroup(ctx context.Context, req ctrl.Request, finalErr error, finalRes ctrl.Result) (ctrl.Result, error) {
 	for _, reconciler := range g.reconcilers {
-		logrus.Infof("Starting cycle for %T", reconciler)
+		logrus.Debugf("Starting cycle for %T", reconciler)
 		res, err := reconciler.Reconcile(ctx, req)
 		if err != nil {
 			if finalErr == nil {


### PR DESCRIPTION
Prior to this PR, we would try to label Completed pods, but this is not possible, resulting in an error being logged. This didn't have any impact other than reporting error logs.