### PR TITLE
Addressing empty version before determining release stage

### DIFF
--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -45,7 +45,7 @@ func Init(componentName string, version string, apiKey string) {
 	errorsServerAddress := viper.GetString(telemetriesconfig.TelemetryErrorsAddressKey)
 	releaseStage := viper.GetString(telemetriesconfig.TelemetryErrorsStageKey)
 	// send to staging if Otterize Cloud API is not the default
-	if viper.GetString(otterizecloudclient.OtterizeAPIAddressKey) != otterizecloudclient.OtterizeAPIAddressDefault || isStagingVersion(version) {
+	if viper.GetString(otterizecloudclient.OtterizeAPIAddressKey) != otterizecloudclient.OtterizeAPIAddressDefault || isStagingOrDevVersion(version) {
 		releaseStage = "staging"
 	}
 

--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -45,7 +45,7 @@ func Init(componentName string, version string, apiKey string) {
 	errorsServerAddress := viper.GetString(telemetriesconfig.TelemetryErrorsAddressKey)
 	releaseStage := viper.GetString(telemetriesconfig.TelemetryErrorsStageKey)
 	// send to staging if Otterize Cloud API is not the default
-	if viper.GetString(otterizecloudclient.OtterizeAPIAddressKey) != otterizecloudclient.OtterizeAPIAddressDefault || strings.HasPrefix(version, "0.0.") || version == "0-local" {
+	if viper.GetString(otterizecloudclient.OtterizeAPIAddressKey) != otterizecloudclient.OtterizeAPIAddressDefault || isStagingVersion(version) {
 		releaseStage = "staging"
 	}
 
@@ -69,6 +69,10 @@ func Init(componentName string, version string, apiKey string) {
 		logrus.WithError(err).Panic("failed to initialize bugsnag")
 	}
 	logrus.AddHook(hook)
+}
+
+func isStagingVersion(version string) bool {
+	return strings.HasPrefix(version, "0.0.") || version == "0-local" || version == ""
 }
 
 func AutoNotify() {

--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -71,7 +71,7 @@ func Init(componentName string, version string, apiKey string) {
 	logrus.AddHook(hook)
 }
 
-func isStagingVersion(version string) bool {
+func isStagingOrDevVersion(version string) bool {
 	return strings.HasPrefix(version, "0.0.") || version == "0-local" || version == ""
 }
 


### PR DESCRIPTION
### Description
Addressing empty version before determining release stage to avoid cases where locally built images with no version that happen to error, will get reported as production envs
