### PR TITLE
Add support for detecting AWS ALB ingress resources and auto-allowing traffic

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -57,6 +57,10 @@ func NewNetworkPolicyHandler(
 	return &NetworkPolicyHandler{client: client, scheme: scheme, allowExternalTraffic: allowExternalTraffic, ingressControllerIdentities: ingressControllerIdentities, ingressControllerALBAllowAll: ingressControllerALBAllowAll}
 }
 
+func (r *NetworkPolicyHandler) SetIngressControllerALBAllowAll(ingressControllerALBAllowAll bool) {
+	r.ingressControllerALBAllowAll = ingressControllerALBAllowAll
+}
+
 func (r *NetworkPolicyHandler) createOrUpdateNetworkPolicy(
 	ctx context.Context, endpoints *corev1.Endpoints, owner *corev1.Service, otterizeServiceName string, selector metav1.LabelSelector, ingressList *v1.IngressList, successMsg string) error {
 	policyName := r.formatPolicyName(endpoints.Name)

--- a/src/operator/controllers/external_traffic/network_policy_test.go
+++ b/src/operator/controllers/external_traffic/network_policy_test.go
@@ -22,7 +22,7 @@ type NetworkPolicyHandlerTestSuite struct {
 
 func (s *NetworkPolicyHandlerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0))
+	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleBeforeAccessPolicyRemoval_createWhenNoIntentsEnabled_doNothing() {

--- a/src/operator/controllers/external_traffic/service_uploader.go
+++ b/src/operator/controllers/external_traffic/service_uploader.go
@@ -146,10 +146,12 @@ func convertToCloudExternalService(svc corev1.Service, identity serviceidentity.
 
 	// Remember to update the cache key that determines whether an update is needed.
 	serviceInput := graphqlclient.ExternallyAccessibleServiceInput{
-		Namespace:         identity.Namespace,
-		ServerName:        identity.Name,
-		ReferredByIngress: ReferredByIngress,
-		ServiceType:       cloudServiceType,
+		Namespace:                      identity.Namespace,
+		ServerName:                     identity.Name,
+		ReferredByIngress:              ReferredByIngress,
+		ServiceType:                    cloudServiceType,
+		ServiceName:                    svc.Name,
+		HasInternetFacingAWSALBIngress: isIngressListHasInternetFacingAWSALB(referringIngressList.Items),
 	}
 	return serviceInput, true, nil
 }

--- a/src/operator/controllers/external_traffic/service_uploader_test.go
+++ b/src/operator/controllers/external_traffic/service_uploader_test.go
@@ -227,18 +227,21 @@ func (s *ServiceUploaderTestSuite) TestUploadNamespaceServices() {
 		{
 			Namespace:         testNamespace,
 			ServerName:        podForServiceWithIngressName,
+			ServiceName:       serviceWithIngressName,
 			ReferredByIngress: true,
 			ServiceType:       graphqlclient.KubernetesServiceTypeClusterIp,
 		},
 		{
 			Namespace:         testNamespace,
 			ServerName:        podForServiceWithNodePortName,
+			ServiceName:       serviceWithNodePortName,
 			ReferredByIngress: false,
 			ServiceType:       graphqlclient.KubernetesServiceTypeNodePort,
 		},
 		{
 			Namespace:         testNamespace,
 			ServerName:        podForServiceWithLoadBalancerName,
+			ServiceName:       serviceWithLoadBalancerName,
 			ReferredByIngress: false,
 			ServiceType:       graphqlclient.KubernetesServiceTypeLoadBalancer,
 		},

--- a/src/operator/controllers/external_traffic/shared.go
+++ b/src/operator/controllers/external_traffic/shared.go
@@ -1,6 +1,7 @@
 package external_traffic
 
 import (
+	"github.com/samber/lo"
 	"k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -22,4 +23,19 @@ func serviceNamesFromIngress(ingress *v1.Ingress) sets.Set[string] {
 	}
 
 	return serviceNames
+}
+
+func isIngressListHasInternetFacingAWSALB(ingressList []v1.Ingress) bool {
+	return lo.SomeBy(ingressList, func(ingress v1.Ingress) bool {
+		if ingress.Annotations == nil {
+			return false
+		}
+
+		scheme, ok := ingress.Annotations["alb.ingress.kubernetes.io/scheme"]
+		if !ok {
+			return false
+		}
+
+		return scheme == "internet-facing"
+	})
 }

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -92,7 +92,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	testName := s.T().Name()
 	isShadowMode := strings.Contains(testName, "ShadowMode")
 	defaultActive := !isShadowMode
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0))
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), netpolHandler, true)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder(), builders.NewPortNetworkPolicyReconciler(s.Mgr.GetClient())}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
@@ -817,7 +817,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, make([]serviceidentity.ServiceIdentity, 0))
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, make([]serviceidentity.ServiceIdentity, 0), false)
 	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -105,7 +105,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 			Namespace: ingressControllerNamespace,
 			Name:      ingressControllerName,
 		},
