### PR TITLE
Fix a bug where using clientIntents conversion webhook from `v2` to `v1` could crash if it has `service` target to `kubernetes.default`

### DIFF
--- a/src/operator/api/v1alpha3/webhooks.go
+++ b/src/operator/api/v1alpha3/webhooks.go
@@ -287,7 +287,7 @@ func (in *ClientIntents) ConvertFrom(srcRaw conversion.Hub) error {
 		if target.IsTargetTheKubernetesAPIServer(src.Namespace) {
 			// Using "svc:kubernetes.default" was a common use case in v1alpha3 -
 			// therefore we prefer to convert to this form.
-			in.Spec.Calls[i] = Intent{Name: "svc:" + target.Kubernetes.Name}
+			in.Spec.Calls[i] = Intent{Name: "svc:" + target.GetTargetServerNameAsWritten()}
 			continue
 		}
 		if target.Kubernetes != nil {

--- a/src/operator/api/v1alpha3/webhooks_test.go
+++ b/src/operator/api/v1alpha3/webhooks_test.go
@@ -189,6 +189,27 @@ func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	t.Require().Equal(original.Status, converted.Status)
 }
 
+func (t *WebhooksTestSuite) TestClientIntentsFromV2_serviceKubernetesDefault() {
+	// Create a v2alpha1.ClientIntents with random data
+	original := &v2alpha1.ClientIntents{
+		Spec: &v2alpha1.IntentsSpec{
+			Targets: []v2alpha1.Target{
+				{
+					Service: &v2alpha1.ServiceTarget{
+						Name: "kubernetes.default",
+					},
+				},
+			},
+		},
+	}
+
+	// ConvertFrom
+	converted := &ClientIntents{}
+	err := converted.ConvertFrom(original)
+	t.Require().NoError(err)
+	t.Require().Equal("svc:kubernetes.default", converted.Spec.Calls[0].Name)
+}
+
 func TestWebhooksTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhooksTestSuite))
 }

--- a/src/operator/api/v1beta1/webhooks.go
+++ b/src/operator/api/v1beta1/webhooks.go
@@ -288,7 +288,7 @@ func (in *ClientIntents) ConvertFrom(srcRaw conversion.Hub) error {
 		if target.IsTargetTheKubernetesAPIServer(src.Namespace) {
 			// Using "svc:kubernetes.default" was a common use case in v1alpha3 -
 			// therefore we prefer to convert to this form.
-			in.Spec.Calls[i] = Intent{Name: "svc:" + target.Kubernetes.Name}
+			in.Spec.Calls[i] = Intent{Name: "svc:" + target.GetTargetServerNameAsWritten()}
 			continue
 		}
 		if target.Kubernetes != nil {

--- a/src/operator/api/v1beta1/webhooks_test.go
+++ b/src/operator/api/v1beta1/webhooks_test.go
@@ -189,6 +189,27 @@ func (t *WebhooksTestSuite) TestClientIntentsKubernetes() {
 	t.Require().Equal(original.Status, converted.Status)
 }
 
+func (t *WebhooksTestSuite) TestClientIntentsFromV2_serviceKubernetesDefault() {
+	// Create a v2alpha1.ClientIntents with random data
+	original := &v2alpha1.ClientIntents{
+		Spec: &v2alpha1.IntentsSpec{
+			Targets: []v2alpha1.Target{
+				{
+					Service: &v2alpha1.ServiceTarget{
+						Name: "kubernetes.default",
+					},
+				},
+			},
+		},
+	}
+
+	// ConvertFrom
+	converted := &ClientIntents{}
+	err := converted.ConvertFrom(original)
+	t.Require().NoError(err)
+	t.Require().Equal("svc:kubernetes.default", converted.Spec.Calls[0].Name)
+}
+
 func TestWebhooksTestSuite(t *testing.T) {
 	suite.Run(t, new(WebhooksTestSuite))
 }


### PR DESCRIPTION
### Description

Fix a bug where using clientIntents conversion webhook from `v2` to `v1` could crash if it has `service` target to `kubernetes.default`

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
