### PR TITLE
Ensure webhook reconciler patches the Latest `CRD`/`ValidationWebhook` revision to minimize CA bundle edge cases

### DIFF
--- a/src/operator/controllers/custom_resource_definition_controller.go
+++ b/src/operator/controllers/custom_resource_definition_controller.go
@@ -58,7 +58,7 @@ func NewCustomResourceDefinitionsReconciler(
 }
 
 func (r *CustomResourceDefinitionsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logrus.Debugf("Reconciling due to CustomResourceDefinition change: %s", req.Name)
+	logrus.Infof("Reconciling due to CustomResourceDefinition change: %s", req.Name)
 
 	// Fetch the validating webhook configuration object
 	crd := &apiextensionsv1.CustomResourceDefinition{}
@@ -77,7 +77,7 @@ func (r *CustomResourceDefinitionsReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, errors.Errorf("CRD does not contain a proper conversion webhook definition")
 	}
 	if bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, r.certPem) && crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace == r.namespace {
-		logrus.Debugf("CustomResourceDefinition %s already has the correct CA bundle and namespace", resourceCopy.Name)
+		logrus.Infof("CustomResourceDefinition %s already has the correct CA bundle and namespace", resourceCopy.Name)
 		return ctrl.Result{}, nil
 
 	}

--- a/src/operator/controllers/custom_resource_definition_controller_test.go
+++ b/src/operator/controllers/custom_resource_definition_controller_test.go
@@ -66,7 +66,7 @@ func (s *CustomResourceDefinitionsTestSuite) TestAssigningCABundle() {
 		},
 	)
 
-	matcher := intents_reconcilers.MatchPatch(client.MergeFrom(crd))
+	matcher := intents_reconcilers.MatchPatch(client.MergeFromWithOptions(crd, client.MergeFromWithOptimisticLock{}))
 	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(updatedCRD), matcher).Return(nil)
 
 	// Call the reconcile function

--- a/src/operator/controllers/custom_resource_definition_controller_test.go
+++ b/src/operator/controllers/custom_resource_definition_controller_test.go
@@ -53,20 +53,24 @@ func (s *CustomResourceDefinitionsTestSuite) TestAssigningCABundle() {
 	crd, err := otterizecrds.GetCRDDefinitionByName(TestCRD)
 	s.Require().NoError(err)
 
+	copyCRD := crd.DeepCopy()
+	copyCRD.ResourceVersion = "1"
+
 	updatedCRD, err := otterizecrds.GetCRDDefinitionByName(TestCRD)
 	s.Require().NoError(err)
 
 	updatedCRD.Spec.Conversion.Webhook.ClientConfig.CABundle = s.Cert
 	updatedCRD.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = TestControllerNamespace
+	updatedCRD.ResourceVersion = "1"
 
 	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(crd)).DoAndReturn(
 		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *apiextensionsv1.CustomResourceDefinition, arg3 ...client.GetOption) error {
-			*arg2 = *crd
+			*arg2 = *copyCRD
 			return nil
 		},
 	)
 
-	matcher := intents_reconcilers.MatchPatch(client.MergeFromWithOptions(crd, client.MergeFromWithOptimisticLock{}))
+	matcher := intents_reconcilers.MatchPatch(client.MergeFromWithOptions(copyCRD, client.MergeFromWithOptimisticLock{}))
 	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(updatedCRD), matcher).Return(nil)
 
 	// Call the reconcile function

