### PR TITLE
Support enabling enforcement per namespace while using defaultShadow enforcement mode

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/database"
@@ -80,7 +81,7 @@ func NewIntentsReconciler(
 	otterizeClient operator_cloud_client.CloudClient,
 	operatorPodName string,
 	operatorPodNamespace string,
-	activeNamespaces []string,
+	activeNamespaces goset.Set[string],
 	additionalReconcilers ...reconcilergroup.ReconcilerWithEvents,
 ) *IntentsReconciler {
 

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -81,15 +81,15 @@ func NewIntentsReconciler(
 	otterizeClient operator_cloud_client.CloudClient,
 	operatorPodName string,
 	operatorPodNamespace string,
-	activeNamespaces goset.Set[string],
+	enforcedNamespaces *goset.Set[string],
 	additionalReconcilers ...reconcilergroup.ReconcilerWithEvents,
 ) *IntentsReconciler {
 
 	serviceIdResolver := serviceidresolver.NewResolver(client)
 	reconcilers := []reconcilergroup.ReconcilerWithEvents{
 		intents_reconcilers.NewPodLabelReconciler(client, scheme),
-		intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState, operatorPodName, operatorPodNamespace, serviceIdResolver, activeNamespaces),
-		intents_reconcilers.NewIstioPolicyReconciler(client, scheme, restrictToNamespaces, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementDefaultState),
+		intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState, operatorPodName, operatorPodNamespace, serviceIdResolver, enforcedNamespaces),
+		intents_reconcilers.NewIstioPolicyReconciler(client, scheme, restrictToNamespaces, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementDefaultState, enforcedNamespaces),
 	}
 	reconcilers = append(reconcilers, additionalReconcilers...)
 	reconcilersGroup := reconcilergroup.NewGroup(

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -80,13 +80,14 @@ func NewIntentsReconciler(
 	otterizeClient operator_cloud_client.CloudClient,
 	operatorPodName string,
 	operatorPodNamespace string,
+	activeNamespaces []string,
 	additionalReconcilers ...reconcilergroup.ReconcilerWithEvents,
 ) *IntentsReconciler {
 
 	serviceIdResolver := serviceidresolver.NewResolver(client)
 	reconcilers := []reconcilergroup.ReconcilerWithEvents{
 		intents_reconcilers.NewPodLabelReconciler(client, scheme),
-		intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState, operatorPodName, operatorPodNamespace, serviceIdResolver),
+		intents_reconcilers.NewKafkaACLReconciler(client, scheme, kafkaServerStore, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState, operatorPodName, operatorPodNamespace, serviceIdResolver, activeNamespaces),
 		intents_reconcilers.NewIstioPolicyReconciler(client, scheme, restrictToNamespaces, enforcementConfig.EnableIstioPolicy, enforcementConfig.EnforcementDefaultState),
 	}
 	reconcilers = append(reconcilers, additionalReconcilers...)

--- a/src/operator/controllers/intents_controller_test.go
+++ b/src/operator/controllers/intents_controller_test.go
@@ -33,6 +33,7 @@ func (s *IntentsControllerTestSuite) SetupTest() {
 		"",
 		"",
 		nil,
+		nil,
 	)
 }
 

--- a/src/operator/controllers/intents_controller_test.go
+++ b/src/operator/controllers/intents_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"github.com/amit7itz/goset"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -33,7 +32,7 @@ func (s *IntentsControllerTestSuite) SetupTest() {
 		nil,
 		"",
 		"",
-		*goset.NewSet[string](),
+		nil,
 		nil,
 	)
 }

--- a/src/operator/controllers/intents_controller_test.go
+++ b/src/operator/controllers/intents_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/amit7itz/goset"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -32,7 +33,7 @@ func (s *IntentsControllerTestSuite) SetupTest() {
 		nil,
 		"",
 		"",
-		nil,
+		*goset.NewSet[string](),
 		nil,
 	)
 }

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -72,7 +72,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	defaultActive := !isShadowMode
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), netpolHandler, true)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, *goset.NewSet[string](), true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	epReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, epReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -87,7 +87,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, *goset.NewSet[string]())
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, goset.NewSet[string]())
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -3,6 +3,7 @@ package external_traffic_network_policy
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	"github.com/google/uuid"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers"
@@ -71,7 +72,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	defaultActive := !isShadowMode
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), netpolHandler, true)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, []string{}, true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, *goset.NewSet[string](), true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	epReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, epReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -86,7 +87,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, nil)
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, *goset.NewSet[string]())
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -71,7 +71,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	defaultActive := !isShadowMode
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), netpolHandler, true)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, []string{}, true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	epReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, epReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -86,7 +86,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true)
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, nil)
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -63,7 +63,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, []string{}, true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, groupReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -78,7 +78,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true)
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, nil)
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -3,6 +3,7 @@ package external_traffic_network_policy
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers"
 	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
