### PR TITLE
Avoid attempting to override pod containers when updating labels & annotations

### DIFF
--- a/src/operator/controllers/intents_reconcilers/client_matcher.go
+++ b/src/operator/controllers/intents_reconcilers/client_matcher.go
@@ -7,16 +7,17 @@ import (
 
 type ClientPatch struct {
 	client.Patch
+	modified client.Object
 }
 
 func (p ClientPatch) Matches(x interface{}) bool {
 	patch := x.(client.Patch)
-	actualData, err := patch.Data(nil)
+	actualData, err := patch.Data(p.modified)
 	if err != nil {
 		return false
 	}
 
-	expectedData, err := p.Data(nil)
+	expectedData, err := p.Data(p.modified)
 	if err != nil {
 		return false
 	}
@@ -33,5 +34,9 @@ func (p ClientPatch) String() string {
 }
 
 func MatchPatch(patch client.Patch) gomock.Matcher {
-	return ClientPatch{patch}
+	return ClientPatch{patch, nil}
+}
+
+func MatchMergeFromPatch(patch client.Patch, modified client.Object) gomock.Matcher {
+	return ClientPatch{patch, modified}
 }

--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -358,7 +358,7 @@ func (r *DatabaseReconciler) handleDatabaseAnnotationOnPod(ctx context.Context, 
 		updatedPod.Annotations[databaseconfigurator.DatabaseAccessAnnotation] = strings.Join(getAllowedDatabasesSlice(pod, dbInstance), ",")
 	}
 
-	if err := r.client.Patch(ctx, updatedPod, client.MergeFrom(&pod)); err != nil {
+	if err := r.client.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod)); err != nil {
 		return errors.Wrap(err)
 	}
 	return nil

--- a/src/operator/controllers/intents_reconcilers/pods.go
+++ b/src/operator/controllers/intents_reconcilers/pods.go
@@ -120,7 +120,7 @@ func (r *PodLabelReconciler) removeLabelsFromPods(
 		}
 
 		prometheus.IncrementPodsUnlabeledForNetworkPolicies(1)
-		err := r.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err := r.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/src/operator/controllers/intents_reconcilers/pods_test.go
+++ b/src/operator/controllers/intents_reconcilers/pods_test.go
@@ -264,7 +264,7 @@ func (s *PodLabelReconcilerTestSuite) testClientAccessLabelRemovedWithParams(pod
 		Spec: v1.PodSpec{},
 	}
 
-	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(&updatedPod), MatchPatch(client.MergeFrom(&pod))).Return(nil)
+	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(&updatedPod), MatchMergeFromPatch(client.StrategicMergeFrom(&pod), &updatedPod)).Return(nil)
 
 	res, err := s.Reconciler.Reconcile(context.Background(), req)
 	s.NoError(err)

--- a/src/operator/controllers/pod_reconcilers/namespace.go
+++ b/src/operator/controllers/pod_reconcilers/namespace.go
@@ -48,7 +48,7 @@ func (ns *NamespaceWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		updatedNS.Labels = make(map[string]string)
 	}
 	updatedNS.Labels[otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey] = req.Name
-	err = ns.Patch(ctx, updatedNS, client.MergeFrom(namespace))
+	err = ns.Patch(ctx, updatedNS, client.StrategicMergeFrom(namespace))
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
 	}

--- a/src/operator/controllers/pod_reconcilers/namespace_test.go
+++ b/src/operator/controllers/pod_reconcilers/namespace_test.go
@@ -51,7 +51,7 @@ func (s *NamespaceWatcherTestSuite) TestAddLabelToNewNamespace() {
 		"kubernetes.io/metadata.name": nsName,
 	}
 
-	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(nsWithLabel), intents_reconcilers.MatchPatch(client.MergeFrom(&namespaceWithoutLabels))).Return(nil)
+	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(nsWithLabel), intents_reconcilers.MatchMergeFromPatch(client.StrategicMergeFrom(&namespaceWithoutLabels), nsWithLabel)).Return(nil)
 
 	res, err := s.reconciler.Reconcile(context.Background(), req)
 	s.Require().NoError(err)
@@ -117,7 +117,7 @@ func (s *NamespaceWatcherTestSuite) TestOtherLabelsExists() {
 		"kubernetes.io/metadata.name": nsName,
 	}
 
-	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(nsWithLabel), intents_reconcilers.MatchPatch(client.MergeFrom(&namespaceWithOtherLabels))).Return(nil)
+	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(nsWithLabel), intents_reconcilers.MatchMergeFromPatch(client.StrategicMergeFrom(&namespaceWithOtherLabels), nsWithLabel)).Return(nil)
 
 	res, err := s.reconciler.Reconcile(context.Background(), req)
 	s.Require().NoError(err)

--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -270,7 +270,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 	}
 
 	if hasUpdates {
-		err = p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err = p.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if client.IgnoreNotFound(err) != nil {
 			return errors.Errorf("failed updating Otterize labels for pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
 		}

--- a/src/shared/gcpagent/config_conector.go
+++ b/src/shared/gcpagent/config_conector.go
@@ -47,7 +47,7 @@ func (a *Agent) AnnotateGKENamespace(ctx context.Context, namespaceName string) 
 	updatedNamespace.Annotations[gcpk8s.ProjectIdAnnotation] = a.projectID
 
 	logger.Debugf("annotating namespace %s with gcp workload identity tag", namespaceName)
-	err = a.client.Patch(ctx, updatedNamespace, client.MergeFrom(&namespace))
+	err = a.client.Patch(ctx, updatedNamespace, client.StrategicMergeFrom(&namespace))
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			return true, nil


### PR DESCRIPTION
### Description
This PR fixes a bug in the operator, in which updating pod labels and annotations sometimes failed due to unexpected changes being detected in the pod's containers. 
This is resolved by using StrategicMergeFrom rather than (plain) MergeFrom, which applies updates as strategic patches rather than complete overrides. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
