### PR TITLE
Report `AllowExternalTrafficPolicy` to the cloud to improve access status calculation for non-default config

### DIFF
--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -9,6 +9,14 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+type AllowExternalTrafficPolicy string
+
+const (
+	AllowExternalTrafficPolicyOff                 AllowExternalTrafficPolicy = "OFF"
+	AllowExternalTrafficPolicyAlways              AllowExternalTrafficPolicy = "ALWAYS"
+	AllowExternalTrafficPolicyIfBlockedByOtterize AllowExternalTrafficPolicy = "IF_BLOCKED_BY_OTTERIZE"
+)
+
 type AzureKeyVaultPolicyInput struct {
 	CertificatePermissions []*string `json:"certificatePermissions"`
 	KeyPermissions         []*string `json:"keyPermissions"`
@@ -354,6 +362,7 @@ type IntentsOperatorConfigurationInput struct {
 	EnforcedNamespaces                    []string                       `json:"enforcedNamespaces"`
 	IngressControllerConfig               []IngressControllerConfigInput `json:"ingressControllerConfig"`
 	AwsALBLoadBalancerExemptionEnabled    bool                           `json:"awsALBLoadBalancerExemptionEnabled"`
+	AllowExternalTrafficPolicy            AllowExternalTrafficPolicy     `json:"allowExternalTrafficPolicy"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -419,6 +428,11 @@ func (v *IntentsOperatorConfigurationInput) GetIngressControllerConfig() []Ingre
 // GetAwsALBLoadBalancerExemptionEnabled returns IntentsOperatorConfigurationInput.AwsALBLoadBalancerExemptionEnabled, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetAwsALBLoadBalancerExemptionEnabled() bool {
 	return v.AwsALBLoadBalancerExemptionEnabled
+}
+
+// GetAllowExternalTrafficPolicy returns IntentsOperatorConfigurationInput.AllowExternalTrafficPolicy, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetAllowExternalTrafficPolicy() AllowExternalTrafficPolicy {
+	return v.AllowExternalTrafficPolicy
 }
 
 type InternetConfigInput struct {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -175,6 +175,12 @@ type AccessLogEdge {
 	accessStatuses: EdgeAccessStatuses!
 }
 
+enum AllowExternalTrafficPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
+}
+
 enum ApiFieldAction {
 """Do nothing, expose models to the REST API as id-only structs (Default behaviour)"""
 	COLLAPSE_MODEL
@@ -1137,7 +1143,7 @@ input IntentsOperatorConfigurationInput {
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
-	allowExternalTrafficPolicy: allowExternalTrafficPolicy
+	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 }
 
 type IntentsOperatorState {
@@ -2387,12 +2393,6 @@ enum WorkloadTag {
 	HIPAA
 	Sensitive
 	External
-}
-
-enum allowExternalTrafficPolicy {
-	OFF
-	ALWAYS
-	IF_BLOCKED_BY_OTTERIZE
 }
 
 

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1137,6 +1137,7 @@ input IntentsOperatorConfigurationInput {
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
+	allowExternalTrafficPolicy: allowExternalTrafficPolicy
 }
 
 type IntentsOperatorState {
@@ -1921,6 +1922,12 @@ type Query {
 	testDatabaseVisibilityConnection(
 		databaseInfo: DatabaseInfoInput!
 	): TestDatabaseConnectionResponse!
+	clientIntentEventsForWorkload(
+		id: ID!
+	): [ClientIntentEvent!]
+	clientIntentStatusForWorkload(
+		id: ID!
+	): ClientIntentStatus
 """List user invites"""
 	invites(
 		email: String
@@ -2130,6 +2137,7 @@ type Service {
 	azureResource: AzureResource
 	discoveredByIntegration: Integration
 	awsVisibility: AWSVisibility
+	databaseIntegration: Integration
 	tlsKeyPair: KeyPair!
 }
 
@@ -2159,6 +2167,8 @@ input ServiceBackendPortInput {
 type ServiceClientIntents {
 	asClient: ClientIntentsFiles
 	asServer: ClientIntentsFiles
+	appliedIntentStatus: ClientIntentStatus
+	appliedIntentEvents: [ClientIntentEvent!]
 }
 
 enum ServiceExternalTrafficPolicy {
@@ -2213,6 +2223,14 @@ type SlackChannelInfo {
 	channelName: String!
 }
 
+type SlackChannelIntegrationAlerts {
+	channelInfo: SlackChannelInfo!
+}
+
+input SlackChannelIntegrationAlertsInput {
+	channelInfo: ChannelInfoInput!
+}
+
 type SlackFilterPair {
 	filter: IntegrationAccessGraphFilter!
 	channelInfo: SlackChannelInfo!
@@ -2226,11 +2244,13 @@ input SlackFilterPairInput {
 type SlackSettings {
 	isActive: Boolean!
 	channelFilterPairs: [SlackFilterPair!]!
+	channelIntegrationAlerts: [SlackChannelIntegrationAlerts!]
 }
 
 input SlackSettingsInput {
 	isActive: Boolean!
 	channelFilterPairs: [SlackFilterPairInput!]!
+	channelIntegrationAlerts: [SlackChannelIntegrationAlertsInput!]
 }
 
 input StackFrame {
@@ -2367,6 +2387,12 @@ enum WorkloadTag {
 	HIPAA
 	Sensitive
 	External
+}
+
+enum allowExternalTrafficPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
 }
 
 


### PR DESCRIPTION


### Description

Report `AllowExternalTrafficPolicy` to the cloud to improve access status calculation for non-default config

### References

https://docs.otterize.com/reference/configuration/intents-operator/helm-chart

