### PR TITLE
Reuse cloud API address config key for error telemetries APIs

### DIFF
--- a/src/shared/telemetries/errorreporter/errorsender.go
+++ b/src/shared/telemetries/errorreporter/errorsender.go
@@ -2,8 +2,10 @@ package errorreporter
 
 import (
 	"context"
+	"fmt"
 	"github.com/Khan/genqlient/graphql"
 	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/telemetries/basicbatch"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesconfig"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
@@ -21,10 +23,11 @@ type ErrorSender struct {
 }
 
 func newGqlClient() graphql.Client {
-	apiAddress := viper.GetString(telemetriesconfig.TelemetryAPIAddressKey)
+	apiAddress := viper.GetString(otterizecloudclient.OtterizeAPIAddressKey)
+	graphqlUrl := fmt.Sprintf("%s/telemetry/query", apiAddress)
 	clientTimeout := viper.GetDuration(telemetriesconfig.TimeoutKey)
 	clientWithTimeout := &http.Client{Timeout: clientTimeout}
-	return graphql.NewClient(apiAddress, clientWithTimeout)
+	return graphql.NewClient(graphqlUrl, clientWithTimeout)
 }
 
 func (s *ErrorSender) SendSync(errs []*telemetriesgql.Error) error {

--- a/src/shared/telemetries/telemetriesconfig/config.go
+++ b/src/shared/telemetries/telemetriesconfig/config.go
@@ -6,8 +6,6 @@ import (
 )
 
 const (
-	TelemetryAPIAddressKey         = "telemetry-address"
-	TelemetryAPIAddressDefault     = "https://app.otterize.com/api/telemetry/query"
 	TimeoutKey                     = "telemetry-client-timeout"
 	CloudClientTimeoutDefault      = "30s"
 	TelemetryEnabledKey            = "telemetry-enabled"
@@ -26,13 +24,10 @@ const (
 	TelemetryErrorEnabledDefault   = true
 	TelemetryErrorsStageKey        = "telemetry-errors-stage"
 	TelemetryErrorsStageDefault    = "production"
-	TelemetryErrorsAddressKey      = "telemetry-errors-address"
-	TelemetryErrorsAddressDefault  = "https://app.otterize.com/api/errors"
 	EnvPrefix                      = "OTTERIZE"
 )
 
 func init() {
-	viper.SetDefault(TelemetryAPIAddressKey, TelemetryAPIAddressDefault)
 	viper.SetDefault(TimeoutKey, CloudClientTimeoutDefault)
 	viper.SetDefault(TelemetryIntervalKey, TelemetryIntervalDefault)
 	viper.SetDefault(TelemetryMaxBatchSizeKey, TelemetryMaxBatchSizeDefault)
@@ -42,7 +37,6 @@ func init() {
 	viper.SetDefault(TelemetryActiveIntervalKey, TelemetryActiveIntervalDefault)
 	viper.SetDefault(TelemetryErrorsEnabledKey, TelemetryErrorEnabledDefault)
 	viper.SetDefault(TelemetryErrorsStageKey, TelemetryErrorsStageDefault)
-	viper.SetDefault(TelemetryErrorsAddressKey, TelemetryErrorsAddressDefault)
 	viper.SetEnvPrefix(EnvPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/src/shared/telemetries/telemetrysender/sender.go
+++ b/src/shared/telemetries/telemetrysender/sender.go
@@ -2,8 +2,10 @@ package telemetrysender
 
 import (
 	"context"
+	"fmt"
 	"github.com/Khan/genqlient/graphql"
 	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/telemetries/basicbatch"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesconfig"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
@@ -23,10 +25,11 @@ type TelemetrySender struct {
 }
 
 func newGqlClient() graphql.Client {
-	apiAddress := viper.GetString(telemetriesconfig.TelemetryAPIAddressKey)
+	apiAddress := viper.GetString(otterizecloudclient.OtterizeAPIAddressKey)
+	graphqlUrl := fmt.Sprintf("%s/telemetry/query", apiAddress)
 	clientTimeout := viper.GetDuration(telemetriesconfig.TimeoutKey)
 	clientWithTimeout := &http.Client{Timeout: clientTimeout}
-	return graphql.NewClient(apiAddress, clientWithTimeout)
+	return graphql.NewClient(graphqlUrl, clientWithTimeout)
 }
 
 func batchSendTelemetries(ctx context.Context, telemetriesClient graphql.Client, telemetries []telemetriesgql.TelemetryInput) error {


### PR DESCRIPTION
### Description
Reuse cloud API address config key for error telemetries APIs, so that OSS components connected to staging / development clouds will report errors & telemetries to them. 

### References
Builds on top of: https://github.com/otterize/intents-operator/pull/435