-	})
+	}, false)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), netpolHandler, true)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, defaultActive, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder(), builders.NewPortNetworkPolicyReconciler(s.Mgr.GetClient())}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
@@ -899,7 +899,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 			Name:      ingressControllerName,
 			Kind:      "Deployment",
 		},
-	})
+	}, false)
 	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -58,6 +58,7 @@ type ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite st
 	EffectivePolicyIntentsReconciler *intents_reconcilers.ServiceEffectivePolicyIntentsReconciler
 	podWatcher                       *pod_reconcilers.PodWatcher
 	defaultDenyReconciler            *protected_service_reconcilers.DefaultDenyReconciler
+	netpolHandler                    *external_traffic.NetworkPolicyHandler
 }
 
 func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) SetupSuite() {
@@ -122,6 +123,8 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 	s.IngressReconciler = external_traffic.NewIngressReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
+
+	s.netpolHandler = netpolHandler
 
 	controller := gomock.NewController(s.T())
 	serviceEffectivePolicyReconciler := podreconcilersmocks.NewMockGroupReconciler(controller)
@@ -923,6 +926,145 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 	default:
 		s.Fail("event not raised")
 	}
+}
+
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyForAWSALBExemption_enabled() {
+	serviceName := "ingress-service"
+	ingressName := "test-ingress-alb"
+	ingressNamespace := s.TestNamespace
+	s.netpolHandler.SetIngressControllerALBAllowAll(true)
+
+	// Add Ingress with the annotation "alb.ingress.kubernetes.io/scheme": "internet-facing"
+	ingress := s.AddIngressWithAnnotation(ingressName, ingressNamespace, serviceName, map[string]string{
+		"alb.ingress.kubernetes.io/scheme": "internet-facing",
+	})
+
+	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
+		Service: &otterizev2alpha1.ServiceTarget{Name: ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name},
+	},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: intents.Namespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+
+	// Reconcile the ingress
+	res, err := s.IngressReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ingressNamespace, Name: ingressName},
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	// Verify that the network policy allows all ingress traffic
+	np := &v1.NetworkPolicy{}
+	policyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: ingressNamespace, Name: policyName}, np)
+		assert.NoError(err)
+		assert.NotEmpty(np)
+		assert.Len(np.Spec.Ingress, 1)
+		if len(np.Spec.Ingress) == 1 {
+			assert.Len(np.Spec.Ingress[0].From, 0) // Allow all ingress traffic
+		}
+	})
+}
+
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyForAWSALBExemption_disabled() {
+	serviceName := "ingress-service"
+	ingressName := "test-ingress-alb"
+	ingressNamespace := s.TestNamespace
+	s.netpolHandler.SetIngressControllerALBAllowAll(false)
+
+	// Add Ingress with the annotation "alb.ingress.kubernetes.io/scheme": "internet-facing"
+	ingress := s.AddIngressWithAnnotation(ingressName, ingressNamespace, serviceName, map[string]string{
+		"alb.ingress.kubernetes.io/scheme": "internet-facing",
+	})
+
+	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
+		Service: &otterizev2alpha1.ServiceTarget{Name: ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name},
+	},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: intents.Namespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+
+	// Reconcile the ingress
+	res, err := s.IngressReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ingressNamespace, Name: ingressName},
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	// Verify that the network policy allows all ingress traffic
+	np := &v1.NetworkPolicy{}
+	policyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: ingressNamespace, Name: policyName}, np)
+		assert.NoError(err)
+		assert.NotEmpty(np)
+		assert.Len(np.Spec.Ingress, 1)
+		if len(np.Spec.Ingress) == 1 {
+			assert.Len(np.Spec.Ingress[0].From, 1) // Only allow traffic from the ingress controller
+		}
+	})
+}
+
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) AddIngressWithAnnotation(name, namespace, serviceName string, annotations map[string]string) *v1.Ingress {
+	ingress := &v1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: v1.IngressSpec{
+			Rules: []v1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: v1.IngressRuleValue{
+						HTTP: &v1.HTTPIngressRuleValue{
+							Paths: []v1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: lo.ToPtr(v1.PathTypePrefix),
+									Backend: v1.IngressBackend{
+										Service: &v1.IngressServiceBackend{
+											Name: serviceName,
+											Port: v1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	s.Require().NoError(s.Mgr.GetClient().Create(context.Background(), ingress))
+	s.WaitForObjectToBeCreated(ingress)
+
+	s.AddDeploymentWithService(serviceName, []string{"3.3.3.3"}, map[string]string{"app": "test"}, nil)
+
+	// the ingress reconciler expect the pod watcher labels in order to work
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	s.Require().NoError(err)
+
+	return ingress
 }
 
 func TestExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite(t *testing.T) {

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -85,7 +85,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.Require().NoError((&otterizev2alpha1.ClientIntents{}).SetupWebhookWithManager(s.Mgr, intentsValidator2))
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always, make([]serviceidentity.ServiceIdentity, 0))
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always, make([]serviceidentity.ServiceIdentity, 0), false)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, true, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, serviceIdResolver, netpolReconciler)
@@ -246,7 +246,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, make([]serviceidentity.ServiceIdentity, 0))
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, make([]serviceidentity.ServiceIdentity, 0), false)
 	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -197,7 +197,7 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
 
-	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), allowExternalTraffic, operatorconfig.GetIngressControllerServiceIdentities())
+	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), allowExternalTraffic, operatorconfig.GetIngressControllerServiceIdentities(), viper.GetBool(operatorconfig.IngressControllerALBExemptKey))
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), extNetpolHandler)
 	ingressRulesBuilder := builders.NewIngressNetpolBuilder()
 

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -61,6 +61,8 @@ const (
 	TelemetryErrorsAPIKeyKey               = "telemetry-errors-api-key"
 	TelemetryErrorsAPIKeyDefault           = "60a78208a2b4fe714ef9fb3d3fdc0714"
 	AWSAccountsKey                         = "aws"
+	IngressControllerALBExemptKey          = "ingress-controllers-exempt-alb"
+	IngressControllerALBExemptDefault      = false
 	IngressControllerConfigKey             = "ingressControllers"
 )
 
