### PR TITLE
Fix error reporting missing stack trace due to using fmt.Errorf rather than errors.Errorf

### DIFF
--- a/src/operator/api/v1alpha3/otterize_labels.go
+++ b/src/operator/api/v1alpha3/otterize_labels.go
@@ -2,7 +2,6 @@ package v1alpha3
 
 import (
 	"context"
-	"fmt"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"golang.org/x/exp/maps"
@@ -102,7 +101,7 @@ func ServiceIdentityToLabelsForWorkloadSelection(ctx context.Context, k8sClient 
 			return nil, false, errors.Wrap(err)
 		}
 		if svc.Spec.Selector == nil {
-			return nil, false, fmt.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
+			return nil, false, errors.Errorf("service %s/%s has no selector", svc.Namespace, svc.Name)
 		}
 		return maps.Clone(svc.Spec.Selector), true, nil
 	}

--- a/src/shared/awsagent/rolesanywhere_creds/credentials_provider.go
+++ b/src/shared/awsagent/rolesanywhere_creds/credentials_provider.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"fmt"
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws"
@@ -116,7 +115,7 @@ func getCredentials(keyPath string, certPath string, roleARN string, account ope
 	}
 	output, err := rolesAnywhereClient.CreateSession(&createSessionRequest)
 	if err != nil {
-		return awsv2.Credentials{}, fmt.Errorf("failed to create session: %w", err)
+		return awsv2.Credentials{}, errors.Errorf("failed to create session: %w", err)
 	}
 
 	if len(output.CredentialSet) == 0 {
@@ -126,7 +125,7 @@ func getCredentials(keyPath string, certPath string, roleARN string, account ope
 	credentials := output.CredentialSet[0].Credentials
 	expirationAsTime, err := time.Parse(time.RFC3339, *credentials.Expiration)
 	if err != nil {
-		return awsv2.Credentials{}, fmt.Errorf("failed to parse expiration time: %w", err)
+		return awsv2.Credentials{}, errors.Errorf("failed to parse expiration time: %w", err)
 	}
 	finalCredentials := awsv2.Credentials{
 		AccessKeyID:     *credentials.AccessKeyId,

--- a/src/shared/databaseconfigurator/postgres/postgres.go
+++ b/src/shared/databaseconfigurator/postgres/postgres.go
@@ -192,7 +192,7 @@ func (p *PostgresConfigurator) revokeDatabasePermissions(ctx context.Context, us
 	if err != nil {
 		pgErr, ok := TranslatePostgresConnectionError(err)
 		if ok {
-			return errors.Wrap(fmt.Errorf(pgErr))
+			return errors.Errorf(pgErr)
 		}
 		return errors.Wrap(err)
 	}

--- a/src/shared/databaseconfigurator/postgres/utils.go
+++ b/src/shared/databaseconfigurator/postgres/utils.go
@@ -49,7 +49,7 @@ func TranslatePostgresCommandsError(err error) error {
 	if pgErr := &(pgconn.PgError{}); errors.As(err, &pgErr) {
 		// See: https://www.postgresql.org/docs/current/errcodes-appendix.html
 		if pgErr.Code == "42P01" || pgErr.Code == "3F000" {
-			return errors.Wrap(fmt.Errorf("bad schema/table name: %s", pgErr.Message))
+			return errors.Errorf("bad schema/table name: %s", pgErr.Message)
 		}
 		if pgErr.Code == "42704" {
 			return errors.Wrap(ErrUndefinedObject)

--- a/src/shared/gcpagent/utils.go
+++ b/src/shared/gcpagent/utils.go
@@ -6,6 +6,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/k8s/v1alpha1"
 	otterizev1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
 	"github.com/otterize/intents-operator/src/shared/agentutils"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +67,7 @@ func (a *Agent) generateIAMPartialPolicy(namespace string, intentsServiceName st
 		expression := fmt.Sprintf("resource.name == \"%s\"", intent.Name)
 		if strings.Contains(intent.Name, "*") {
 			if strings.Index(intent.Name, "*") != len(intent.Name)-1 {
-				return nil, fmt.Errorf("wildcard in the middle of the name is not supported: %s", intent.Name)
+				return nil, errors.Errorf("wildcard in the middle of the name is not supported: %s", intent.Name)
 			}
 
 			cleanName := strings.ReplaceAll(intent.Name, "*", "")


### PR DESCRIPTION
### Description
Replace usage of `fmt.Errorf` with our internal `errors.Errorf` implementation, to ensure that errors are reported with full stack traces. 
