### PR TITLE
Fix a case of an infinite reconciliation loop caused by a missing status of converted `clientIntents`

### DIFF
--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -38,7 +38,7 @@ const (
 	OtterizeAccessLabelPrefix                        = "intents.otterize.com/access"
 	OtterizeServiceAccessLabelPrefix                 = "intents.otterize.com/svc-access"
 	OtterizeAccessLabelKey                           = "intents.otterize.com/access-%s"
-	OtterizeExternalAccessLabelKey             = "intents.otterize.com/external-access-%s"
+	OtterizeExternalAccessLabelKey                   = "intents.otterize.com/external-access-%s"
 	OtterizeSvcAccessLabelKey                        = "intents.otterize.com/svc-access-%s"
 	OtterizeClientLabelKey                           = "intents.otterize.com/client"
 	OtterizeServiceLabelKey                          = "intents.otterize.com/service"

--- a/src/operator/api/v1alpha3/webhooks_test.go
+++ b/src/operator/api/v1alpha3/webhooks_test.go
@@ -149,6 +149,7 @@ func (t *WebhooksTestSuite) TestProtectedServiceConversion() {
 func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	// Create a ClientIntents with random data
 	original := &ClientIntents{
+		Status: IntentsStatus{ObservedGeneration: 1, UpToDate: true, ResolvedIPs: []ResolvedIPs{{DNS: "a.test", IPs: []string{"1.3.3.7"}}}},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",

--- a/src/operator/api/v1alpha3/webhooks_test.go
+++ b/src/operator/api/v1alpha3/webhooks_test.go
@@ -186,6 +186,7 @@ func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	t.Require().NoError(err)
 
 	t.Require().Equal(original.Spec, converted.Spec)
+	t.Require().Equal(original.Status, converted.Status)
 }
 
 func TestWebhooksTestSuite(t *testing.T) {

--- a/src/operator/api/v1beta1/webhooks_test.go
+++ b/src/operator/api/v1beta1/webhooks_test.go
@@ -149,6 +149,7 @@ func (t *WebhooksTestSuite) TestProtectedServiceConversion() {
 func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	// Create a ClientIntents with random data
 	original := &ClientIntents{
+		Status: IntentsStatus{ObservedGeneration: 1, UpToDate: true, ResolvedIPs: []ResolvedIPs{{DNS: "a.test", IPs: []string{"1.3.3.7"}}}},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",

--- a/src/operator/api/v1beta1/webhooks_test.go
+++ b/src/operator/api/v1beta1/webhooks_test.go
@@ -186,6 +186,7 @@ func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	t.Require().NoError(err)
 
 	t.Require().Equal(original.Spec, converted.Spec)
+	t.Require().Equal(original.Status, converted.Status)
 }
 
 func TestWebhooksTestSuite(t *testing.T) {


### PR DESCRIPTION
### Description

The webhook didn't convert `clientIntents.Status` and caused an infinite reconciliation loop of the intents-controller.



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
