### PR TITLE
Use $BUILDPLATFORM in Dockerfile

### DIFF
--- a/src/intents-operator.Dockerfile
+++ b/src/intents-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Upgraded Go version? Make sure to upgrade it in the GitHub Actions setup, the Dockerfile and the go.mod as well, so the linter and tests run the same version.
-FROM --platform=linux/amd64 golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
### Description

Uses $BUILDPLATFORM in build stage in Dockerfile: This will cause the builder image to be arm64 on Macs, and amd64 on CI and other environments.

Not cross-compiling arm64->amd64 on macs is significantly faster. The resulting images are without change.

### References

https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/