--- a/src/operator/controllers/intents_reconcilers/client_matcher.go
+++ b/src/operator/controllers/intents_reconcilers/client_matcher.go
@@ -2,6 +2,7 @@ package intents_reconcilers
 
 import (
 	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -11,12 +12,12 @@ type ClientPatch struct {
 
 func (p ClientPatch) Matches(x interface{}) bool {
 	patch := x.(client.Patch)
-	actualData, err := patch.Data(nil)
+	actualData, err := patch.Data(&DummyObject{})
 	if err != nil {
 		return false
 	}
 
-	expectedData, err := p.Data(nil)
+	expectedData, err := p.Data(&DummyObject{})
 	if err != nil {
 		return false
 	}
@@ -25,7 +26,7 @@ func (p ClientPatch) Matches(x interface{}) bool {
 }
 
 func (p ClientPatch) String() string {
-	data, err := p.Data(nil)
+	data, err := p.Data(&DummyObject{})
 	if err != nil {
 		return "format error"
 	}
@@ -34,4 +35,9 @@ func (p ClientPatch) String() string {
 
 func MatchPatch(patch client.Patch) gomock.Matcher {
 	return ClientPatch{patch}
+}
+
+// DummyObject is a placeholder to avoid nil dereference
+type DummyObject struct {
+	v1.Pod
 }

--- a/src/operator/controllers/validating_webhook_configurations_controller.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller.go
@@ -77,7 +77,8 @@ func (r *ValidatingWebhookConfigsReconciler) Reconcile(ctx context.Context, req 
 		resourceCopy.Webhooks[i].ClientConfig.CABundle = r.certPEM
 	}
 
-	if err := r.Patch(ctx, resourceCopy, client.MergeFrom(webhookConfig)); err != nil {
+	// Use optimistic locking to avoid using "mergeFrom" with an outdated resource
+	if err := r.Patch(ctx, resourceCopy, client.MergeFromWithOptions(webhookConfig, client.MergeFromWithOptimisticLock{})); err != nil {
 		return ctrl.Result{}, errors.Errorf("Failed to patch ValidatingWebhookConfiguration: %w", err)
 	}
 

--- a/src/operator/controllers/validating_webhook_configurations_controller.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller.go
@@ -68,7 +68,7 @@ func (r *ValidatingWebhookConfigsReconciler) Reconcile(ctx context.Context, req 
 	if lo.EveryBy(webhookConfig.Webhooks, func(item admissionregistrationv1.ValidatingWebhook) bool {
 		return bytes.Equal(item.ClientConfig.CABundle, r.certPEM)
 	}) {
-		logrus.Info("All ValidatingWebhookConfiguration certs match, skipping reconciliation. %s", req.Name)
+		logrus.Infof("All ValidatingWebhookConfiguration certs match, skipping reconciliation. %s", req.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/src/operator/controllers/validating_webhook_configurations_controller.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller.go
@@ -56,7 +56,7 @@ func NewValidatingWebhookConfigsReconciler(
 }
 
 func (r *ValidatingWebhookConfigsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logrus.Debugf("Reconciling due to ValidatingWebhookConfiguration change: %s", req.Name)
+	logrus.Infof("Reconciling due to ValidatingWebhookConfiguration change: %s", req.Name)
 
 	// Fetch the validating webhook configuration object
 	webhookConfig := &admissionregistrationv1.ValidatingWebhookConfiguration{}
@@ -68,6 +68,7 @@ func (r *ValidatingWebhookConfigsReconciler) Reconcile(ctx context.Context, req 
 	if lo.EveryBy(webhookConfig.Webhooks, func(item admissionregistrationv1.ValidatingWebhook) bool {
 		return bytes.Equal(item.ClientConfig.CABundle, r.certPEM)
 	}) {
+		logrus.Info("All ValidatingWebhookConfiguration certs match, skipping reconciliation. %s", req.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/src/operator/controllers/validating_webhook_configurations_controller_test.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller_test.go
@@ -61,6 +61,7 @@ func (s *ValidatingWebhookControllerTestSuite) TestAssigningCABundle() {
 			},
 		},
 	}
+	webhookConfig.ResourceVersion = "1"
 
 	updatedWebhookConfig := admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,6 +76,7 @@ func (s *ValidatingWebhookControllerTestSuite) TestAssigningCABundle() {
 			},
 		},
 	}
+	updatedWebhookConfig.ResourceVersion = "1"
 
 	s.Client.EXPECT().Get(gomock.Any(), req.NamespacedName, gomock.AssignableToTypeOf(&webhookConfig)).DoAndReturn(
 		func(arg0 context.Context, arg1 types.NamespacedName, arg2 *admissionregistrationv1.ValidatingWebhookConfiguration, arg3 ...client.GetOption) error {

--- a/src/operator/controllers/validating_webhook_configurations_controller_test.go
+++ b/src/operator/controllers/validating_webhook_configurations_controller_test.go
@@ -83,7 +83,7 @@ func (s *ValidatingWebhookControllerTestSuite) TestAssigningCABundle() {
 		},
 	)
 
-	matcher := intents_reconcilers.MatchPatch(client.MergeFrom(&webhookConfig))
+	matcher := intents_reconcilers.MatchPatch(client.MergeFromWithOptions(&webhookConfig, client.MergeFromWithOptimisticLock{}))
 	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(&updatedWebhookConfig), matcher).Return(nil)
 
 	// Call the reconcile function


### PR DESCRIPTION

### Description

Make sure the webhook reconciler patches the latest `CRD`/`validationWebhook` version - to reduce the risk of wrong CA bundle edge cases

