### PR TITLE
Fix bug where DNS egress rules would be added twice; enable pprof by default on loopback

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
@@ -23,7 +23,7 @@ func NewDNSEgressNetworkPolicyBuilder() *DNSEgressNetworkPolicyBuilder {
 // a function that creates []NetworkPolicyEgressRule from ep
 func (r *DNSEgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effectivepolicy.ServiceEffectivePolicy) []v1.NetworkPolicyEgressRule {
 	if lo.NoneBy(ep.Calls, func(call otterizev1alpha3.Intent) bool {
-		return call.Type == "" || call.Type == otterizev1alpha3.IntentTypeHTTP || call.Type == otterizev1alpha3.IntentTypeKafka
+		return call.IsTargetInCluster()
 	}) {
 		return make([]v1.NetworkPolicyEgressRule, 0)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
@@ -1,0 +1,46 @@
+package builders
+
+import (
+	"context"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// The DNSEgressNetworkPolicyBuilder creates network policies that allow egress traffic from pods.
+type DNSEgressNetworkPolicyBuilder struct {
+	injectablerecorder.InjectableRecorder
+}
+
+func NewDNSEgressNetworkPolicyBuilder() *DNSEgressNetworkPolicyBuilder {
+	return &DNSEgressNetworkPolicyBuilder{}
+}
+
+// a function that creates []NetworkPolicyEgressRule from ep
+func (r *DNSEgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effectivepolicy.ServiceEffectivePolicy) []v1.NetworkPolicyEgressRule {
+	if lo.NoneBy(ep.Calls, func(call otterizev1alpha3.Intent) bool {
+		return call.Type == "" || call.Type == otterizev1alpha3.IntentTypeHTTP || call.Type == otterizev1alpha3.IntentTypeKafka
+	}) {
+		return make([]v1.NetworkPolicyEgressRule, 0)
+	}
+	egressRules := make([]v1.NetworkPolicyEgressRule, 0)
+
+	// DNS
+	egressRules = append(egressRules, v1.NetworkPolicyEgressRule{
+		Ports: []v1.NetworkPolicyPort{
+			{
+				Protocol: lo.ToPtr(corev1.ProtocolUDP),
+				Port:     lo.ToPtr(intstr.FromInt32(53)),
+			},
+		},
+	})
+	return egressRules
+}
+
+func (r *DNSEgressNetworkPolicyBuilder) Build(_ context.Context, ep effectivepolicy.ServiceEffectivePolicy) ([]v1.NetworkPolicyEgressRule, error) {
+	return r.buildNetworkPolicyEgressRules(ep), nil
+}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
@@ -1,0 +1,177 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/mock/gomock"
+	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/samber/lo"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+type EgressDNSNetworkPolicyReconcilerTestSuite struct {
+	RulesBuilderTestSuiteBase
+	Builder *DNSEgressNetworkPolicyBuilder
+}
+
+func (s *EgressDNSNetworkPolicyReconcilerTestSuite) SetupTest() {
+	s.RulesBuilderTestSuiteBase.SetupTest()
+	s.Builder = NewDNSEgressNetworkPolicyBuilder()
+	s.Builder.Recorder = s.Recorder
+	s.Reconciler.AddEgressRuleBuilder(s.Builder)
+}
+
+func (s *EgressDNSNetworkPolicyReconcilerTestSuite) TearDownTest() {
+	s.RulesBuilderTestSuiteBase.TearDownTest()
+	s.Builder = nil
+}
+
+func (s *EgressDNSNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicy() {
+	viper.Set(operatorconfig.EnableEgressAutoallowDNSTrafficKey, true)
+	defer func() {
+		viper.Set(operatorconfig.EnableEgressAutoallowDNSTrafficKey, false)
+	}()
+	clientIntentsName := "client-intents"
+	policyName := "test-client-access"
+	serviceName := "test-client"
+	serverNamespace := testServerNamespace
+	clientNamespace := testClientNamespace
+	formattedTargetServer := "test-server-test-server-namespac-48aee4"
+
+	s.testCreateNetworkPolicyDNS(
+		clientIntentsName,
+		clientNamespace,
+		serverNamespace,
+		serviceName,
+		policyName,
+		formattedTargetServer,
+		true,
+		nil,
+	)
+	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
+}
+
+func (s *EgressDNSNetworkPolicyReconcilerTestSuite) testCreateNetworkPolicyDNS(
+	clientIntentsName string,
+	clientNamespace string,
+	serverNamespace string,
+	serviceName string,
+	policyName string,
+	formattedTargetServer string,
+	defaultEnforcementState bool,
+	protectedServices []otterizev1alpha3.ProtectedService,
+) {
+	s.Reconciler.EnforcementDefaultState = defaultEnforcementState
+	namespacedName := types.NamespacedName{
+		Namespace: testClientNamespace,
+		Name:      clientIntentsName,
+	}
+	req := ctrl.Request{
+		NamespacedName: namespacedName,
+	}
+
+	serverName := fmt.Sprintf("test-server.%s", serverNamespace)
+	intentsSpec := &otterizev1alpha3.IntentsSpec{
+		Service: otterizev1alpha3.Service{Name: serviceName},
+		Calls: []otterizev1alpha3.Intent{
+			{
+				Name: serverName,
+			},
+		},
+	}
+
+	// Initial call to get the ClientIntents object when reconciler starts
+	clientIntents := otterizev1alpha3.ClientIntents{Spec: intentsSpec}
+	clientIntents.Namespace = clientNamespace
+	clientIntents.Name = clientIntentsName
+
+	if defaultEnforcementState == false {
+		s.Client.EXPECT().List(gomock.Any(), gomock.Eq(&otterizev1alpha3.ProtectedServiceList{}), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, list *otterizev1alpha3.ProtectedServiceList, opts ...client.ListOption) error {
+				list.Items = append(list.Items, protectedServices...)
+				return nil
+			})
+	}
+
+	// Search for existing NetworkPolicy
+	emptyNetworkPolicy := &v1.NetworkPolicy{}
+	networkPolicyNamespacedName := types.NamespacedName{
+		Namespace: clientNamespace,
+		Name:      policyName,
+	}
+	s.Client.EXPECT().Get(gomock.Any(), networkPolicyNamespacedName, gomock.Eq(emptyNetworkPolicy)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, networkPolicy *v1.NetworkPolicy, options ...client.ListOption) error {
+			return apierrors.NewNotFound(v1.Resource("networkpolicy"), name.Name)
+		})
+
+	// Create NetworkPolicy
+	newPolicy := networkPolicyDNSEgressTemplate(
+		policyName,
+		serverNamespace,
+		"test-client-test-client-namespac-edb3a2",
+		formattedTargetServer,
+		testClientNamespace,
+	)
+	s.Client.EXPECT().Create(gomock.Any(), gomock.Eq(newPolicy)).Return(nil)
+
+	s.ignoreRemoveOrphan()
+
+	s.expectGetAllEffectivePolicies([]otterizev1alpha3.ClientIntents{clientIntents})
+	s.externalNetpolHandler.EXPECT().HandlePodsByLabelSelector(gomock.Any(), gomock.Any(), gomock.Any())
+	res, err := s.EPIntentsReconciler.Reconcile(context.Background(), req)
+	s.NoError(err)
+	s.Empty(res)
+}
+
+func networkPolicyDNSEgressTemplate(
+	policyName string,
+	targetNamespace string,
+	formattedTargetClient string,
+	formattedTargetServer string,
+	intentsObjNamespace string,
+) *v1.NetworkPolicy {
+	return &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: intentsObjNamespace,
+			Labels: map[string]string{
+				otterizev1alpha3.OtterizeNetworkPolicy: formattedTargetClient,
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					otterizev1alpha3.OtterizeServiceLabelKey: formattedTargetClient,
+				},
+			},
+			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
+			Egress: []v1.NetworkPolicyEgressRule{
+				{
+					Ports: []v1.NetworkPolicyPort{
+						{
+							Protocol: lo.ToPtr(corev1.ProtocolUDP),
+							Port:     lo.ToPtr(intstr.FromInt32(53)),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDNSEgressNetworkPolicyReconcilerTestSuite(t *testing.T) {
+	suite.Run(t, new(EgressDNSNetworkPolicyReconcilerTestSuite))
+}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy.go
@@ -5,13 +5,8 @@ import (
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig"
-	"github.com/samber/lo"
-	"github.com/spf13/viper"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // The EgressNetworkPolicyBuilder creates network policies that allow egress traffic from pods.
@@ -50,18 +45,6 @@ func (r *EgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effectivep
 				},
 			},
 		})
-
-		if viper.GetBool(operatorconfig.EnableEgressAutoallowDNSTrafficKey) {
-			// DNS
-			egressRules = append(egressRules, v1.NetworkPolicyEgressRule{
-				Ports: []v1.NetworkPolicyPort{
-					{
-						Protocol: lo.ToPtr(corev1.ProtocolUDP),
-						Port:     lo.ToPtr(intstr.FromInt32(53)),
-					},
-				},
-			})
-		}
 	}
 	return egressRules
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy.go
@@ -7,9 +7,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig"
 	"github.com/samber/lo"
-	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -59,17 +57,6 @@ func (r *PortEgressRulesBuilder) buildEgressRulesFromEffectivePolicy(ctx context
 			return nil, errors.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
 		}
 		egressRules = append(egressRules, egressRule)
-		if viper.GetBool(operatorconfig.EnableEgressAutoallowDNSTrafficKey) {
-			// DNS
-			egressRules = append(egressRules, v1.NetworkPolicyEgressRule{
-				Ports: []v1.NetworkPolicyPort{
-					{
-						Protocol: lo.ToPtr(corev1.ProtocolUDP),
-						Port:     lo.ToPtr(intstr.FromInt32(53)),
-					},
-				},
-			})
-		}
 	}
 	return egressRules, nil
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy_test.go
@@ -6,9 +6,7 @@ import (
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig"
 	"github.com/samber/lo"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +45,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) networkPolicyTemplate(
 	formattedServer string,
 	intentsObjNamespace string,
 	svcObject *corev1.Service,
-	allowDNS bool,
 ) *v1.NetworkPolicy {
 	netpol := &v1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -82,16 +79,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) networkPolicyTemplate(
 				},
 			},
 		},