@@ -63,7 +64,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, []string{}, true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, *goset.NewSet[string](), true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, groupReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -78,7 +79,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, nil)
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, *goset.NewSet[string]())
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -64,7 +64,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
 	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always)
-	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, *goset.NewSet[string](), true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
+	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolReconciler)
 	s.EffectivePolicyIntentsReconciler = intents_reconcilers.NewServiceEffectiveIntentsReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, groupReconciler)
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
@@ -79,7 +79,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, *goset.NewSet[string]())
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, goset.NewSet[string]())
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -42,7 +42,7 @@ func NewIstioPolicyReconciler(
 	}
 
 	reconciler.policyManager = istiopolicy.NewPolicyManager(c, &reconciler.InjectableRecorder, restrictToNamespaces,
-		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation)
+		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation, nil)
 
 	return reconciler
 }

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -2,6 +2,7 @@ package intents_reconcilers
 
 import (
 	"context"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	istiopolicy "github.com/otterize/intents-operator/src/operator/controllers/istiopolicy"
@@ -42,7 +43,7 @@ func NewIstioPolicyReconciler(
 	}
 
 	reconciler.policyManager = istiopolicy.NewPolicyManager(c, &reconciler.InjectableRecorder, restrictToNamespaces,
-		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation, nil)
+		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation, *goset.NewSet[string]())
 
 	return reconciler
 }

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -32,7 +32,9 @@ func NewIstioPolicyReconciler(
 	s *runtime.Scheme,
 	restrictToNamespaces []string,
 	enableIstioPolicyCreation bool,
-	enforcementDefaultState bool) *IstioPolicyReconciler {
+	enforcementDefaultState bool,
+	enforcedNamespaces *goset.Set[string],
+) *IstioPolicyReconciler {
 	reconciler := &IstioPolicyReconciler{
 		Client:                    c,
 		Scheme:                    s,
@@ -43,7 +45,7 @@ func NewIstioPolicyReconciler(
 	}
 
 	reconciler.policyManager = istiopolicy.NewPolicyManager(c, &reconciler.InjectableRecorder, restrictToNamespaces,
-		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation, *goset.NewSet[string]())
+		reconciler.enforcementDefaultState, reconciler.enableIstioPolicyCreation, enforcedNamespaces)
 
 	return reconciler
 }

