### PR TITLE
Use `"alb.ingress.kubernetes.io/target-type"` instead of `"alb.ingress.kubernetes.io/scheme"` to detect AWS ALB presence on Ingress

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -135,7 +135,7 @@ func (r *NetworkPolicyHandler) buildNetworkPolicyObjectForEndpoints(
 
 	rule := v1.NetworkPolicyIngressRule{}
 	// Only limit netpol if there is an ingress controller restriction configured AND the service is not directly exposed.
-	if len(r.ingressControllerIdentities) != 0 && svc.Spec.Type == corev1.ServiceTypeClusterIP && !(r.ingressControllerALBAllowAll && isIngressListHasInternetFacingAWSALB(ingressList.Items)) {
+	if len(r.ingressControllerIdentities) != 0 && svc.Spec.Type == corev1.ServiceTypeClusterIP && !(r.ingressControllerALBAllowAll && isIngressListHasIPAWSALB(ingressList.Items)) {
 		for _, ingressController := range r.ingressControllerIdentities {
 			rule.From = append(rule.From, v1.NetworkPolicyPeer{
 				PodSelector: &metav1.LabelSelector{

--- a/src/operator/controllers/external_traffic/service_uploader.go
+++ b/src/operator/controllers/external_traffic/service_uploader.go
@@ -151,7 +151,7 @@ func convertToCloudExternalService(svc corev1.Service, identity serviceidentity.
 		ReferredByIngress:              ReferredByIngress,
 		ServiceType:                    cloudServiceType,
 		ServiceName:                    svc.Name,
-		HasInternetFacingAWSALBIngress: isIngressListHasInternetFacingAWSALB(referringIngressList.Items),
+		HasInternetFacingAWSALBIngress: isIngressListHasIPAWSALB(referringIngressList.Items),
 	}
 	return serviceInput, true, nil
 }

--- a/src/operator/controllers/external_traffic/shared.go
+++ b/src/operator/controllers/external_traffic/shared.go
@@ -25,17 +25,17 @@ func serviceNamesFromIngress(ingress *v1.Ingress) sets.Set[string] {
 	return serviceNames
 }
 
-func isIngressListHasInternetFacingAWSALB(ingressList []v1.Ingress) bool {
+func isIngressListHasIPAWSALB(ingressList []v1.Ingress) bool {
 	return lo.SomeBy(ingressList, func(ingress v1.Ingress) bool {
 		if ingress.Annotations == nil {
 			return false
 		}
 
-		scheme, ok := ingress.Annotations["alb.ingress.kubernetes.io/scheme"]
+		scheme, ok := ingress.Annotations["alb.ingress.kubernetes.io/target-type"]
 		if !ok {
 			return false
 		}
 
-		return scheme == "internet-facing"
+		return scheme == "ip"
 	})
 }

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -936,7 +936,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 
 	// Add Ingress with the annotation "alb.ingress.kubernetes.io/scheme": "internet-facing"
 	ingress := s.AddIngressWithAnnotation(ingressName, ingressNamespace, serviceName, map[string]string{
-		"alb.ingress.kubernetes.io/scheme": "internet-facing",
+		"alb.ingress.kubernetes.io/target-type": "ip",
 	})
 
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{


### PR DESCRIPTION
This was done because `target-type`: `ip` is sufficient to indicate that an AWS ALB will attempt to connect, rather than `scheme`: `internet-facing`.