-	}
-	if allowDNS {
-		netpol.Spec.Egress = append(netpol.Spec.Egress, v1.NetworkPolicyEgressRule{
-			Ports: []v1.NetworkPolicyPort{
-				{
-					Protocol: lo.ToPtr(corev1.ProtocolUDP),
-					Port:     lo.ToPtr(intstr.FromInt32(53)),
-				},
-			},
-		})
 	}
 	return netpol
 }
@@ -173,32 +160,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyKube
 		policyName,
 		formattedClient,
 		formattedServer,
-		false,
-	)
-	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
-}
-
-func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyKubernetesServiceWithAutoallowedDNS() {
-	clientIntentsName := "client-intents"
-	policyName := "test-client-access"
-	serviceName := "test-client"
-	serverNamespace := testNamespace
-	formattedClient := "test-client-test-client-namespac-edb3a2"
-	formattedServer := "test-server-test-namespace-8ddecb"
-	viper.Set(operatorconfig.EnableEgressAutoallowDNSTrafficKey, true)
-	defer func() {
-		viper.Set(operatorconfig.EnableEgressAutoallowDNSTrafficKey, false)
-	}()
-
-	s.testCreateNetworkPolicyForKubernetesService(
-		clientIntentsName,
-		serverNamespace,
-		serviceName,
-		[]corev1.ServicePort{{TargetPort: intstr.IntOrString{IntVal: 80}}},
-		policyName,
-		formattedClient,
-		formattedServer,
-		true,
 	)
 	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
 }
