### PR TITLE
Fixing bug where hashed usernames would exceed allowed MySQL username length

### DIFF
--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
+	"github.com/otterize/intents-operator/src/shared/clusterutils"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
@@ -158,6 +159,17 @@ func (s *DatabaseReconcilerTestSuite) reconcileWithExpectedResources(clientInten
 	req := ctrl.Request{NamespacedName: s.namespacedName}
 
 	return s.Reconciler.Reconcile(context.Background(), req)
+}
+
+func (s *DatabaseReconcilerTestSuite) TestHashedUsernameLength() {
+	longWorkloadName := "my.super.long-workload-name"
+	longNamespace := "my.super.long-namespace-name"
+	clusterID := "abc-def-ghi-jkl-mno-189023123"
+	hashedUsername := clusterutils.BuildHashedUsername(longWorkloadName, longNamespace, clusterID)
+	s.Require().True(len(hashedUsername) <= 32)
+
+	pgUsername := clusterutils.KubernetesToPostgresName(hashedUsername)
+	s.Require().True(len(pgUsername) <= 32)
 }
 
 func TestDatabaseReconcilerTestSuite(t *testing.T) {

--- a/src/shared/clusterutils/username.go
+++ b/src/shared/clusterutils/username.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	HashedUsernameSectionMaxLength = 11
+	HashedUsernameSectionMaxLength = 10
 )
 
 func BuildHashedUsername(workloadName, namespace, clusterUID string) string {
@@ -18,11 +18,11 @@ func BuildHashedUsername(workloadName, namespace, clusterUID string) string {
 	hash := md5.Sum([]byte(fullUsername))
 
 	if len(workloadName) > HashedUsernameSectionMaxLength {
-		workloadName = workloadName[:HashedUsernameSectionMaxLength]
+		workloadName = strings.TrimSuffix(workloadName[:HashedUsernameSectionMaxLength], "-")
 	}
 
 	if len(namespace) > HashedUsernameSectionMaxLength {
-		namespace = namespace[:HashedUsernameSectionMaxLength]
+		namespace = strings.TrimSuffix(namespace[:HashedUsernameSectionMaxLength], "-")
 	}
 
 	hashSuffix := hex.EncodeToString(hash[:])[:6]
@@ -31,9 +31,8 @@ func BuildHashedUsername(workloadName, namespace, clusterUID string) string {
 
 // KubernetesToPostgresName translates a name with Kubernetes conventions to Postgres conventions
 func KubernetesToPostgresName(kubernetesName string) string {
-	// '.' are replaced with dunders '__'
-	// '-' are replaced with single underscores '_'
-	return strings.ReplaceAll(strings.ReplaceAll(kubernetesName, ".", "__"), "-", "_")
+	// '.' and '-' are replaced with single underscores '_'
+	return strings.ReplaceAll(strings.ReplaceAll(kubernetesName, ".", "_"), "-", "_")
 }
 
 func PostgresToKubernetesName(pgName string) string {

--- a/src/shared/clusterutils/username.go
+++ b/src/shared/clusterutils/username.go
@@ -34,7 +34,3 @@ func KubernetesToPostgresName(kubernetesName string) string {
 	// '.' and '-' are replaced with single underscores '_'
 	return strings.ReplaceAll(strings.ReplaceAll(kubernetesName, ".", "_"), "-", "_")
 }
-
-func PostgresToKubernetesName(pgName string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(pgName, "__", "."), "_", "-")
-}


### PR DESCRIPTION
### Description
Fixing a bug where hashed usernames would exceed allowed MySQL username length.

### Testing
Added a UT in database reconciler tests to ensure long workload & namespace names do not exceed the maximum length.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
