### PR TITLE
Upload AWS ALB exemption config to cloud

### DIFF
--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -84,5 +84,7 @@ func uploadConfiguration(ctx context.Context, client CloudClient) {
 		configInput.IngressControllerConfig = ingressControllerConfigInput
 	}
 
+	configInput.AwsALBLoadBalancerExemptionEnabled = viper.GetBool(operatorconfig.IngressControllerALBExemptKey)
+
 	client.ReportIntentsOperatorConfiguration(timeoutCtx, configInput)
 }

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -250,6 +250,7 @@ type IntentsOperatorConfigurationInput struct {
 	DatabaseEnforcementEnabled            bool                           `json:"databaseEnforcementEnabled"`
 	EnforcedNamespaces                    []string                       `json:"enforcedNamespaces"`
 	IngressControllerConfig               []IngressControllerConfigInput `json:"ingressControllerConfig"`
+	AwsALBLoadBalancerExemptionEnabled    bool                           `json:"awsALBLoadBalancerExemptionEnabled"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -310,6 +311,11 @@ func (v *IntentsOperatorConfigurationInput) GetEnforcedNamespaces() []string {
 // GetIngressControllerConfig returns IntentsOperatorConfigurationInput.IngressControllerConfig, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetIngressControllerConfig() []IngressControllerConfigInput {
 	return v.IngressControllerConfig
+}
+
+// GetAwsALBLoadBalancerExemptionEnabled returns IntentsOperatorConfigurationInput.AwsALBLoadBalancerExemptionEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetAwsALBLoadBalancerExemptionEnabled() bool {
+	return v.AwsALBLoadBalancerExemptionEnabled
 }
 
 type InternetConfigInput struct {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1079,6 +1079,7 @@ input IntentsOperatorConfigurationInput {
 	databaseEnforcementEnabled: Boolean
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
+	awsALBLoadBalancerExemptionEnabled: Boolean
 }
 
 type IntentsOperatorState {


### PR DESCRIPTION
### Description

The previous, as of yet unreleased PR #476 did not upload the configuration to Otterize Cloud that is necessary for correctly calculating the access status.