### PR TITLE
Fix 'missing annotation shared service account' error reported due to race in intents reconcilers

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -356,14 +356,15 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 
 	status.IstioStatus.ServiceAccountName = toPtrOrNil(serviceAccountName)
 	isSharedValue, ok := clientIntents.Annotations[OtterizeSharedServiceAccountAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation shared service account for client intents %s", clientIntents.Name)
+	isShared := false
+	if ok {
+		parsedIsShared, err := strconv.ParseBool(isSharedValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+		}
+		isShared = parsedIsShared
 	}
 
-	isShared, err := strconv.ParseBool(isSharedValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
-	}
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]


### PR DESCRIPTION
### Description
Fix 'missing annotation shared service account' error reported due to race in intents reconcilers, when the cloud reconciler is called on intents which haven't completed the policy reconciler loop just yet. 