@@ -76,6 +78,7 @@ func init() {
 	viper.SetDefault(AWSRolesAnywhereCertDirKey, AWSRolesAnywhereCertDirDefault)
 	viper.SetDefault(AWSRolesAnywherePrivKeyFilenameKey, AWSRolesAnywherePrivKeyFilenameDefault)
 	viper.SetDefault(AWSRolesAnywhereCertFilenameKey, AWSRolesAnywhereCertFilenameDefault)
+	viper.SetDefault(IngressControllerALBExemptKey, IngressControllerALBExemptDefault)
 	viper.SetDefault(KafkaServerTLSCertKey, "")
 	viper.SetDefault(KafkaServerTLSKeyKey, "")
 	viper.SetDefault(KafkaServerTLSCAKey, "")

--- a/src/shared/otterizecloud/graphqlclient/generate.go
+++ b/src/shared/otterizecloud/graphqlclient/generate.go
@@ -2,5 +2,5 @@ package graphqlclient
 
 import _ "github.com/suessflorian/gqlfetch"
 
-//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql"
+//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:3000/api/graphql/v1beta > schema.graphql"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml

--- a/src/shared/otterizecloud/graphqlclient/generate.go
+++ b/src/shared/otterizecloud/graphqlclient/generate.go
@@ -2,5 +2,5 @@ package graphqlclient
 
 import _ "github.com/suessflorian/gqlfetch"
 
-//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:3000/api/graphql/v1beta > schema.graphql"
+//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -74,10 +74,12 @@ const (
 )
 
 type ExternallyAccessibleServiceInput struct {
-	Namespace         string                `json:"namespace"`
-	ServerName        string                `json:"serverName"`
-	ReferredByIngress bool                  `json:"referredByIngress"`
-	ServiceType       KubernetesServiceType `json:"serviceType"`
+	Namespace                      string                `json:"namespace"`
+	ServerName                     string                `json:"serverName"`
+	ServiceName                    string                `json:"serviceName"`
+	ReferredByIngress              bool                  `json:"referredByIngress"`
+	HasInternetFacingAWSALBIngress bool                  `json:"hasInternetFacingAWSALBIngress"`
+	ServiceType                    KubernetesServiceType `json:"serviceType"`
 }
 
 // GetNamespace returns ExternallyAccessibleServiceInput.Namespace, and is useful for accessing the field via an interface.
