### PR TITLE
Ignore not-found errors when attempting to delete external traffic policies

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -460,7 +460,7 @@ func (r *NetworkPolicyHandler) handlePolicyDelete(ctx context.Context, policyNam
 	r.RecordNormalEvent(owner, ReasonRemovingExternalTrafficPolicy, "removing external traffic network policy, reconciler was disabled")
 
 	err = r.client.Delete(ctx, policy)
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		r.RecordWarningEventf(owner, ReasonRemovingExternalTrafficPolicyFailed, "failed removing external traffic network policy: %s", err.Error())
 		return errors.Wrap(err)
 	}


### PR DESCRIPTION
### Description
Catch and ignore k8s NotFound errors when attempting to delete and already non-exising network policy rule. 
