### PR TITLE
Fixed bug where deleted & reapplied intents would not trigger credentials-operator to configure database password

### DIFF
--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -281,7 +281,8 @@ func (r *DatabaseReconciler) handleDatabaseAnnotationOnPod(ctx context.Context, 
 	updatedPod.Annotations[databaseconfigurator.LatestAccessChangeAnnotation] = time.Now().Format(time.RFC3339)
 	if !intents.DeletionTimestamp.IsZero() {
 		// Clean all databases
-		updatedPod.Annotations[databaseconfigurator.DatabaseAccessAnnotation] = ""
+		delete(updatedPod.Annotations, databaseconfigurator.DatabaseAccessAnnotation)
+		delete(updatedPod.Annotations, databaseconfigurator.LatestAccessChangeAnnotation)
 	} else {
 		// We cannot simply add all DB instances mentioned in the client intents because we also depend on server configs
 		// So we add one instance at a time, and only those which the operator successfully created a user for

--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -200,6 +200,10 @@ func (r *DatabaseReconciler) applyDBInstanceIntentsOnConfigurator(
 			return errors.Wrap(err)
 		}
 
+		if err := r.handleDatabaseAnnotationOnPod(ctx, *clientIntents, dbInstanceName); err != nil {
+			return errors.Wrap(err)
+		}
+
 		return nil
 	}
 

--- a/src/shared/databaseconfigurator/dbconfigurator.go
+++ b/src/shared/databaseconfigurator/dbconfigurator.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	DatabaseAccessAnnotation = "intents.otterize.com/database-access"
+	DatabaseAccessAnnotation     = "intents.otterize.com/database-access"
+	LatestAccessChangeAnnotation = "intents.otterize.com/database-access-update-time"
 )
 
 type DatabaseConfigurator interface {


### PR DESCRIPTION
### Description
Added logic to clean database access annotation for deleted intents and update pod with 'access changed' timestamp for already existing instances

### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
