### PR TITLE
Bugfixes to AWS IAM policy creation and deletion edge cases

### DIFF
--- a/src/shared/awsagent/errorhandling.go
+++ b/src/shared/awsagent/errorhandling.go
@@ -25,3 +25,23 @@ func isNoSuchEntityException(err error) bool {
 		return false
 	}
 }
+
+func isEntityAlreadyExistsException(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiError smithy.APIError
+
+	if errors.As(err, &apiError) {
+		var entityAlreadyExistsException *types.EntityAlreadyExistsException
+		switch {
+		case errors.As(apiError, &entityAlreadyExistsException):
+			return true
+		default:
+			return false
+		}
+	} else {
+		return false
+	}
+}

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -135,6 +135,9 @@ func (a *Agent) DeleteRolePolicy(ctx context.Context, policyName string) error {
 	})
 
 	if err != nil {
+		if isNoSuchEntityException(err) {
+			return nil
+		}
 		return errors.Wrap(err)
 	}
 

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -68,6 +68,7 @@ func (a *Agent) DeleteRolePolicyByNamespacedName(ctx context.Context, namespace 
 }
 
 func (a *Agent) DeleteRolePolicy(ctx context.Context, policyName string) error {
+	logrus.WithField("policy", policyName).Info("deleting IAM role policy")
 	output, err := a.iamClient.GetPolicy(ctx, &iam.GetPolicyInput{
 		PolicyArn: aws.String(a.generatePolicyArn(policyName)),
 	})

--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -108,6 +108,8 @@ func (a *Agent) GetOtterizeProfile(ctx context.Context, namespaceName, serviceAc
 }
 
 func (a *Agent) DeleteRolesAnywhereProfileForServiceAccount(ctx context.Context, namespace string, serviceAccountName string) (bool, error) {
+	logger := logrus.WithField("namespace", namespace).WithField("serviceAccount", serviceAccountName)
+
 	found, profile, err := a.GetOtterizeProfile(ctx, namespace, serviceAccountName)
 	if err != nil {
 		return false, errors.Wrap(err)
@@ -116,6 +118,8 @@ func (a *Agent) DeleteRolesAnywhereProfileForServiceAccount(ctx context.Context,
 	if !found {
 		return false, nil
 	}
+
+	logger.WithField("profile", *profile.Name).Info("deleting rolesanywhere profile")
 
 	_, err = a.rolesAnywhereClient.DeleteProfile(ctx, &rolesanywhere.DeleteProfileInput{ProfileId: profile.ProfileId})
 	if err != nil {

--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -272,7 +272,7 @@ func (a *Agent) DeleteOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 	}
 
 	if HasSoftDeleteStrategyTagSet(role.Tags) {
-		logger.Debug("role has softDeleteStrategy tag, tagging as unused")
+		logger.Info("role has softDeleteStrategy tag, tagging as unused")
 		return a.SoftDeleteOtterizeIAMRole(ctx, role)
 	}
 
@@ -282,6 +282,7 @@ func (a *Agent) DeleteOtterizeIAMRole(ctx context.Context, namespaceName, accoun
 		return errors.Wrap(err)
 	}
 
+	logger.WithField("role", *role.RoleName).Info("deleting IAM role")
 	_, err = a.iamClient.DeleteRole(ctx, &iam.DeleteRoleInput{
 		RoleName: role.RoleName,
 	})

--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -99,13 +99,13 @@ func (a *Agent) DeleteUserAssignedIdentity(ctx context.Context, namespace string
 	userAssignedIdentityName := a.GenerateUserAssignedIdentityName(namespace, accountName)
 	federatedIdentityCredentialsName := a.generateFederatedIdentityCredentialsName(namespace, accountName)
 
-	logger.WithField("federatedIdentity", federatedIdentityCredentialsName).Debug("deleting federated identity credentials")
+	logger.WithField("federatedIdentity", federatedIdentityCredentialsName).Info("deleting federated identity credentials")
 	_, err := a.federatedIdentityCredentialsClient.Delete(ctx, a.Conf.ResourceGroup, userAssignedIdentityName, federatedIdentityCredentialsName, nil)
 	if err != nil && !azureerrors.IsNotFoundErr(err) && !IsParentResourceNotFoundErr(err) {
 		return errors.Wrap(err)
 	}
 
-	logger.WithField("identity", userAssignedIdentityName).Debug("deleting user assigned identity")
+	logger.WithField("identity", userAssignedIdentityName).Info("deleting user assigned identity")
 	_, err = a.userAssignedIdentitiesClient.Delete(ctx, a.Conf.ResourceGroup, userAssignedIdentityName, nil)
 	if err != nil && !azureerrors.IsNotFoundErr(err) {
 		return errors.Wrap(err)

--- a/src/shared/gcpagent/config_conector.go
+++ b/src/shared/gcpagent/config_conector.go
@@ -232,6 +232,7 @@ func (a *Agent) deleteIAMServiceAccount(ctx context.Context, namespaceName strin
 		return errors.Wrap(err)
 	}
 
+	logger.WithField("name", gsaName).Info("Deleting IAMServiceAccount")
 	err = a.client.Delete(ctx, iamServiceAccount.DeepCopy())
 	if err != nil {
 		logger.WithError(err).Errorf("failed to delete IAMServiceAccount %s", gsaName)
@@ -255,6 +256,8 @@ func (a *Agent) deleteGSAToKSAPolicy(ctx context.Context, namespaceName string, 
 		}
 		return errors.Wrap(err)
 	}
+
+	logger.WithField("name", policyName).Info("Deleting IAMPolicyMember")
 
 	err = a.client.Delete(ctx, iamPolicyMember.DeepCopy())
 	if err != nil {


### PR DESCRIPTION
### Description
This PR fixes a few bugs in the AWS I AM integration managing of IAM policies:
- Attempt to delete an already deleted IAM policy would raise a NoSuchEntity error (which should be ignored)
- Attempt to create an already created IAM policy would raise an EntityAlreadyExists error (which should also be ignored). 

In addition, this PR adds some logging to IAM role deletion for easier troubleshooting. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
