### PR TITLE
Fixed bug where externally accessible services would be reported with an incorrect name sometimes, causing them to be incorrectly taken into account in the access graph simulation

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -303,8 +303,8 @@ func (r *NetworkPolicyHandler) handlePod(ctx context.Context, pod *corev1.Pod) e
 //		   If the Service is deleted completely, then the corresponding network policy will be deleted, since it is owned
 //		   by the service.
 func (r *NetworkPolicyHandler) HandleEndpoints(ctx context.Context, endpoints *corev1.Endpoints) error {
-	svc := &corev1.Service{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: endpoints.GetName(), Namespace: endpoints.GetNamespace()}, svc)
+	svc := corev1.Service{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: endpoints.GetName(), Namespace: endpoints.GetNamespace()}, &svc)
 	if k8serrors.IsNotFound(err) {
 		// delete is handled by garbage collection - the service owns the network policy
 		return nil

--- a/src/operator/controllers/external_traffic/service_uploader.go
+++ b/src/operator/controllers/external_traffic/service_uploader.go
@@ -2,16 +2,27 @@ package external_traffic
 
 import (
 	"context"
+	"fmt"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/shared"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ServiceUploaderImpl struct {
 	client.Client
-	otterizeClient operator_cloud_client.CloudClient
+	otterizeClient        operator_cloud_client.CloudClient
+	serviceIdResolver     *serviceidresolver.Resolver
+	reportedServicesCache *lru.ARCCache
 }
 
 type ServiceUploader interface {
@@ -20,8 +31,10 @@ type ServiceUploader interface {
 
 func NewServiceUploader(client client.Client, otterizeClient operator_cloud_client.CloudClient) ServiceUploader {
 	return &ServiceUploaderImpl{
-		Client:         client,
-		otterizeClient: otterizeClient,
+		Client:                client,
+		otterizeClient:        otterizeClient,
+		serviceIdResolver:     serviceidresolver.NewResolver(client),
+		reportedServicesCache: shared.MustRet(lru.NewARC(1000)),
 	}
 }
 
@@ -38,7 +51,7 @@ func (s *ServiceUploaderImpl) UploadNamespaceServices(ctx context.Context, names
 
 	externallyAccessibleServices := make([]graphqlclient.ExternallyAccessibleServiceInput, 0)
 	for _, service := range services.Items {
-		externalService, isExternal, err := s.getExternalService(ctx, &service)
+		externalService, isExternal, err := s.getExternalService(ctx, service)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -48,27 +61,107 @@ func (s *ServiceUploaderImpl) UploadNamespaceServices(ctx context.Context, names
 		}
 	}
 
+	allServicesReported := lo.EveryBy(externallyAccessibleServices, func(service graphqlclient.ExternallyAccessibleServiceInput) bool {
+		return s.reportedServicesCache.Contains(reportedServicesCacheKey(service.Namespace, service.ServerName))
+	})
+
+	if allServicesReported && len(externallyAccessibleServices) != 0 {
+		return nil
+	}
+
 	err = s.otterizeClient.ReportExternallyAccessibleServices(ctx, namespace, externallyAccessibleServices)
 	if err != nil {
 		return errors.Wrap(err)
 	}
 
+	for _, service := range externallyAccessibleServices {
+		s.reportedServicesCache.Add(reportedServicesCacheKey(service.Namespace, service.ServerName), true)
+	}
+
 	return nil
 }
 
-func (s *ServiceUploaderImpl) getExternalService(ctx context.Context, svc *corev1.Service) (graphqlclient.ExternallyAccessibleServiceInput, bool, error) {
+func reportedServicesCacheKey(namespace, serverName string) string {
+	return fmt.Sprintf("%s%s", serverName, namespace)
+}
+
+func (s *ServiceUploaderImpl) getExternalService(ctx context.Context, svc corev1.Service) (graphqlclient.ExternallyAccessibleServiceInput, bool, error) {
 	if svc.DeletionTimestamp != nil {
 		return graphqlclient.ExternallyAccessibleServiceInput{}, false, nil
 	}
 
-	ingressList, err := getIngressRefersToService(ctx, s.Client, svc)
+	referringIngressList, err := getIngressRefersToService(ctx, s.Client, svc)
 	if err != nil {
 		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.Wrap(err)
 	}
 
-	externalService, isExternal, err := convertToCloudExternalService(svc, ingressList)
+	if !isServiceExternallyAccessible(svc, referringIngressList) {
+		return graphqlclient.ExternallyAccessibleServiceInput{}, false, nil
+	}
+
+	// get pods that are targeted by the service
+	podList := corev1.PodList{}
+	err = s.Client.List(ctx, &podList, &client.ListOptions{Namespace: svc.Namespace, LabelSelector: labels.SelectorFromSet(svc.Spec.Selector)})
+	if err != nil {
+		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.Wrap(err)
+	}
+
+	if len(podList.Items) == 0 {
+		return graphqlclient.ExternallyAccessibleServiceInput{}, false, nil
+	}
+
+	identity, err := s.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &podList.Items[0])
+	if err != nil {
+		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.Wrap(err)
+	}
+
+	externalService, isExternal, err := convertToCloudExternalService(svc, identity, referringIngressList)
 	if err != nil {
 		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.Wrap(err)
 	}
 	return externalService, isExternal, nil
+}
+
+func isServiceExternallyAccessible(svc corev1.Service, referringIngressList *v1.IngressList) bool {
+	return svc.Spec.Type == corev1.ServiceTypeLoadBalancer || svc.Spec.Type == corev1.ServiceTypeNodePort || len(referringIngressList.Items) > 0
+}
+
+func convertToCloudExternalService(svc corev1.Service, identity serviceidentity.ServiceIdentity, referringIngressList *v1.IngressList) (graphqlclient.ExternallyAccessibleServiceInput, bool, error) {
+	ReferredByIngress := len(referringIngressList.Items) > 0
+	var cloudServiceType graphqlclient.KubernetesServiceType
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeLoadBalancer:
+		cloudServiceType = graphqlclient.KubernetesServiceTypeLoadBalancer
+	case corev1.ServiceTypeNodePort:
+		cloudServiceType = graphqlclient.KubernetesServiceTypeNodePort
+	case corev1.ServiceTypeClusterIP:
+		cloudServiceType = graphqlclient.KubernetesServiceTypeClusterIp
+	case corev1.ServiceTypeExternalName:
+		cloudServiceType = graphqlclient.KubernetesServiceTypeExternalName
+	default:
+		// Should not reach here until k8s adds new service type
+		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.Errorf("unsupported service type: %s", svc.Spec.Type)
+	}
+
+	serviceInput := graphqlclient.ExternallyAccessibleServiceInput{
+		Namespace:         identity.Namespace,
+		ServerName:        identity.Name,
+		ReferredByIngress: ReferredByIngress,
+		ServiceType:       cloudServiceType,
+	}
+	return serviceInput, true, nil
+}
+
+func getIngressRefersToService(ctx context.Context, k8sClient client.Client, svc corev1.Service) (*v1.IngressList, error) {
+	var ingressList v1.IngressList
+	err := k8sClient.List(
+		ctx,
+		&ingressList,
+		&client.MatchingFields{v1alpha3.IngressServiceNamesIndexField: svc.Name},
+		&client.ListOptions{Namespace: svc.Namespace})
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	return &ingressList, nil
 }

--- a/src/operator/controllers/external_traffic/shared.go
+++ b/src/operator/controllers/external_traffic/shared.go
@@ -1,15 +1,8 @@
 package external_traffic
 
 import (
-	"context"
-	"fmt"
-	"github.com/otterize/intents-operator/src/operator/api/v1alpha3"
-	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/otterize/intents-operator/src/shared/otterizecloud/graphqlclient"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func serviceNamesFromIngress(ingress *v1.Ingress) sets.Set[string] {
@@ -29,52 +22,4 @@ func serviceNamesFromIngress(ingress *v1.Ingress) sets.Set[string] {
 	}
 
 	return serviceNames
-}
-
-func isServiceExternallyAccessible(svc *corev1.Service, referringIngressList *v1.IngressList) bool {
-	return svc.Spec.Type == corev1.ServiceTypeLoadBalancer || svc.Spec.Type == corev1.ServiceTypeNodePort || len(referringIngressList.Items) > 0
-}
-
-func convertToCloudExternalService(svc *corev1.Service, referringIngressList *v1.IngressList) (graphqlclient.ExternallyAccessibleServiceInput, bool, error) {
-	if !isServiceExternallyAccessible(svc, referringIngressList) {
-		return graphqlclient.ExternallyAccessibleServiceInput{}, false, nil
-	}
-
-	ReferredByIngress := len(referringIngressList.Items) > 0
-	var cloudServiceType graphqlclient.KubernetesServiceType
-	switch svc.Spec.Type {
-	case corev1.ServiceTypeLoadBalancer:
-		cloudServiceType = graphqlclient.KubernetesServiceTypeLoadBalancer
-	case corev1.ServiceTypeNodePort:
-		cloudServiceType = graphqlclient.KubernetesServiceTypeNodePort
-	case corev1.ServiceTypeClusterIP:
-		cloudServiceType = graphqlclient.KubernetesServiceTypeClusterIp
-	case corev1.ServiceTypeExternalName:
-		cloudServiceType = graphqlclient.KubernetesServiceTypeExternalName
-	default:
-		// Should not reach here until k8s adds new service type
-		return graphqlclient.ExternallyAccessibleServiceInput{}, false, errors.New(fmt.Sprintf("unsupported service type: %s", svc.Spec.Type))
-	}
-
-	serviceInput := graphqlclient.ExternallyAccessibleServiceInput{
-		Namespace:         svc.Namespace,
-		ServerName:        svc.Name,
-		ReferredByIngress: ReferredByIngress,
-		ServiceType:       cloudServiceType,
-	}
-	return serviceInput, true, nil
-}
-
-func getIngressRefersToService(ctx context.Context, k8sClient client.Client, svc *corev1.Service) (*v1.IngressList, error) {
-	var ingressList v1.IngressList
-	err := k8sClient.List(
-		ctx,
-		&ingressList,
-		&client.MatchingFields{v1alpha3.IngressServiceNamesIndexField: svc.Name},
-		&client.ListOptions{Namespace: svc.Namespace})
-	if err != nil {
-		return nil, errors.Wrap(err)
-	}
-
-	return &ingressList, nil
 }


### PR DESCRIPTION
TODO: Handle new pods starting up, in the case that the service has not been reported because no pods were up.

Please see the [contributing guidelines](CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. This template is based on Auth0's excellent template.

### Description

Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.


### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
