### PR TITLE
Add support for HTTP_PROXY, HTTPS_PROXY env variables

### DIFF
--- a/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
+++ b/src/shared/otterizecloud/otterizecloudclient/cloud_client.go
@@ -57,7 +57,8 @@ func NewClient(ctx context.Context) (graphql.Client, bool, error) {
 		}
 	}
 
-	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: rootCAs}}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{RootCAs: rootCAs}
 
 	// Timeout for oauth token acquisition is set by http client passed to the token source context
 	// See example 'Example (CustomHTTP)' in https://pkg.go.dev/golang.org/x/oauth2

--- a/src/shared/telemetries/telemetrysender/sender.go
+++ b/src/shared/telemetries/telemetrysender/sender.go
@@ -25,8 +25,7 @@ type TelemetrySender struct {
 func newGqlClient() graphql.Client {
 	apiAddress := viper.GetString(telemetriesconfig.TelemetryAPIAddressKey)
 	clientTimeout := viper.GetDuration(telemetriesconfig.TimeoutKey)
-	transport := &http.Transport{}
-	clientWithTimeout := &http.Client{Timeout: clientTimeout, Transport: transport}
+	clientWithTimeout := &http.Client{Timeout: clientTimeout}
 	return graphql.NewClient(apiAddress, clientWithTimeout)
 }
 


### PR DESCRIPTION
### Description

Prior to this PR, we inadvertently ignored the HTTP_PROXY, HTTPS_PROXY env variables in Otterize's cloud and telemetry HTTP clients. We now use the default transport.