### PR TITLE
Fix a case where applied kafka intents were reported without namespace to the cloud

### DIFF
--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
@@ -770,6 +770,21 @@ func (s *CloudReconcilerTestSuite) TestNamespaceParseSuccess() {
 	s.Require().Equal(lo.FromPtr(cloudIntent.ServerNamespace), "other-namespace")
 }
 
+// TestIntents With Kafka Target
+func (s *CloudReconcilerTestSuite) TestKafkaTarget() {
+	serverName := "server.other-namespace"
+	intent := &otterizev2alpha1.Target{Kafka: &otterizev2alpha1.KafkaTarget{Name: serverName, Topics: []otterizev2alpha1.KafkaTopic{{Name: "test", Operations: []otterizev2alpha1.KafkaOperation{otterizev2alpha1.KafkaOperationConsume}}}}}
+	cloudIntent, err := intent.ConvertToCloudFormat(context.Background(), s.client, serviceidentity.ServiceIdentity{Name: clientName, Namespace: testNamespace})
+	s.Require().NoError(err)
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerName), "server")
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerNamespace), "other-namespace")
+	s.Require().Len(cloudIntent.Topics, 1)
+	s.Require().Equal(lo.FromPtr(cloudIntent.Topics[0].Name), "test")
+	s.Require().Len(cloudIntent.Topics[0].Operations, 1)
+	s.Require().Equal(lo.FromPtr(cloudIntent.Topics[0].Operations[0]), graphqlclient.KafkaOperationConsume)
+
+}
+
 func (s *CloudReconcilerTestSuite) TestTargetNamespaceAsSourceNamespace() {
 	serverName := "server"
 	intent := &otterizev2alpha1.Target{Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serverName}}


### PR DESCRIPTION
### Description

Since the last merge, applied intents with Kafka intents were reported to the cloud without the target namespace. 

### Testing

Added test for this use case.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
