### PR TITLE
Make the conversion whebhook of `v1alpha3` and `v1beta1` preserve the way a service is addressed in `clientIntent.Spec.call[x].name` instead of changing it to an explicit form

### DIFF
--- a/src/operator/api/v1alpha3/webhooks_test.go
+++ b/src/operator/api/v1alpha3/webhooks_test.go
@@ -146,6 +146,47 @@ func (t *WebhooksTestSuite) TestProtectedServiceConversion() {
 	t.Require().Equal(original.Spec, converted.Spec)
 }
 
+func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
+	// Create a ClientIntents with random data
+	original := &ClientIntents{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: &IntentsSpec{
+			Service: Service{
+				Name: "test",
+				Kind: "test",
+			},
+			Calls: []Intent{
+				{
+					Name: "test.test",
+				},
+				{
+					Name: "test2",
+				},
+				{
+					Name: "test3.other-namespace",
+				},
+				{
+					Name: "svc:kubernetes.default",
+				},
+			},
+		}}
+
+	// ConvertTo
+	dstRaw := &v2alpha1.ClientIntents{}
+	err := original.ConvertTo(dstRaw)
+	t.Require().NoError(err)
+
+	// ConvertFrom
+	converted := &ClientIntents{}
+	err = converted.ConvertFrom(dstRaw)
+	t.Require().NoError(err)
+
+	t.Require().Equal(original.Spec, converted.Spec)
+}
+
 func TestWebhooksTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhooksTestSuite))
 }

--- a/src/operator/api/v1beta1/webhooks_test.go
+++ b/src/operator/api/v1beta1/webhooks_test.go
@@ -146,6 +146,47 @@ func (t *WebhooksTestSuite) TestProtectedServiceConversion() {
 	t.Require().Equal(original.Spec, converted.Spec)
 }
 
+func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
+	// Create a ClientIntents with random data
+	original := &ClientIntents{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: &IntentsSpec{
+			Service: Service{
+				Name: "test",
+				Kind: "test",
+			},
+			Calls: []Intent{
+				{
+					Name: "test.test",
+				},
+				{
+					Name: "test2",
+				},
+				{
+					Name: "test3.other-namespace",
+				},
+				{
+					Name: "svc:kubernetes.default",
+				},
+			},
+		}}
+
+	// ConvertTo
+	dstRaw := &v2alpha1.ClientIntents{}
+	err := original.ConvertTo(dstRaw)
+	t.Require().NoError(err)
+
+	// ConvertFrom
+	converted := &ClientIntents{}
+	err = converted.ConvertFrom(dstRaw)
+	t.Require().NoError(err)
+
+	t.Require().Equal(original.Spec, converted.Spec)
+}
+
 func TestWebhooksTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhooksTestSuite))
 }


### PR DESCRIPTION

### Description

Previously, our conversion webhooks transformed calls to an explicit way of addressing services: `server` -> `server.namespace` this behavior could make tools such as Terraform mad when applying intents. In this PR we change the webhook so it will keep the call as is.



### Testing

Added a "dummy test" that converts intents to and from the hub version, and checks it keeps the same structure and values.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