@@ -86,8 +88,16 @@ func (v *ExternallyAccessibleServiceInput) GetNamespace() string { return v.Name
 // GetServerName returns ExternallyAccessibleServiceInput.ServerName, and is useful for accessing the field via an interface.
 func (v *ExternallyAccessibleServiceInput) GetServerName() string { return v.ServerName }
 
+// GetServiceName returns ExternallyAccessibleServiceInput.ServiceName, and is useful for accessing the field via an interface.
+func (v *ExternallyAccessibleServiceInput) GetServiceName() string { return v.ServiceName }
+
 // GetReferredByIngress returns ExternallyAccessibleServiceInput.ReferredByIngress, and is useful for accessing the field via an interface.
 func (v *ExternallyAccessibleServiceInput) GetReferredByIngress() bool { return v.ReferredByIngress }
+
+// GetHasInternetFacingAWSALBIngress returns ExternallyAccessibleServiceInput.HasInternetFacingAWSALBIngress, and is useful for accessing the field via an interface.
+func (v *ExternallyAccessibleServiceInput) GetHasInternetFacingAWSALBIngress() bool {
+	return v.HasInternetFacingAWSALBIngress
+}
 
 // GetServiceType returns ExternallyAccessibleServiceInput.ServiceType, and is useful for accessing the field via an interface.
 func (v *ExternallyAccessibleServiceInput) GetServiceType() KubernetesServiceType {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -104,13 +104,36 @@ type AWSS3Resource {
 	bucketName: String!
 }
 
+type AWSVisibility {
+	arn: String!
+	resourceType: String!
+	name: String!
+	lbArn: String
+	domain: String
+	ips: [String!]!
+	eksIngressName: String
+	region: String!
+}
+
+type AWSVisibilitySettings {
+	isActive: Boolean!
+	awsAccountId: String!
+	externalId: String!
+	regions: [String!]!
+}
+
+input AWSVisibilitySettingsInput {
+	isActive: Boolean!
+	awsAccountId: String!
+	regions: [String!]!
+}
+
 type AccessGraph {
 	filter: AccessGraphFilter!
 """Clusters for which there are results"""
 	clusters: [Cluster!]!
 	serviceAccessGraphs: [ServiceAccessGraph!]!
 	serviceCount: Int!
-	findings: [Finding!]!
 }
 
 type AccessGraphEdge {
@@ -120,10 +143,10 @@ type AccessGraphEdge {
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
-	missingTags: [MissingTagInfo!]
+	violations: [CallViolation!]!
 }
 
-"""Access graph filter"""
+""" Access graph filter """
 type AccessGraphFilter {
 	clusterIds: IDFilterValue
 	serviceIds: IDFilterValue
@@ -131,6 +154,25 @@ type AccessGraphFilter {
 	environmentIds: IDFilterValue
 	lastSeen: TimeFilterValue
 	featureFlags: FeatureFlags
+}
+
+type AccessLog {
+	clusters: [Cluster!]!
+	namespaces: [Namespace!]!
+	serviceCount: Int!
+	entries: [AccessLogEdge!]!
+	timeRange: TimeRange!
+}
+
+type AccessLogEdge {
+	timestamp: Time!
+	client: Service!
+	server: Service!
+	appliedIntents: [Intent!]
+	originIntent: Intent!
+	dns: String!
+	accessStatus: EdgeAccessStatus!
+	accessStatuses: EdgeAccessStatuses!
 }
 
 enum ApiFieldAction {
@@ -218,6 +260,12 @@ input CLIIdentifier {
 input CLITelemetry {
 	identifier: CLIIdentifier!
 	command: CLICommand!
+}
+
+type CallViolation {
+	standard: RegulationStandard!
+	code: RegulationCode!
+	reason: String!
 }
 
 input CertificateCustomization {
@@ -313,6 +361,12 @@ input ClusterFormSettingsInput {
 	enforcement: Boolean!
 }
 
+type ClusterViolation {
+	cluster: Cluster!
+	reason: String!
+	intentsOperatorState: IntentsOperatorState
+}
+
 input Component {
 	componentType: TelemetryComponentType!
 	componentInstanceId: ID!
@@ -370,6 +424,11 @@ enum CustomConstraint {
 input DNSIPPairInput {
 	dnsName: String!
 	ips: [String!]
+}
+
+type Dashboard {
+	findings: [Finding!]!
+	summary: FindingsSummary!
 }
 
 type DatabaseConfig {
@@ -552,7 +611,9 @@ input ExternalTrafficIntentInput {
 input ExternallyAccessibleServiceInput {
 	namespace: String!
 	serverName: String!
+	serviceName: String
 	referredByIngress: Boolean!
+	hasInternetFacingAWSALBIngress: Boolean
 	serviceType: KubernetesServiceType!
 }
 
@@ -562,17 +623,35 @@ type FeatureFlags {
 }
 
 type Finding {
-	id: ID!
+	standard: RegulationStandard!
+	codeLabel: String!
+	code: RegulationCode!
 	severity: Severity!
-	message: String!
-	server: ServiceAccessGraph!
-	clientsMissingTags: [ServiceAccessGraph!]!
-	ruleTags: [String!]!
-	totalClientsCount: Int!
+	description: String!
+	validationDescription: String
+	clusterViolations: [ClusterViolation!]!
+	serviceViolations: [ServiceViolation!]!
+	clusterCount: Int!
+	serviceCount: Int!
+	requirements: [Finding!]
+}
+
+type FindingsSummary {
+	violations: Int!
+	nonCompliantClusters: Fraction!
+	nonCompliantWorkloads: Fraction!
+	overallCompliance: Fraction!
+	nonCompliantStandards: Fraction!
+	nonCompliantControls: Fraction!
 }
 
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
+
+type Fraction {
+	numerator: Int!
+	denominator: Int!
+}
 
 type GCPInfo {
 	region: String!
@@ -739,9 +818,34 @@ input InputAccessGraphFilter {
 	featureFlags: InputFeatureFlags
 }
 
+input InputAccessLogFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+	timeRange: TimeRangeInput
+	featureFlags: InputFeatureFlags
+}
+
 input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+}
+
+""" Findings filter """
+input InputFindingFilter {
+""" Findings filter """
+	severity: InputIDFilterValue
+""" Findings filter """
+	clusterIds: InputIDFilterValue
+""" Findings filter """
+	serviceIds: InputIDFilterValue
+""" Findings filter """
+	namespaceIds: InputIDFilterValue
+""" Findings filter """
+	regulationIds: InputIDFilterValue
+""" Findings filter """
+	environmentIds: InputIDFilterValue
 }
 
 input InputIDFilterValue {
@@ -760,9 +864,42 @@ input InputIntegrationAccessGraphFilter {
 	serviceFilterType: IDFilterOperators
 }
 
+input InputResourceInventoryFilter {
+	serviceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+}
+
+""" Service filter """
+input InputServiceFilter {
+""" Service filter """
+	serviceType: InputIDFilterValue
+""" Service filter """
+	serviceIds: [ID!]
+""" Service filter """
+	clusterIds: [ID!]
+""" Service filter """
+	namespaceIds: [ID!]
+""" Service filter """
+	environmentIds: [ID!]
+""" Service filter """
+	integrationIds: [ID!]
+}
+
 input InputTimeFilterValue {
 	value: Time!
 	operator: TimeFilterOperators!
+}
+
+""" Workload/Resource inventory filter """
+input InputWorkloadInventoryFilter {
+""" Workload/Resource inventory filter """
+	clusterIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	serviceIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	namespaceIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	environmentIds: InputIDFilterValue
 }
 
 """The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."""
@@ -789,6 +926,7 @@ type Integration {
 	gitHubSettings: GitHubSettings
 	gitLabSettings: GitLabSettings
 	slackSettings: SlackSettings
+	awsVisibilitySettings: AWSVisibilitySettings
 	organizationId: String!
 	status: IntegrationStatus
 }
@@ -845,6 +983,7 @@ enum IntegrationType {
 	GITLAB
 	AZURE
 	SLACK
+	AWS_VISIBILITY
 }
 
 type Intent {
@@ -940,6 +1079,12 @@ input IntentsOperatorConfigurationInput {
 	databaseEnforcementEnabled: Boolean
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
+}
+
+type IntentsOperatorState {
+	globalEnforcementEnabled: Boolean!
+	networkPolicyEnforcementEnabled: Boolean!
+	egressNetworkPolicyEnforcementEnabled: Boolean!
 }
 
 type InternetConfig {
@@ -1239,11 +1384,6 @@ input MetadataEntry {
 	value: String!
 }
 
-type MissingTagInfo {
-	tags: [String!]!
-	reason: String!
-}
-
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
@@ -1352,6 +1492,17 @@ type Mutation {
 		id: ID!
 		name: String!
 		slackSettings: SlackSettingsInput!
+	): Integration
+"""Create a new AWS Visibility integration"""
+	createAwsVisibilityIntegration(
+		name: String!
+		awsVisibilitySettings: AWSVisibilitySettingsInput!
+	): Integration
+"""Update an AWS Visibility integration"""
+	updateAwsVisibilityIntegration(
+		id: ID!
+		name: String
+		awsVisibilitySettings: AWSVisibilitySettingsInput
 	): Integration
 """Create a new GCP integration"""
 	createGCPIntegration(
@@ -1585,16 +1736,18 @@ type Organization {
 	id: ID!
 	name: String!
 	imageURL: String
-	settings: OrganizationSettings
+	settings: OrganizationSettings!
 	created: Time!
 }
 
 type OrganizationSettings {
-	domains: [String]
+	domains: [String!]
+	enforcedRegulations: [String!]
 }
 
 input OrganizationSettingsInput {
-	domains: [String]
+	domains: [String!]
+	enforcedRegulations: [String]
 }
 
 enum PathType {
@@ -1630,11 +1783,15 @@ type Query {
 	serviceClientIntents(
 		id: ID!
 		asServiceId: ID
-		lastSeenAfter: Time!
+		lastSeenAfter: Time
 		clusterIds: [ID!]
 		enableInternetIntents: Boolean
 		featureFlags: InputFeatureFlags
 	): ServiceClientIntents!
+"""Get access log"""
+	accessLog(
+		filter: InputAccessLogFilter
+	): AccessLog!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -1661,8 +1818,13 @@ type Query {
 		name: String!
 	): Environment!
 	findings(
-		filter: InputAccessGraphFilter!
+		filter: InputFindingFilter
+		tree: Boolean
 	): [Finding!]!
+	dashboard(
+		filter: InputFindingFilter
+		tree: Boolean
+	): Dashboard!
 """List integrations"""
 	integrations(
 		name: String
@@ -1726,8 +1888,9 @@ type Query {
 	): Organization!
 """Checks the availability of the API server"""
 	ping: Boolean!
+	regulations: [Regulation!]!
 	resources(
-		filter: InputAccessGraphFilter
+		filter: InputResourceInventoryFilter
 	): [Resource!]!
 """Get service"""
 	service(
@@ -1739,6 +1902,7 @@ type Query {
 		environmentId: ID
 		namespaceId: ID
 		name: String
+		filter: InputServiceFilter
 	): [Service!]!
 """Get service by filters"""
 	oneService(
@@ -1753,8 +1917,38 @@ type Query {
 		id: ID!
 	): User!
 	workloads(
-		filter: InputAccessGraphFilter
+		filter: InputWorkloadInventoryFilter
 	): [Workload!]!
+}
+
+type Regulation {
+	code: RegulationCode!
+	standard: RegulationStandard!
+	enforced: Boolean!
+	requirements: [Regulation!]
+	label: String!
+	description: String!
+	validationDescription: String
+}
+
+enum RegulationCode {
+	PCI_4_0
+	PCI_4_0_1_1
+	PCI_4_0_1_1_4
+	PCI_4_0_1_2
+	PCI_4_0_1_2_1
+	PCI_4_0_1_3
+	PCI_4_0_1_3_4
+	PCI_4_0_1_3_6
+	ZERO_TRUST
+	ZERO_TRUST_SENSITIVE
+}
+
+enum RegulationStandard {
+	PCI_4_0
+	PII
+	HIPAA
+	ZERO_TRUST
 }
 
 type Resource {
@@ -1857,6 +2051,7 @@ type Service {
 	gcpResource: GCPResource
 	azureResource: AzureResource
 	discoveredByIntegration: Integration
+	awsVisibility: AWSVisibility
 	tlsKeyPair: KeyPair!
 }
 
@@ -1910,6 +2105,13 @@ enum ServiceType {
 	INTERNET
 	DATABASE_USER
 	KUBERNETES_LOAD_BALANCER
+	AWS_VISIBILITY_EKS
+}
+
+type ServiceViolation {
+	service: Service!
+	reason: String!
+	violatedCalls: [AccessGraphEdge!]
 }
 
 enum SessionAffinity {
@@ -1997,6 +2199,16 @@ type TimeFilterValue {
 	operator: TimeFilterOperators!
 }
 
+type TimeRange {
+	from: Time
+	to: Time
+}
+
+input TimeRangeInput {
+	from: Time
+	to: Time
+}
+
 enum TutorialEvent {
 	CLUSTER_CREATED
 	CLUSTER_CONNECTED
@@ -2069,6 +2281,13 @@ type Workload {
 	types: [ServiceType!]!
 	inboundStatus: ServerProtectionStatusVerdict!
 	outboundStatus: EdgeAccessStatusVerdict!
+}
+
+enum WorkloadTag {
+	PCI
+	PII
+	HIPAA
+	Sensitive
 }
 
 

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -104,13 +104,36 @@ type AWSS3Resource {
 	bucketName: String!
 }
 
+type AWSVisibility {
+	arn: String!
+	resourceType: String!
+	name: String!
+	lbArn: String
+	domain: String
+	ips: [String!]!
+	eksIngressName: String
+	region: String!
+}
+
+type AWSVisibilitySettings {
+	isActive: Boolean!
+	awsAccountId: String!
+	externalId: String!
+	regions: [String!]!
+}
+
+input AWSVisibilitySettingsInput {
+	isActive: Boolean!
+	awsAccountId: String!
+	regions: [String!]!
+}
+
 type AccessGraph {
 	filter: AccessGraphFilter!
 """Clusters for which there are results"""
 	clusters: [Cluster!]!
 	serviceAccessGraphs: [ServiceAccessGraph!]!
 	serviceCount: Int!
-	findings: [Finding!]!
 }
 
 type AccessGraphEdge {
@@ -120,10 +143,10 @@ type AccessGraphEdge {
 	appliedIntents: [Intent!]!
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
-	missingTags: [MissingTagInfo!]
+	violations: [CallViolation!]!
 }
 
-"""Access graph filter"""
+""" Access graph filter """
 type AccessGraphFilter {
 	clusterIds: IDFilterValue
 	serviceIds: IDFilterValue
@@ -131,6 +154,25 @@ type AccessGraphFilter {
 	environmentIds: IDFilterValue
 	lastSeen: TimeFilterValue
 	featureFlags: FeatureFlags
+}
+
+type AccessLog {
+	clusters: [Cluster!]!
+	namespaces: [Namespace!]!
+	serviceCount: Int!
+	entries: [AccessLogEdge!]!
+	timeRange: TimeRange!
+}
+
+type AccessLogEdge {
+	timestamp: Time!
+	client: Service!
+	server: Service!
+	appliedIntents: [Intent!]
+	originIntent: Intent!
+	dns: String!
+	accessStatus: EdgeAccessStatus!
+	accessStatuses: EdgeAccessStatuses!
 }
 
 enum ApiFieldAction {
@@ -218,6 +260,12 @@ input CLIIdentifier {
 input CLITelemetry {
 	identifier: CLIIdentifier!
 	command: CLICommand!
+}
+
+type CallViolation {
+	standard: RegulationStandard!
+	code: RegulationCode!
+	reason: String!
 }
 
 input CertificateCustomization {
@@ -313,6 +361,12 @@ input ClusterFormSettingsInput {
 	enforcement: Boolean!
 }
 
+type ClusterViolation {
+	cluster: Cluster!
+	reason: String!
+	intentsOperatorState: IntentsOperatorState
+}
+
 input Component {
 	componentType: TelemetryComponentType!
 	componentInstanceId: ID!
@@ -370,6 +424,11 @@ enum CustomConstraint {
 input DNSIPPairInput {
 	dnsName: String!
 	ips: [String!]
+}
+
+type Dashboard {
+	findings: [Finding!]!
+	summary: FindingsSummary!
 }
 
 type DatabaseConfig {
@@ -562,17 +621,35 @@ type FeatureFlags {
 }
 
 type Finding {
-	id: ID!
+	standard: RegulationStandard!
+	codeLabel: String!
+	code: RegulationCode!
 	severity: Severity!
-	message: String!
-	server: ServiceAccessGraph!
-	clientsMissingTags: [ServiceAccessGraph!]!
-	ruleTags: [String!]!
-	totalClientsCount: Int!
+	description: String!
+	validationDescription: String
+	clusterViolations: [ClusterViolation!]!
+	serviceViolations: [ServiceViolation!]!
+	clusterCount: Int!
+	serviceCount: Int!
+	requirements: [Finding!]
+}
+
+type FindingsSummary {
+	violations: Int!
+	nonCompliantClusters: Fraction!
+	nonCompliantWorkloads: Fraction!
+	overallCompliance: Fraction!
+	nonCompliantStandards: Fraction!
+	nonCompliantControls: Fraction!
 }
 
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
+
+type Fraction {
+	numerator: Int!
+	denominator: Int!
+}
 
 type GCPInfo {
 	region: String!
@@ -739,9 +816,34 @@ input InputAccessGraphFilter {
 	featureFlags: InputFeatureFlags
 }
 
+input InputAccessLogFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+	timeRange: TimeRangeInput
+	featureFlags: InputFeatureFlags
+}
+
 input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+}
+
+""" Findings filter """
+input InputFindingFilter {
+""" Findings filter """
+	severity: InputIDFilterValue
+""" Findings filter """
+	clusterIds: InputIDFilterValue
+""" Findings filter """
+	serviceIds: InputIDFilterValue
+""" Findings filter """
+	namespaceIds: InputIDFilterValue
+""" Findings filter """
+	regulationIds: InputIDFilterValue
+""" Findings filter """
+	environmentIds: InputIDFilterValue
 }
 
 input InputIDFilterValue {
@@ -760,9 +862,42 @@ input InputIntegrationAccessGraphFilter {
 	serviceFilterType: IDFilterOperators
 }
 
+input InputResourceInventoryFilter {
+	serviceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+}
+
+""" Service filter """
+input InputServiceFilter {
+""" Service filter """
+	serviceType: InputIDFilterValue
+""" Service filter """
+	serviceIds: [ID!]
+""" Service filter """
+	clusterIds: [ID!]
+""" Service filter """
+	namespaceIds: [ID!]
+""" Service filter """
+	environmentIds: [ID!]
+""" Service filter """
+	integrationIds: [ID!]
+}
+
 input InputTimeFilterValue {
 	value: Time!
 	operator: TimeFilterOperators!
+}
+
+""" Workload/Resource inventory filter """
+input InputWorkloadInventoryFilter {
+""" Workload/Resource inventory filter """
+	clusterIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	serviceIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	namespaceIds: InputIDFilterValue
+""" Workload/Resource inventory filter """
+	environmentIds: InputIDFilterValue
 }
 
 """The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."""
@@ -789,6 +924,7 @@ type Integration {
 	gitHubSettings: GitHubSettings
 	gitLabSettings: GitLabSettings
 	slackSettings: SlackSettings
+	awsVisibilitySettings: AWSVisibilitySettings
 	organizationId: String!
 	status: IntegrationStatus
 }
@@ -845,6 +981,7 @@ enum IntegrationType {
 	GITLAB
 	AZURE
 	SLACK
+	AWS_VISIBILITY
 }
 
 type Intent {
@@ -940,6 +1077,12 @@ input IntentsOperatorConfigurationInput {
 	databaseEnforcementEnabled: Boolean
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
+}
+
+type IntentsOperatorState {
+	globalEnforcementEnabled: Boolean!
+	networkPolicyEnforcementEnabled: Boolean!
+	egressNetworkPolicyEnforcementEnabled: Boolean!
 }
 
 type InternetConfig {
@@ -1239,11 +1382,6 @@ input MetadataEntry {
 	value: String!
 }
 
-type MissingTagInfo {
-	tags: [String!]!
-	reason: String!
-}
-
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
@@ -1352,6 +1490,17 @@ type Mutation {
 		id: ID!
 		name: String!
 		slackSettings: SlackSettingsInput!
+	): Integration
+"""Create a new AWS Visibility integration"""
+	createAwsVisibilityIntegration(
+		name: String!
+		awsVisibilitySettings: AWSVisibilitySettingsInput!
+	): Integration
+"""Update an AWS Visibility integration"""
+	updateAwsVisibilityIntegration(
+		id: ID!
+		name: String
+		awsVisibilitySettings: AWSVisibilitySettingsInput
 	): Integration
 """Create a new GCP integration"""
 	createGCPIntegration(
@@ -1585,16 +1734,18 @@ type Organization {
 	id: ID!
 	name: String!
 	imageURL: String
-	settings: OrganizationSettings
+	settings: OrganizationSettings!
 	created: Time!
 }
 
 type OrganizationSettings {
-	domains: [String]
+	domains: [String!]
+	enforcedRegulations: [String!]
 }
 
 input OrganizationSettingsInput {
-	domains: [String]
+	domains: [String!]
+	enforcedRegulations: [String]
 }
 
 enum PathType {
@@ -1630,11 +1781,15 @@ type Query {
 	serviceClientIntents(
 		id: ID!
 		asServiceId: ID
-		lastSeenAfter: Time!
+		lastSeenAfter: Time
 		clusterIds: [ID!]
 		enableInternetIntents: Boolean
 		featureFlags: InputFeatureFlags
 	): ServiceClientIntents!
+"""Get access log"""
+	accessLog(
+		filter: InputAccessLogFilter
+	): AccessLog!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -1661,8 +1816,13 @@ type Query {
 		name: String!
 	): Environment!
 	findings(
-		filter: InputAccessGraphFilter!
+		filter: InputFindingFilter
+		tree: Boolean
 	): [Finding!]!
+	dashboard(
+		filter: InputFindingFilter
+		tree: Boolean
+	): Dashboard!
 """List integrations"""
 	integrations(
 		name: String
@@ -1726,8 +1886,9 @@ type Query {
 	): Organization!
 """Checks the availability of the API server"""
 	ping: Boolean!
+	regulations: [Regulation!]!
 	resources(
-		filter: InputAccessGraphFilter
+		filter: InputResourceInventoryFilter
 	): [Resource!]!
 """Get service"""
 	service(
@@ -1739,6 +1900,7 @@ type Query {
 		environmentId: ID
 		namespaceId: ID
 		name: String
+		filter: InputServiceFilter
 	): [Service!]!
 """Get service by filters"""
 	oneService(
@@ -1753,8 +1915,38 @@ type Query {
 		id: ID!
 	): User!
 	workloads(
-		filter: InputAccessGraphFilter
+		filter: InputWorkloadInventoryFilter
 	): [Workload!]!
+}
+
+type Regulation {
+	code: RegulationCode!
+	standard: RegulationStandard!
+	enforced: Boolean!
+	requirements: [Regulation!]
+	label: String!
+	description: String!
+	validationDescription: String
+}
+
+enum RegulationCode {
+	PCI_4_0
+	PCI_4_0_1_1
+	PCI_4_0_1_1_4
+	PCI_4_0_1_2
+	PCI_4_0_1_2_1
+	PCI_4_0_1_3
+	PCI_4_0_1_3_4
+	PCI_4_0_1_3_6
+	ZERO_TRUST
+	ZERO_TRUST_SENSITIVE
+}
+
+enum RegulationStandard {
+	PCI_4_0
+	PII
+	HIPAA
+	ZERO_TRUST
 }
 
 type Resource {
@@ -1857,6 +2049,7 @@ type Service {
 	gcpResource: GCPResource
 	azureResource: AzureResource
 	discoveredByIntegration: Integration
+	awsVisibility: AWSVisibility
 	tlsKeyPair: KeyPair!
 }
 
@@ -1910,6 +2103,13 @@ enum ServiceType {
 	INTERNET
 	DATABASE_USER
 	KUBERNETES_LOAD_BALANCER
+	AWS_VISIBILITY_EKS
+}
+
+type ServiceViolation {
+	service: Service!
+	reason: String!
+	violatedCalls: [AccessGraphEdge!]
 }
 
 enum SessionAffinity {
@@ -1997,6 +2197,16 @@ type TimeFilterValue {
 	operator: TimeFilterOperators!
 }
 
+type TimeRange {
+	from: Time
+	to: Time
+}
+
+input TimeRangeInput {
+	from: Time
+	to: Time
+}
+
 enum TutorialEvent {
 	CLUSTER_CREATED
 	CLUSTER_CONNECTED
@@ -2069,6 +2279,13 @@ type Workload {
 	types: [ServiceType!]!
 	inboundStatus: ServerProtectionStatusVerdict!
 	outboundStatus: EdgeAccessStatusVerdict!
+}
+
+enum WorkloadTag {
+	PCI
+	PII
+	HIPAA
+	Sensitive
 }
 
 


### PR DESCRIPTION
Enable with `--set operator.ingressControllerAWSALBExempt=true`. Use `intentsOperator.operator.ingressControllerAWSALBExempt` if using the `otterize-kubernetes` Helm chart.

### Description

Prior to this PR, if the `ingressControllers` configuration was passed in order to restrict Ingress traffic to in-cluster ingress Pods, AWS ALB would be (correctly) blocked. This PR enables the intents operator to detect when an AWS ALB ingress resource is used in tandem, and to open access to that pod as required.