### PR TITLE
Add stack traces to panics reported in telemetry error reporting

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/operator/otterizecrds"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
+	"github.com/otterize/intents-operator/src/shared"
 	"github.com/otterize/intents-operator/src/shared/awsagent"
 	"github.com/otterize/intents-operator/src/shared/azureagent"
 	"github.com/otterize/intents-operator/src/shared/clusterutils"
@@ -120,6 +121,7 @@ func main() {
 	}
 	errorreporter.Init("intents-operator", version.Version(), viper.GetString(operatorconfig.TelemetryErrorsAPIKeyKey))
 	defer errorreporter.AutoNotify()
+	shared.RegisterPanicHandlers()
 
 	metricsAddr := viper.GetString(operatorconfig.MetricsAddrKey)
 	probeAddr := viper.GetString(operatorconfig.ProbeAddrKey)

--- a/src/shared/panichandler.go
+++ b/src/shared/panichandler.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/sirupsen/logrus"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func RegisterPanicHandlers() {
+	utilruntime.PanicHandlers = []func(interface{}){
+		panicHandler,
+	}
+}
+
+// shared.panicHandler
+// controller.Reconciler.recover
+// runtime.gopanic
+// original panic location <--
+const skipStackFramesCount = 3
+
+func panicHandler(item any) {
+	err := errors.ErrorfWithSkip(3, "panic: %v", item)
+
+	if errOrig, ok := item.(error); ok {
+		err = errors.WrapWithSkip(errOrig, 3)
+	}
+
+	logrus.WithError(err).Error("caught panic")
+}

--- a/src/shared/panichandler.go
+++ b/src/shared/panichandler.go
@@ -19,10 +19,10 @@ func RegisterPanicHandlers() {
 const skipStackFramesCount = 3
 
 func panicHandler(item any) {
-	err := errors.ErrorfWithSkip(3, "panic: %v", item)
+	err := errors.ErrorfWithSkip(skipStackFramesCount, "panic: %v", item)
 
 	if errOrig, ok := item.(error); ok {
-		err = errors.WrapWithSkip(errOrig, 3)
+		err = errors.WrapWithSkip(errOrig, skipStackFramesCount)
 	}
 
 	logrus.WithError(err).Error("caught panic")


### PR DESCRIPTION
### Description

Prior to this PR, panics were reported with the stack trace of the panic recover code in controller-runtime.