### PR TITLE
Fix error reporting for errors caused by sentinel errors

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -420,6 +420,9 @@ func (r *Reconciler) removeNetworkPolicy(ctx context.Context, networkPolicy v1.N
 		return errors.Wrap(err)
 	}
 	err = r.Delete(ctx, &networkPolicy)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/operator/controllers/kafkaacls/servers_store.go
+++ b/src/operator/controllers/kafkaacls/servers_store.go
@@ -1,14 +1,13 @@
 package kafkaacls
 
 import (
-	gerrors "errors"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
-	ServerSpecNotFound = gerrors.New("failed getting kafka server connection - server configuration specs not set")
+	ServerSpecNotFound = errors.NewCustomError("failed getting kafka server connection - server configuration specs not set")
 )
 
 type ServersStore interface {

--- a/src/operator/controllers/kafkaacls/servers_store.go
+++ b/src/operator/controllers/kafkaacls/servers_store.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ServerSpecNotFound = errors.NewCustomError("failed getting kafka server connection - server configuration specs not set")
+	ServerSpecNotFound = errors.NewSentinelError("failed getting kafka server connection - server configuration specs not set")
 )
 
 type ServersStore interface {

--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -36,7 +36,7 @@ func (a *Agent) generateFederatedIdentityCredentialsName(namespace string, accou
 	return agentutils.TruncateHashName(fullName, maxFederatedIdentityLength)
 }
 
-var ErrUserIdentityNotFound = errors.New("user assigned identity not found")
+var ErrUserIdentityNotFound = errors.NewCustomError("user assigned identity not found")
 
 func (a *Agent) FindUserAssignedIdentity(ctx context.Context, namespace string, accountName string) (armmsi.Identity, error) {
 	userAssignedIdentityName := a.GenerateUserAssignedIdentityName(namespace, accountName)

--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -36,7 +36,7 @@ func (a *Agent) generateFederatedIdentityCredentialsName(namespace string, accou
 	return agentutils.TruncateHashName(fullName, maxFederatedIdentityLength)
 }
 
-var ErrUserIdentityNotFound = errors.NewCustomError("user assigned identity not found")
+var ErrUserIdentityNotFound = errors.NewSentinelError("user assigned identity not found")
 
 func (a *Agent) FindUserAssignedIdentity(ctx context.Context, namespace string, accountName string) (armmsi.Identity, error) {
 	userAssignedIdentityName := a.GenerateUserAssignedIdentityName(namespace, accountName)

--- a/src/shared/errors/errors.go
+++ b/src/shared/errors/errors.go
@@ -10,6 +10,10 @@ func New(text string) error {
 	return bugsnagerrors.New(text, 1)
 }
 
+func NewCustomError(text string) error {
+	return gerrors.New(text)
+}
+
 func Errorf(format string, a ...any) error {
 	return bugsnagerrors.New(fmt.Errorf(format, a...), 1)
 }

--- a/src/shared/errors/errors.go
+++ b/src/shared/errors/errors.go
@@ -10,7 +10,7 @@ func New(text string) error {
 	return bugsnagerrors.New(text, 1)
 }
 
-func NewCustomError(text string) error {
+func NewSentinelError(text string) error {
 	return gerrors.New(text)
 }
 

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var ErrPodNotFound = errors.NewCustomError("pod not found")
+var ErrPodNotFound = errors.NewSentinelError("pod not found")
 
 //+kubebuilder:rbac:groups="apps",resources=deployments;replicasets;daemonsets;statefulsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch

--- a/src/shared/serviceidresolver/serviceidresolver.go
+++ b/src/shared/serviceidresolver/serviceidresolver.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-var ErrPodNotFound = errors.New("pod not found")
+var ErrPodNotFound = errors.NewCustomError("pod not found")
 
 //+kubebuilder:rbac:groups="apps",resources=deployments;replicasets;daemonsets;statefulsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="batch",resources=jobs;cronjobs,verbs=get;list;watch


### PR DESCRIPTION
### Description

When creating a new error using bugsnag constructor it will freeze the error traceback. instead we fallback to go default error module that does not apply a traceback and bugsnag will add the traceback on throw.
