### PR TITLE
Fix issue where panics would be misreported in error telemetry

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -116,6 +116,7 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 	errorreporter.Init("intents-operator", version.Version(), viper.GetString(operatorconfig.TelemetryErrorsAPIKeyKey))
+	defer errorreporter.AutoNotify()
 
 	metricsAddr := viper.GetString(operatorconfig.MetricsAddrKey)
 	probeAddr := viper.GetString(operatorconfig.ProbeAddrKey)
@@ -292,6 +293,8 @@ func main() {
 	if err = endpointReconciler.InitIngressReferencedServicesIndex(mgr); err != nil {
 		logrus.WithError(err).Panic("unable to init index for ingress")
 	}
+
+	logrus.Panic("testing")
 
 	otterizeCloudClient, connectedToCloud, err := operator_cloud_client.NewClient(signalHandlerCtx)
 	if err != nil {

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -294,8 +294,6 @@ func main() {
 		logrus.WithError(err).Panic("unable to init index for ingress")
 	}
 
-	logrus.Panic("testing")
-
 	otterizeCloudClient, connectedToCloud, err := operator_cloud_client.NewClient(signalHandlerCtx)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to initialize Otterize Cloud client")

--- a/src/shared/logrus_bugsnag/logrus.go
+++ b/src/shared/logrus_bugsnag/logrus.go
@@ -47,6 +47,10 @@ const errorLogKey = "error"
 // Fire forwards an error to Bugsnag. Given a logrus.Entry, it extracts the
 // "error" field (or the Message if the error isn't present) and sends it off.
 func (hook *bugsnagHook) Fire(entry *logrus.Entry) error {
+	return SendToBugsnag(entry)
+}
+
+func SendToBugsnag(entry *logrus.Entry, rawData ...any) error {
 	notifyErr := bugsnagerrors.New(entry.Message, 1).Err
 	if err, ok := entry.Data[errorLogKey].(error); ok {
 		notifyErr = err
@@ -63,6 +67,7 @@ func (hook *bugsnagHook) Fire(entry *logrus.Entry) error {
 	}
 
 	bugsnagRawData = append(bugsnagRawData, metadata)
+	bugsnagRawData = append(bugsnagRawData, rawData...)
 
 	errWithStack := errors.WrapWithSkip(notifyErr, skipStackFrames)
 	bugsnagErr := bugsnag.Notify(errWithStack, bugsnagRawData...)

--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -79,7 +79,12 @@ func AutoNotify() {
 
 	if err := recover(); err != nil {
 		const shouldNotifySync = true
-		_ = bugsnag.Notify(errors.ErrorfWithSkip(2, "panic caught: %s", err), bugsnag.SeverityError, bugsnag.SeverityReasonHandledPanic, shouldNotifySync)
+		rawData := []any{bugsnag.SeverityError, bugsnag.SeverityReasonHandledPanic, shouldNotifySync}
+		if logrusEntry, ok := err.(*logrus.Entry); ok {
+			_ = logrus_bugsnag.SendToBugsnag(logrusEntry, rawData...)
+			return
+		}
+		_ = bugsnag.Notify(errors.ErrorfWithSkip(2, "panic caught: %s", err), rawData...)
 		panic(err)
 	}
 }


### PR DESCRIPTION
Prior to this PR, the error sent would be a wrapped *logrus.Entry, resulting in hard-to-parse errors.