@@ -219,7 +180,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyKube
 		policyName,
 		formattedClient,
 		formattedServer,
-		false,
 	)
 	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
 }
@@ -240,7 +200,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyName
 		policyName,
 		formattedClient,
 		formattedServer,
-		false,
 	)
 	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
 }
@@ -555,7 +514,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) testCreateNetworkPolicyForK
 	policyName string,
 	formattedClient string,
 	formattedServer string,
-	expectAllowDNS bool,
 ) {
 	namespacedName := types.NamespacedName{
 		Namespace: testClientNamespace,
@@ -600,7 +558,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) testCreateNetworkPolicyForK
 		formattedServer,
 		testNamespace,
 		svcObject,
-		expectAllowDNS,
 	)
 	// Add target port and change selector in ingress to use svc
 	newPolicy.Spec.Egress[0].Ports = lo.Map(ports, func(port corev1.ServicePort, _ int) v1.NetworkPolicyPort {
@@ -664,7 +621,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestUpdateNetworkPolicyForK
 		formattedServer,
 		testNamespace,
 		svcObject,
-		false,
 	)
 	// Add target port and change selector in egress to use svc
 	newPolicy.Spec.Egress[0].Ports = []v1.NetworkPolicyPort{{Port: &intstr.IntOrString{IntVal: 80}}}
@@ -746,7 +702,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCleanNetworkPolicyForKu
 		formattedTargetServer,
 		testNamespace,
 		&svcObject,
-		false,
 	)
 	// Add target port and change selector in ingress to use svc
 	existingPolicy.Spec.Egress[0].Ports = []v1.NetworkPolicyPort{{Port: &intstr.IntOrString{IntVal: 80}}}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -163,6 +163,7 @@ func main() {
 			CertDir: webhooks.CertDirPath,
 		}),
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       viper.GetString(operatorconfig.PprofBindAddressKey),
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a3a7d614.otterize.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
@@ -222,7 +223,10 @@ func main() {
 		epNetpolReconciler.AddEgressRuleBuilder(internetNetpolReconciler)
 		svcEgressNetworkPolicyHandler := builders.NewPortEgressRulesBuilder(mgr.GetClient())
 		epNetpolReconciler.AddEgressRuleBuilder(svcEgressNetworkPolicyHandler)
-
+		if viper.GetBool(operatorconfig.EnableEgressAutoallowDNSTrafficKey) {
+			dnsEgressNetpolBuilder := builders.NewDNSEgressNetworkPolicyBuilder()
+			epNetpolReconciler.AddEgressRuleBuilder(dnsEgressNetpolBuilder)
+		}
 	}
 
 	epIntentsReconciler := intents_reconcilers.NewServiceEffectiveIntentsReconciler(mgr.GetClient(), scheme, epGroupReconciler)

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -18,6 +18,8 @@ const (
 	MetricsAddrDefault                          = ":2112"
 	ProbeAddrKey                                = "health-probe-bind-address" // The address the probe endpoint binds to
 	ProbeAddrDefault                            = ":8181"
+	PprofBindAddressKey                         = "pprof-bind-address"
+	PprofAddrDefault                            = "127.0.0.1:9001"
 	EnableLeaderElectionKey                     = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
 	EnableLeaderElectionDefault                 = false
 	WatchedNamespacesKey                        = "watched-namespaces"            // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
@@ -147,6 +149,7 @@ func InitCLIFlags() {
 	pflag.Bool(EnableKafkaACLKey, EnableKafkaACLDefault, "Whether to disable Intents Kafka ACL creation")
 	pflag.String(MetricsAddrKey, MetricsAddrDefault, "The address the metric endpoint binds to.")
 	pflag.String(ProbeAddrKey, ProbeAddrDefault, "The address the probe endpoint binds to.")
+	pflag.String(PprofBindAddressKey, PprofAddrDefault, "The address that the Go pprof profiler binds to.")
 	pflag.Bool(EnableLeaderElectionKey, EnableLeaderElectionDefault, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	pflag.StringSlice(WatchedNamespacesKey, nil, "Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas.")
 	pflag.StringSlice(ActiveEnforcementNamespacesKey, nil, "While using the shadow enforcement mode, namespaces in this list will be treated as if the enforcement were active.")


### PR DESCRIPTION
### Description

Fixed a bug where the DNS egress rules created by the operator would be added twice to each network policy.

Also enabled pprof for the operator by default, to enable performance profiling. 
### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
