### PR TITLE
Fix validation webhook paths for api version `v1beta1`

### DIFF
--- a/src/operator/config/webhook/manifests-patched
+++ b/src/operator/config/webhook/manifests-patched
@@ -128,7 +128,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-mysqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-mysqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: mysqlserverconfigv1.kb.io
@@ -191,7 +191,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-postgresqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-postgresqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: postgresqlserverconfigv1.kb.io
@@ -254,7 +254,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-protectedservice
+      path: /validate-k8s-otterize-com-v1beta1-protectedservice
   failurePolicy: Fail
   matchPolicy: Exact
   name: protectedservicev1.kb.io

--- a/src/operator/config/webhook/manifests.yaml
+++ b/src/operator/config/webhook/manifests.yaml
@@ -115,7 +115,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-k8s-otterize-com-v1-mysqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-mysqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: mysqlserverconfigv1.kb.io
@@ -178,7 +178,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-k8s-otterize-com-v1-postgresqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-postgresqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: postgresqlserverconfigv1.kb.io
@@ -241,7 +241,7 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-k8s-otterize-com-v1-protectedservice
+      path: /validate-k8s-otterize-com-v1beta1-protectedservice
   failurePolicy: Fail
   matchPolicy: Exact
   name: protectedservicev1.kb.io

--- a/src/operator/webhooks/mysqlserverconfigs_webhook_v1.go
+++ b/src/operator/webhooks/mysqlserverconfigs_webhook_v1.go
@@ -48,7 +48,7 @@ func NewMySQLConfValidatorV1(c client.Client) *MySQLConfValidatorV1 {
 	}
 }
 
-//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1-mysqlserverconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=mysqlserverconfigs,verbs=create;update,versions=v1beta1,name=mysqlserverconfigv1.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1beta1-mysqlserverconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=mysqlserverconfigs,verbs=create;update,versions=v1beta1,name=mysqlserverconfigv1.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &MySQLConfValidatorV1{}
 

--- a/src/operator/webhooks/postgresqlserverconfigs_webhook_v1.go
+++ b/src/operator/webhooks/postgresqlserverconfigs_webhook_v1.go
@@ -48,7 +48,7 @@ func NewPostgresConfValidatorV1(c client.Client) *PostgresConfValidatorV1 {
 	}
 }
 
-//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1-postgresqlserverconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=postgresqlserverconfigs,verbs=create;update,versions=v1beta1,name=postgresqlserverconfigv1.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1beta1-postgresqlserverconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=postgresqlserverconfigs,verbs=create;update,versions=v1beta1,name=postgresqlserverconfigv1.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &PostgresConfValidatorV1{}
 

--- a/src/operator/webhooks/protectedservices_webhook_v1.go
+++ b/src/operator/webhooks/protectedservices_webhook_v1.go
@@ -50,7 +50,7 @@ func NewProtectedServiceValidatorV1(c client.Client) *ProtectedServiceValidatorV
 	}
 }
 
-//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1-protectedservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=protectedservice,verbs=create;update,versions=v1beta1,name=protectedservicev1.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:matchPolicy=Exact,path=/validate-k8s-otterize-com-v1beta1-protectedservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=k8s.otterize.com,resources=protectedservice,verbs=create;update,versions=v1beta1,name=protectedservicev1.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &ProtectedServiceValidatorV1{}
 


### PR DESCRIPTION

### Description

The validation webhook should use the explicit name of the version. Otherwise it won't work. 