--- a/src/operator/controllers/intents_reconcilers/istio_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy_test.go
@@ -42,6 +42,7 @@ func (s *IstioPolicyReconcilerTestSuite) SetupTest() {
 		restrictToNamespaces,
 		true,
 		true,
+		nil,
 	)
 
 	s.Reconciler.Recorder = s.Recorder

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -2,6 +2,7 @@ package intents_reconcilers
 
 import (
 	"context"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/protected_services"
@@ -38,7 +39,7 @@ type KafkaACLReconciler struct {
 	operatorPodName         string
 	operatorPodNamespace    string
 	serviceResolver         serviceidresolver.ServiceResolver
-	activeNamespaces        []string
+	activeNamespaces        goset.Set[string]
 	injectablerecorder.InjectableRecorder
 }
 
@@ -52,7 +53,7 @@ func NewKafkaACLReconciler(
 	operatorPodName string,
 	operatorPodNamespace string,
 	serviceResolver serviceidresolver.ServiceResolver,
-	activeNamespaces []string,
+	activeNamespaces goset.Set[string],
 ) *KafkaACLReconciler {
 	return &KafkaACLReconciler{
 		client:                  client,

--- a/src/operator/controllers/intents_reconcilers/kafka_acls.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls.go
@@ -39,7 +39,7 @@ type KafkaACLReconciler struct {
 	operatorPodName         string
 	operatorPodNamespace    string
 	serviceResolver         serviceidresolver.ServiceResolver
-	activeNamespaces        goset.Set[string]
+	activeNamespaces        *goset.Set[string]
 	injectablerecorder.InjectableRecorder
 }
 
@@ -53,7 +53,7 @@ func NewKafkaACLReconciler(
 	operatorPodName string,
 	operatorPodNamespace string,
 	serviceResolver serviceidresolver.ServiceResolver,
-	activeNamespaces goset.Set[string],
+	activeNamespaces *goset.Set[string],
 ) *KafkaACLReconciler {
 	return &KafkaACLReconciler{
 		client:                  client,

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -121,6 +121,7 @@ func (s *KafkaACLReconcilerTestSuite) initKafkaIntentsAdmin(enableAclCreation bo
 		operatorPodName,
 		s.operatorNamespace,
 		s.mockServiceResolver,
+		nil,
 	)
 	s.recorder = record.NewFakeRecorder(100)
 	s.Reconciler.InjectRecorder(s.recorder)

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/Shopify/sarama"
-	"github.com/amit7itz/goset"
 	"github.com/google/uuid"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
@@ -122,7 +121,7 @@ func (s *KafkaACLReconcilerTestSuite) initKafkaIntentsAdmin(enableAclCreation bo
 		operatorPodName,
 		s.operatorNamespace,
 		s.mockServiceResolver,
-		*goset.NewSet[string](),
+		nil,
 	)
 	s.recorder = record.NewFakeRecorder(100)
 	s.Reconciler.InjectRecorder(s.recorder)

--- a/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
+++ b/src/operator/controllers/intents_reconcilers/kafka_acls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Shopify/sarama"
+	"github.com/amit7itz/goset"
 	"github.com/google/uuid"
 	otterizev1alpha2 "github.com/otterize/intents-operator/src/operator/api/v1alpha2"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
@@ -121,7 +122,7 @@ func (s *KafkaACLReconcilerTestSuite) initKafkaIntentsAdmin(enableAclCreation bo
 		operatorPodName,
 		s.operatorNamespace,
 		s.mockServiceResolver,
-		nil,
+		*goset.NewSet[string](),
 	)
 	s.recorder = record.NewFakeRecorder(100)
 	s.Reconciler.InjectRecorder(s.recorder)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
@@ -46,7 +46,7 @@ func (s *NetworkPolicyReconcilerTestSuite) testCreateNetworkPolicy(
 	formattedTargetServer string,
 	defaultEnforcementState bool,
 	protectedServices []otterizev1alpha3.ProtectedService,
-	enforcedNamespaces goset.Set[string],
+	enforcedNamespaces *goset.Set[string],
 ) {
 	s.Reconciler.EnforcedNamespaces = enforcedNamespaces
 	s.Reconciler.EnforcementDefaultState = defaultEnforcementState
@@ -185,7 +185,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicy() {
 		formattedTargetServer,
 		true,
 		nil,
-		*goset.NewSet[string](),
+		goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -205,7 +205,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyActiveNamespac
 		formattedTargetServer,
 		false,
 		nil,
-		*goset.FromSlice([]string{serverNamespace}),
+		goset.FromSlice([]string{serverNamespace}),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -235,7 +235,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedService,
-		*goset.NewSet[string](),
+		goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -276,7 +276,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedServices,
-		*goset.NewSet[string](),
+		goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -296,7 +296,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateCrossNamespace
 		formattedTargetServer,
 		true,
 		nil,
-		*goset.NewSet[string](),
+		goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
@@ -3,6 +3,7 @@ package builders
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
@@ -45,7 +46,7 @@ func (s *NetworkPolicyReconcilerTestSuite) testCreateNetworkPolicy(
 	formattedTargetServer string,
 	defaultEnforcementState bool,
 	protectedServices []otterizev1alpha3.ProtectedService,
-	enforcedNamespaces []string,
+	enforcedNamespaces goset.Set[string],
 ) {
 	s.Reconciler.EnforcedNamespaces = enforcedNamespaces
 	s.Reconciler.EnforcementDefaultState = defaultEnforcementState
@@ -184,7 +185,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicy() {
 		formattedTargetServer,
 		true,
 		nil,
-		nil,
+		*goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -204,7 +205,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyActiveNamespac
 		formattedTargetServer,
 		false,
 		nil,
-		[]string{serverNamespace},
+		*goset.FromSlice([]string{serverNamespace}),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -234,7 +235,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedService,
-		nil,
+		*goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -275,7 +276,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedServices,
-		nil,
+		*goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -295,7 +296,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateCrossNamespace
 		formattedTargetServer,
 		true,
 		nil,
-		nil,
+		*goset.NewSet[string](),
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
@@ -45,7 +45,9 @@ func (s *NetworkPolicyReconcilerTestSuite) testCreateNetworkPolicy(
 	formattedTargetServer string,
 	defaultEnforcementState bool,
 	protectedServices []otterizev1alpha3.ProtectedService,
+	enforcedNamespaces []string,
 ) {
+	s.Reconciler.EnforcedNamespaces = enforcedNamespaces
 	s.Reconciler.EnforcementDefaultState = defaultEnforcementState
 	namespacedName := types.NamespacedName{
 		Namespace: testNamespace,
@@ -182,6 +184,27 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicy() {
 		formattedTargetServer,
 		true,
 		nil,
+		nil,
+	)
+	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
+}
+
+func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyActiveNamespace() {
+	clientIntentsName := "client-intents"
+	policyName := "test-server-access"
+	serviceName := "test-client"
+	serverNamespace := testNamespace
+	formattedTargetServer := "test-server-test-namespace-8ddecb"
+
+	s.testCreateNetworkPolicy(
+		clientIntentsName,
+		serverNamespace,
+		serviceName,
+		policyName,
+		formattedTargetServer,
+		false,
+		nil,
+		[]string{serverNamespace},
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -211,6 +234,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedService,
+		nil,
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -251,6 +275,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyWithProtectedS
 		formattedTargetServer,
 		false,
 		protectedServices,
+		nil,
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)
 }
@@ -269,6 +294,7 @@ func (s *NetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateCrossNamespace
 		policyName,
 		formattedTargetServer,
 		true,
+		nil,
 		nil,
 	)
 	s.ExpectEvent(consts.ReasonCreatedNetworkPolicies)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -2,7 +2,6 @@ package builders
 
 import (
 	"context"
-	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
@@ -51,7 +50,7 @@ func (s *RulesBuilderTestSuiteBase) SetupTest() {
 		s.scheme,
 		s.externalNetpolHandler,
 		restrictToNamespaces,
-		*goset.NewSet[string](),
+		nil,
 		true,
 		true,
 		nil,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -2,6 +2,7 @@ package builders
 
 import (
 	"context"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
@@ -50,7 +51,7 @@ func (s *RulesBuilderTestSuiteBase) SetupTest() {
 		s.scheme,
 		s.externalNetpolHandler,
 		restrictToNamespaces,
-		make([]string, 0),
+		*goset.NewSet[string](),
 		true,
 		true,
 		nil,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -50,6 +50,7 @@ func (s *RulesBuilderTestSuiteBase) SetupTest() {
 		s.scheme,
 		s.externalNetpolHandler,
 		restrictToNamespaces,
+		make([]string, 0),
 		true,
 		true,
 		nil,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -49,7 +49,7 @@ type Reconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
 	RestrictToNamespaces        []string
-	EnforcedNamespaces          []string
+	EnforcedNamespaces          goset.Set[string]
 	EnableNetworkPolicyCreation bool
 	EnforcementDefaultState     bool
 	injectablerecorder.InjectableRecorder
@@ -63,7 +63,7 @@ func NewReconciler(
 	s *runtime.Scheme,
 	externalNetpolHandler ExternalNetpolHandler,
 	restrictToNamespaces []string,
-	enforcedNamespaces []string,
+	enforcedNamespaces goset.Set[string],
 	enableNetworkPolicyCreation bool,
 	enforcementDefaultState bool,
 	ingressBuilders []IngressRuleBuilder,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -49,6 +49,7 @@ type Reconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
 	RestrictToNamespaces        []string
+	EnforcedNamespaces          []string
 	EnableNetworkPolicyCreation bool
 	EnforcementDefaultState     bool
 	injectablerecorder.InjectableRecorder
@@ -62,6 +63,7 @@ func NewReconciler(
 	s *runtime.Scheme,
 	externalNetpolHandler ExternalNetpolHandler,
 	restrictToNamespaces []string,
+	enforcedNamespaces []string,
 	enableNetworkPolicyCreation bool,
 	enforcementDefaultState bool,
 	ingressBuilders []IngressRuleBuilder,
@@ -71,6 +73,7 @@ func NewReconciler(
 		Client:                      c,
 		Scheme:                      s,
 		RestrictToNamespaces:        restrictToNamespaces,
+		EnforcedNamespaces:          enforcedNamespaces,
 		EnableNetworkPolicyCreation: enableNetworkPolicyCreation,
 		EnforcementDefaultState:     enforcementDefaultState,
 		egressRuleBuilders:          egressBuilders,
@@ -216,7 +219,7 @@ func (r *Reconciler) buildIngressRules(ctx context.Context, ep effectivepolicy.S
 	if len(ep.CalledBy) == 0 || len(r.ingressRuleBuilders) == 0 {
 		return rules, false, nil
 	}
-	shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx, r.Client, ep.Service.Name, ep.Service.Namespace, r.EnforcementDefaultState)
+	shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx, r.Client, ep.Service.Name, ep.Service.Namespace, r.EnforcementDefaultState, r.EnforcedNamespaces)
 	if err != nil {
 		return rules, false, errors.Wrap(err)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -49,7 +49,7 @@ type Reconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
 	RestrictToNamespaces        []string
-	EnforcedNamespaces          goset.Set[string]
+	EnforcedNamespaces          *goset.Set[string]
 	EnableNetworkPolicyCreation bool
 	EnforcementDefaultState     bool
 	injectablerecorder.InjectableRecorder
@@ -63,7 +63,7 @@ func NewReconciler(
 	s *runtime.Scheme,
 	externalNetpolHandler ExternalNetpolHandler,
 	restrictToNamespaces []string,
-	enforcedNamespaces goset.Set[string],
+	enforcedNamespaces *goset.Set[string],
 	enableNetworkPolicyCreation bool,
 	enforcementDefaultState bool,
 	ingressBuilders []IngressRuleBuilder,

--- a/src/operator/controllers/intents_reconcilers/protected_services/should_protect.go
+++ b/src/operator/controllers/intents_reconcilers/protected_services/should_protect.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context, kube client.Client, serverName string, serverNamespace string, enforcementDefaultState bool, activeNamespaces goset.Set[string]) (bool, error) {
+func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context, kube client.Client, serverName string, serverNamespace string, enforcementDefaultState bool, activeNamespaces *goset.Set[string]) (bool, error) {
 	if enforcementDefaultState {
 		logrus.Debug("Enforcement is default on, so all services should be protected")
 		return true, nil
@@ -19,7 +19,7 @@ func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context
 	logrus.Debug("Protected services are enabled")
 
 	logrus.Debugf("checking if server's namespace is in acrive namespaces")
-	if activeNamespaces.Contains(serverNamespace) {
+	if activeNamespaces != nil && activeNamespaces.Contains(serverNamespace) {
 		logrus.Debugf("Server %s in namespace %s is in active namespaces", serverName, serverNamespace)
 		return true, nil
 	}

--- a/src/operator/controllers/intents_reconcilers/protected_services/should_protect.go
+++ b/src/operator/controllers/intents_reconcilers/protected_services/should_protect.go
@@ -2,16 +2,16 @@ package protected_services
 
 import (
 	"context"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context, kube client.Client, serverName string, serverNamespace string, enforcementDefaultState bool, activeNamespaces []string) (bool, error) {
+func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context, kube client.Client, serverName string, serverNamespace string, enforcementDefaultState bool, activeNamespaces goset.Set[string]) (bool, error) {
 	if enforcementDefaultState {
 		logrus.Debug("Enforcement is default on, so all services should be protected")
 		return true, nil
@@ -19,7 +19,7 @@ func IsServerEnforcementEnabledDueToProtectionOrDefaultState(ctx context.Context
 	logrus.Debug("Protected services are enabled")
 
 	logrus.Debugf("checking if server's namespace is in acrive namespaces")
-	if lo.Contains(activeNamespaces, serverNamespace) {
+	if activeNamespaces.Contains(serverNamespace) {
 		logrus.Debugf("Server %s in namespace %s is in active namespaces", serverName, serverNamespace)
 		return true, nil
 	}

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -45,7 +45,7 @@ type PolicyManagerImpl struct {
 	client                    client.Client
 	recorder                  *injectablerecorder.InjectableRecorder
 	restrictToNamespaces      []string
-	activeNamespaces          goset.Set[string]
+	activeNamespaces          *goset.Set[string]
 	enforcementDefaultState   bool
 	enableIstioPolicyCreation bool
 }
@@ -57,7 +57,7 @@ type PolicyManager interface {
 	UpdateServerSidecar(ctx context.Context, clientIntents *v1alpha3.ClientIntents, serverName string, missingSideCar bool) error
 }
 
-func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces goset.Set[string]) *PolicyManagerImpl {
+func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces *goset.Set[string]) *PolicyManagerImpl {
 	return &PolicyManagerImpl{
 		client:                    client,
 		recorder:                  recorder,

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -45,6 +45,7 @@ type PolicyManagerImpl struct {
 	client                    client.Client
 	recorder                  *injectablerecorder.InjectableRecorder
 	restrictToNamespaces      []string
+	activeNamespaces          []string
 	enforcementDefaultState   bool
 	enableIstioPolicyCreation bool
 }
@@ -56,13 +57,14 @@ type PolicyManager interface {
 	UpdateServerSidecar(ctx context.Context, clientIntents *v1alpha3.ClientIntents, serverName string, missingSideCar bool) error
 }
 
-func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool) *PolicyManagerImpl {
+func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces []string) *PolicyManagerImpl {
 	return &PolicyManagerImpl{
 		client:                    client,
 		recorder:                  recorder,
 		restrictToNamespaces:      restrictedNamespaces,
 		enforcementDefaultState:   enforcementDefaultState,
 		enableIstioPolicyCreation: istioEnforcementEnabled,
+		activeNamespaces:          activeNamespaces,
 	}
 }
 
@@ -321,7 +323,7 @@ func (c *PolicyManagerImpl) createOrUpdatePolicies(
 			continue
 		}
 		shouldCreatePolicy, err := protected_services.IsServerEnforcementEnabledDueToProtectionOrDefaultState(
-			ctx, c.client, intent.GetTargetServerName(), intent.GetTargetServerNamespace(clientIntents.Namespace), c.enforcementDefaultState)
+			ctx, c.client, intent.GetTargetServerName(), intent.GetTargetServerNamespace(clientIntents.Namespace), c.enforcementDefaultState, c.activeNamespaces)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -45,7 +45,7 @@ type PolicyManagerImpl struct {
 	client                    client.Client
 	recorder                  *injectablerecorder.InjectableRecorder
 	restrictToNamespaces      []string
-	activeNamespaces          []string
+	activeNamespaces          goset.Set[string]
 	enforcementDefaultState   bool
 	enableIstioPolicyCreation bool
 }
@@ -57,7 +57,7 @@ type PolicyManager interface {
 	UpdateServerSidecar(ctx context.Context, clientIntents *v1alpha3.ClientIntents, serverName string, missingSideCar bool) error
 }
 
-func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces []string) *PolicyManagerImpl {
+func NewPolicyManager(client client.Client, recorder *injectablerecorder.InjectableRecorder, restrictedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces goset.Set[string]) *PolicyManagerImpl {
 	return &PolicyManagerImpl{
 		client:                    client,
 		recorder:                  recorder,

--- a/src/operator/controllers/istiopolicy/policy_manager_test.go
+++ b/src/operator/controllers/istiopolicy/policy_manager_test.go
@@ -27,7 +27,7 @@ type PolicyManagerTestSuite struct {
 
 func (s *PolicyManagerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true)
+	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true, nil)
 }
 
 func (s *PolicyManagerTestSuite) TearDownTest() {

--- a/src/operator/controllers/istiopolicy/policy_manager_test.go
+++ b/src/operator/controllers/istiopolicy/policy_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/amit7itz/goset"
 	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
@@ -27,7 +28,7 @@ type PolicyManagerTestSuite struct {
 
 func (s *PolicyManagerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true, nil)
+	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true, *goset.NewSet[string]())
 }
 
 func (s *PolicyManagerTestSuite) TearDownTest() {

--- a/src/operator/controllers/istiopolicy/policy_manager_test.go
+++ b/src/operator/controllers/istiopolicy/policy_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/amit7itz/goset"
 	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
@@ -28,7 +27,7 @@ type PolicyManagerTestSuite struct {
 
 func (s *PolicyManagerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true, *goset.NewSet[string]())
+	s.admin = NewPolicyManager(s.Client, &injectablerecorder.InjectableRecorder{Recorder: s.Recorder}, []string{}, true, true, nil)
 }
 
 func (s *PolicyManagerTestSuite) TearDownTest() {

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -3,6 +3,7 @@ package pod_reconcilers
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/istiopolicy"
 	"github.com/otterize/intents-operator/src/prometheus"
@@ -38,7 +39,7 @@ type PodWatcher struct {
 	injectablerecorder.InjectableRecorder
 }
 
-func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces []string) *PodWatcher {
+func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces goset.Set[string]) *PodWatcher {
 	recorder := injectablerecorder.InjectableRecorder{Recorder: eventRecorder}
 	creator := istiopolicy.NewPolicyManager(c, &recorder, watchedNamespaces, enforcementDefaultState, istioEnforcementEnabled, activeNamespaces)
 	return &PodWatcher{

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -38,9 +38,9 @@ type PodWatcher struct {
 	injectablerecorder.InjectableRecorder
 }
 
-func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool) *PodWatcher {
+func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces []string) *PodWatcher {
 	recorder := injectablerecorder.InjectableRecorder{Recorder: eventRecorder}
-	creator := istiopolicy.NewPolicyManager(c, &recorder, watchedNamespaces, enforcementDefaultState, istioEnforcementEnabled)
+	creator := istiopolicy.NewPolicyManager(c, &recorder, watchedNamespaces, enforcementDefaultState, istioEnforcementEnabled, activeNamespaces)
 	return &PodWatcher{
 		Client:             c,
 		serviceIdResolver:  serviceidresolver.NewResolver(c),

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -39,7 +39,7 @@ type PodWatcher struct {
 	injectablerecorder.InjectableRecorder
 }
 
-func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces goset.Set[string]) *PodWatcher {
+func NewPodWatcher(c client.Client, eventRecorder record.EventRecorder, watchedNamespaces []string, enforcementDefaultState bool, istioEnforcementEnabled bool, activeNamespaces *goset.Set[string]) *PodWatcher {
 	recorder := injectablerecorder.InjectableRecorder{Recorder: eventRecorder}
 	creator := istiopolicy.NewPolicyManager(c, &recorder, watchedNamespaces, enforcementDefaultState, istioEnforcementEnabled, activeNamespaces)
 	return &PodWatcher{

--- a/src/operator/controllers/pod_reconcilers/pods_test.go
+++ b/src/operator/controllers/pod_reconcilers/pods_test.go
@@ -3,6 +3,7 @@ package pod_reconcilers
 import (
 	"context"
 	"fmt"
+	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) SetupSuite() {
 func (s *WatcherPodLabelReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, nil)
+	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, *goset.NewSet[string]())
 	s.Require().NoError(s.Reconciler.InitIntentsClientIndices(s.Mgr))
 }
 

--- a/src/operator/controllers/pod_reconcilers/pods_test.go
+++ b/src/operator/controllers/pod_reconcilers/pods_test.go
@@ -3,7 +3,6 @@ package pod_reconcilers
 import (
 	"context"
 	"fmt"
-	"github.com/amit7itz/goset"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +48,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) SetupSuite() {
 func (s *WatcherPodLabelReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, *goset.NewSet[string]())
+	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, nil)
 	s.Require().NoError(s.Reconciler.InitIntentsClientIndices(s.Mgr))
 }
 

--- a/src/operator/controllers/pod_reconcilers/pods_test.go
+++ b/src/operator/controllers/pod_reconcilers/pods_test.go
@@ -48,7 +48,7 @@ func (s *WatcherPodLabelReconcilerTestSuite) SetupSuite() {
 func (s *WatcherPodLabelReconcilerTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true)
+	s.Reconciler = NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, nil)
 	s.Require().NoError(s.Reconciler.InitIntentsClientIndices(s.Mgr))
 }
 

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -218,7 +218,7 @@ func main() {
 	additionalIntentsReconcilers := make([]reconcilergroup.ReconcilerWithEvents, 0)
 	svcNetworkPolicyBuilder := builders.NewPortNetworkPolicyReconciler(mgr.GetClient())
 	dnsServerNetpolBuilder := builders.NewIngressDNSServerAutoAllowNetpolBuilder()
-	epNetpolReconciler := networkpolicy.NewReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, *enforcedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState,
+	epNetpolReconciler := networkpolicy.NewReconciler(mgr.GetClient(), scheme, extNetpolHandler, watchedNamespaces, enforcedNamespaces, enforcementConfig.EnableNetworkPolicy, enforcementConfig.EnforcementDefaultState,
 		[]networkpolicy.IngressRuleBuilder{ingressRulesBuilder, svcNetworkPolicyBuilder, dnsServerNetpolBuilder}, make([]networkpolicy.EgressRuleBuilder, 0))
 	epGroupReconciler := effectivepolicy.NewGroupReconciler(mgr.GetClient(), scheme, epNetpolReconciler)
 	if enforcementConfig.EnableEgressNetworkPolicyReconcilers {
@@ -397,7 +397,7 @@ func main() {
 		otterizeCloudClient,
 		podName,
 		podNamespace,
-		*enforcedNamespaces,
+		enforcedNamespaces,
 		additionalIntentsReconcilers...,
 	)
 
@@ -461,7 +461,7 @@ func main() {
 		logrus.WithError(err).Panic("unable to create controller", "controller", "ProtectedServices")
 	}
 
-	podWatcher := pod_reconcilers.NewPodWatcher(mgr.GetClient(), mgr.GetEventRecorderFor("intents-operator"), watchedNamespaces, enforcementConfig.EnforcementDefaultState, enforcementConfig.EnableIstioPolicy, *enforcedNamespaces)
+	podWatcher := pod_reconcilers.NewPodWatcher(mgr.GetClient(), mgr.GetEventRecorderFor("intents-operator"), watchedNamespaces, enforcementConfig.EnforcementDefaultState, enforcementConfig.EnableIstioPolicy, enforcedNamespaces)
 	nsWatcher := pod_reconcilers.NewNamespaceWatcher(mgr.GetClient())
 	svcWatcher := port_network_policy.NewServiceWatcher(mgr.GetClient(), mgr.GetEventRecorderFor("intents-operator"), epGroupReconciler)
 

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -18,11 +18,12 @@ const (
 	ProbeAddrDefault                            = ":8181"
 	EnableLeaderElectionKey                     = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
 	EnableLeaderElectionDefault                 = false
-	WatchedNamespacesKey                        = "watched-namespaces"    // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
-	KafkaServerTLSCertKey                       = "kafka-server-tls-cert" // name of tls certificate file
-	KafkaServerTLSKeyKey                        = "kafka-server-tls-key"  // name of tls private key file
-	KafkaServerTLSCAKey                         = "kafka-server-tls-ca"   // name of tls ca file
-	SelfSignedCertKey                           = "self-signed-cert"      // Whether to generate and use a self signed cert as the CA for webhooks
+	WatchedNamespacesKey                        = "watched-namespaces"            // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
+	ActiveEnforcementNamespacesKey              = "active-enforcement-namespaces" // When using the "shadow enforcement" mode, namespaces in this list will be treated as if the enforcement were active
+	KafkaServerTLSCertKey                       = "kafka-server-tls-cert"         // name of tls certificate file
+	KafkaServerTLSKeyKey                        = "kafka-server-tls-key"          // name of tls private key file
+	KafkaServerTLSCAKey                         = "kafka-server-tls-ca"           // name of tls ca file
+	SelfSignedCertKey                           = "self-signed-cert"              // Whether to generate and use a self signed cert as the CA for webhooks
 	SelfSignedCertDefault                       = true
 	DisableWebhookServerKey                     = "disable-webhook-server" // Disable webhook validator server
 	DisableWebhookServerDefault                 = false
@@ -88,6 +89,7 @@ func init() {
 	viper.SetDefault(KafkaServerTLSCAKey, "")
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetDefault(WatchedNamespacesKey, nil)
+	viper.SetDefault(ActiveEnforcementNamespacesKey, nil)
 	viper.SetDefault(EnableDatabasePolicy, EnableDatabasePolicyDefault)
 	viper.SetDefault(RetryDelayTimeKey, RetryDelayTimeDefault)
 	viper.SetDefault(DebugLogKey, DebugLogDefault)
@@ -109,6 +111,7 @@ func InitCLIFlags() {
 	pflag.String(ProbeAddrKey, ProbeAddrDefault, "The address the probe endpoint binds to.")
 	pflag.Bool(EnableLeaderElectionKey, EnableLeaderElectionDefault, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	pflag.StringSlice(WatchedNamespacesKey, nil, "Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas.")
+	pflag.StringSlice(ActiveEnforcementNamespacesKey, nil, "While using the shadow enforcement mode, namespaces in this list will be treated as if the enforcement were active.")
 	pflag.Bool(EnableIstioPolicyKey, EnableIstioPolicyDefault, "Whether to enable Istio authorization policy creation")
 	pflag.Bool(telemetriesconfig.TelemetryEnabledKey, telemetriesconfig.TelemetryEnabledDefault, "When set to false, all telemetries are disabled")
 	pflag.Bool(telemetriesconfig.TelemetryUsageEnabledKey, telemetriesconfig.TelemetryUsageEnabledDefault, "Whether usage telemetry should be enabled")


### PR DESCRIPTION
### Description

Until this PR, when one used shadowEnforcement mode, he could turn on enforcement only by using `protectedServices`, a per-service CRD. In this PR I'm adding support for per-namespace configuration using the helm chart. 


### References

https://github.com/otterize/helm-charts/pull/194
https://github.com/otterize/docs/pull/225

### Testing


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
