### PR TITLE
Bugfix on database integrations: pods were annotated with DB names when intents are applied before pod admission

### DIFF
--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -211,7 +211,7 @@ func (r *DatabaseReconciler) applyDBInstanceIntentsOnConfigurator(
 		}
 	}
 
-	if err := r.annotateDatabaseAndUsernameOnPod(ctx, *clientIntents, dbUsername, dbInstanceName); err != nil {
+	if err := r.annotateDatabaseOnPod(ctx, *clientIntents, dbInstanceName); err != nil {
 		r.RecordWarningEventf(clientIntents, ReasonAnnotatingPodFailedWithDBAccessFailed,
 			"Failed annotating pod with databse: %s", err.Error())
 		return errors.Wrap(err)
@@ -251,7 +251,7 @@ func (r *DatabaseReconciler) getClusterID(ctx context.Context) (string, error) {
 	return clusterID, nil
 }
 
-func (r *DatabaseReconciler) annotateDatabaseAndUsernameOnPod(ctx context.Context, intents otterizev1alpha3.ClientIntents, username string, dbInstance string) error {
+func (r *DatabaseReconciler) annotateDatabaseOnPod(ctx context.Context, intents otterizev1alpha3.ClientIntents, dbInstance string) error {
 	// We annotate a pod here to trigger the credentials operator flow
 	// It will create a user-password secret and modify the databases so those credentials could connect successfully
 	// We only annotate one pod since we just need to trigger the credentials operator once, to create the secret

--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -258,6 +258,12 @@ func (r *DatabaseReconciler) annotateDatabaseOnPod(ctx context.Context, intents 
 	// All pods replicas could then load the secret data and use it as login credentials
 	pod, err := r.serviceIdResolver.ResolveClientIntentToPod(ctx, intents)
 	if err != nil {
+		if errors.Is(err, serviceidresolver.ErrPodNotFound) {
+			// no matching pods are deployed yet, but that's OK.
+			// the first pod to admit with matching database intents will trigger the intents reconcile loop
+			// which will lead it to this code path again.
+			return nil
+		}
 		return errors.Wrap(err)
 	}
 	updatedPod := pod.DeepCopy()


### PR DESCRIPTION
### Description
This PR fixes a bug in database integrations, where the intents-operator did not apply the `database-access` annotation if intents are applied before pod admission. 
