### PR TITLE
Fix a bug where applied intents to the Kubernets API service couldn't be reported to the cloud properly

### DIFF
--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -780,8 +780,7 @@ func (in *Target) ConvertToCloudFormat(ctx context.Context, k8sClient client.Cli
 			Name: lo.ToPtr(serverServiceIdentity.GetNameAsServer()),
 			Kind: lo.ToPtr(serviceidentity.KindService),
 		}
-	}
-	if in.IsTargetServerKubernetesService() && !in.IsTargetTheKubernetesAPIServer(clientServiceIdentity.Namespace) {
+	} else if in.IsTargetServerKubernetesService() {
 		// alias should be the kubernetes service
 		alias = &graphqlclient.ServerAliasInput{
 			Name: lo.ToPtr(serverServiceIdentity.GetNameAsServer()),
@@ -806,7 +805,6 @@ func (in *Target) ConvertToCloudFormat(ctx context.Context, k8sClient client.Cli
 				serverServiceIdentity = si
 			}
 		}
-
 	}
 
 	intentInput := graphqlclient.IntentInput{

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -775,7 +775,13 @@ func (in *Target) GetHTTPResources() []HTTPTarget {
 func (in *Target) ConvertToCloudFormat(ctx context.Context, k8sClient client.Client, clientServiceIdentity serviceidentity.ServiceIdentity) (graphqlclient.IntentInput, error) {
 	serverServiceIdentity := in.ToServiceIdentity(clientServiceIdentity.Namespace)
 	var alias *graphqlclient.ServerAliasInput
-	if in.IsTargetServerKubernetesService() {
+	if in.IsTargetTheKubernetesAPIServer(clientServiceIdentity.Namespace) {
+		alias = &graphqlclient.ServerAliasInput{
+			Name: lo.ToPtr(serverServiceIdentity.GetNameAsServer()),
+			Kind: lo.ToPtr(serviceidentity.KindService),
+		}
+	}
+	if in.IsTargetServerKubernetesService() && !in.IsTargetTheKubernetesAPIServer(clientServiceIdentity.Namespace) {
 		// alias should be the kubernetes service
 		alias = &graphqlclient.ServerAliasInput{
 			Name: lo.ToPtr(serverServiceIdentity.GetNameAsServer()),

--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
@@ -3,6 +3,7 @@ package intents_reconcilers
 import (
 	"context"
 	"errors"
+	"fmt"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
@@ -822,6 +823,18 @@ func (s *CloudReconcilerTestSuite) TestReportKindAndAlias() {
 	s.Require().Equal(lo.FromPtr(cloudIntent.ServerWorkloadKind), "Deployment")
 	s.Require().Equal(lo.FromPtr(cloudIntent.ServerAlias), graphqlclient.ServerAliasInput{Name: lo.ToPtr(serverName + "." + testNamespace), Kind: lo.ToPtr("Service")})
 	s.Require().Equal(lo.FromPtr(cloudIntent.ClientWorkloadKind), "StatefulSet")
+}
+
+func (s *CloudReconcilerTestSuite) TestReportTargetKubernetesAPIServiceWithNoSelector() {
+	serverName := "kubernetes"
+	serverNamespace := "default"
+	intent := &otterizev2alpha1.Target{Service: &otterizev2alpha1.ServiceTarget{Name: fmt.Sprint(serverName, ".", serverNamespace)}}
+	cloudIntent, err := intent.ConvertToCloudFormat(context.Background(), s.client, serviceidentity.ServiceIdentity{Name: clientName, Namespace: testNamespace})
+	s.Require().NoError(err)
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerWorkloadKind), "Service")
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerAlias), graphqlclient.ServerAliasInput{Name: lo.ToPtr(serverName + "." + serverNamespace), Kind: lo.ToPtr("Service")})
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerNamespace), serverNamespace)
+	s.Require().Equal(lo.FromPtr(cloudIntent.ServerName), serverName)
 }
 
 func (s *CloudReconcilerTestSuite) expectNoEvent() {


### PR DESCRIPTION

### Description

Fix a bug where applied intents to Kubernetes API service couldn't be reported to the cloud properly.



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
