### PR TITLE
Fix MalformedPolicyDocument error when applying AWS IAM policies with 0 statements

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/agent.go
@@ -41,6 +41,15 @@ func (a *Agent) createPolicyFromIntents(intents []otterizev2alpha1.Target) awsag
 		Version: "2012-10-17",
 	}
 
+	if len(intents) == 0 {
+		// This is the equivalent of a "null" policy (allowing nothing) for AWS IAM
+		policy.Statement = append(policy.Statement, awsagent.StatementEntry{
+			Effect:   "Allow",
+			Resource: "*",
+			Action:   []string{"none:null"},
+		})
+	}
+
 	for _, intent := range intents {
 		awsResource := a.templateResourceName(intent.AWS.ARN)
 		actions := intent.AWS.Actions

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/agent_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/agent_test.go
@@ -26,7 +26,7 @@ func (s *AWSAgentPolicySuite) Test_templateResourceName() {
 	s.Equal("arn:aws:sqs:test-region:test-accountid:queue1", resourceName)
 }
 
-func (a *AWSAgentPolicySuite) Test_createPolicyFromIntents_TemplateResourceName() {
+func (s *AWSAgentPolicySuite) Test_createPolicyFromIntents_TemplateResourceName() {
 	// Given
 	agent := &Agent{
 		agent: &awsagent.Agent{
@@ -45,8 +45,25 @@ func (a *AWSAgentPolicySuite) Test_createPolicyFromIntents_TemplateResourceName(
 	// When
 	policyDoc := agent.createPolicyFromIntents(intents)
 	// Then
-	a.Equal("arn:aws:sqs:test-region:test-accountid:queue1", policyDoc.Statement[0].Resource)
+	s.Equal("arn:aws:sqs:test-region:test-accountid:queue1", policyDoc.Statement[0].Resource)
 
+}
+
+func (s *AWSAgentPolicySuite) TestCreatePolicyFromIntents_NoStatements() {
+	// Given
+	agent := &Agent{
+		agent: &awsagent.Agent{
+			Region:    "test-region",
+			AccountID: "test-accountid",
+		},
+	}
+	var intents []otterizev2alpha1.Target
+	// When
+	policyDoc := agent.createPolicyFromIntents(intents)
+	// Then
+	s.Len(policyDoc.Statement, 1)
+	s.Equal("*", policyDoc.Statement[0].Resource)
+	s.Equal([]string{"none:null"}, policyDoc.Statement[0].Action)
 }
 
 func TestRunAWSAgentPolicySuite(t *testing.T) {


### PR DESCRIPTION
### Description
This PR fixes a MalformedPolicyDocument returned by the AWS IAM API, when attempting to apply an AWS IAM policy with 0 statements. 
Instead, when there are 0 statements to apply, we generate a "null" policy statement allowing the non-existing action "none:null" (which is equivalent to allowing nothing). 

### References
https://stackoverflow.com/a/66591851/271362

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
