### PR TITLE
Fix a bug where it took 10 minutes to sync operator's configuration with the cloud

### DIFF
--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -28,6 +28,7 @@ func runPeriodicReportConnection(statusInterval int, configReportInterval int, c
 
 	logrus.Info("Starting cloud connection ticker")
 	reportStatus(ctx, client)
+	uploadConfiguration(ctx, client)
 
 	for {
 		select {


### PR DESCRIPTION
### Description

Report the configuration to the cloud on init, in addition to the periodic report task
