### PR TITLE
Improve ClientIntent status & event reporting robustness by using LRU cache & caching only after successful report

### DIFF
--- a/src/shared/operator_cloud_client/cloud_api.go
+++ b/src/shared/operator_cloud_client/cloud_api.go
@@ -18,8 +18,8 @@ type CloudClient interface {
 	ReportNetworkPolicies(ctx context.Context, namespace string, policies []graphqlclient.NetworkPolicyInput) error
 	ReportExternallyAccessibleServices(ctx context.Context, namespace string, services []graphqlclient.ExternallyAccessibleServiceInput) error
 	ReportProtectedServices(ctx context.Context, namespace string, protectedServices []graphqlclient.ProtectedServiceInput) error
-	ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput)
-	ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput)
+	ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput) error
+	ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput) error
 }
 
 type CloudClientImpl struct {
@@ -116,22 +116,12 @@ func (c *CloudClientImpl) ReportProtectedServices(ctx context.Context, namespace
 	return errors.Wrap(err)
 }
 
-func (c *CloudClientImpl) ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput) {
+func (c *CloudClientImpl) ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput) error {
 	_, err := graphqlclient.ReportClientIntentEvents(ctx, c.client, events)
-	if err != nil {
-		logrus.WithError(err).Error("failed to report intent events")
-		return
-	}
-	logrus.Info("Intent events reported to cloud successfully")
-	return
+	return errors.Wrap(err)
 }
 
-func (c *CloudClientImpl) ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput) {
+func (c *CloudClientImpl) ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput) error {
 	_, err := graphqlclient.ReportClientIntentStatuses(ctx, c.client, statuses)
-	if err != nil {
-		logrus.WithError(err).Error("failed to report intent statuses")
-		return
-	}
-	logrus.Info("Intent statuses reported to cloud successfully")
-	return
+	return errors.Wrap(err)
 }

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -858,310 +858,340 @@ type dummyResponse struct {
 // GetDummyError returns dummyResponse.DummyError, and is useful for accessing the field via an interface.
 func (v *dummyResponse) GetDummyError() UserErrorType { return v.DummyError }
 
+// The query or mutation executed by ReportAppliedKubernetesIntents.
+const ReportAppliedKubernetesIntents_Operation = `
+mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
+	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
+}
+`
+
 func ReportAppliedKubernetesIntents(
-	ctx context.Context,
-	client graphql.Client,
+	ctx_ context.Context,
+	client_ graphql.Client,
 	namespace *string,
 	intents []*IntentInput,
 	clusterId *string,
 ) (*ReportAppliedKubernetesIntentsResponse, error) {
-	req := &graphql.Request{
+	req_ := &graphql.Request{
 		OpName: "ReportAppliedKubernetesIntents",
-		Query: `
-mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
-	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
-}
-`,
+		Query:  ReportAppliedKubernetesIntents_Operation,
 		Variables: &__ReportAppliedKubernetesIntentsInput{
 			Namespace: namespace,
 			Intents:   intents,
 			ClusterId: clusterId,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportAppliedKubernetesIntentsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportAppliedKubernetesIntentsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportClientIntentEvents(
-	ctx context.Context,
-	client graphql.Client,
-	events []ClientIntentEventInput,
-) (*ReportClientIntentEventsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportClientIntentEvents",
-		Query: `
+// The query or mutation executed by ReportClientIntentEvents.
+const ReportClientIntentEvents_Operation = `
 mutation ReportClientIntentEvents ($events: [ClientIntentEventInput!]!) {
 	reportClientIntentEvent(events: $events)
 }
-`,
+`
+
+func ReportClientIntentEvents(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	events []ClientIntentEventInput,
+) (*ReportClientIntentEventsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportClientIntentEvents",
+		Query:  ReportClientIntentEvents_Operation,
 		Variables: &__ReportClientIntentEventsInput{
 			Events: events,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportClientIntentEventsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportClientIntentEventsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportClientIntentStatuses(
-	ctx context.Context,
-	client graphql.Client,
-	statuses []ClientIntentStatusInput,
-) (*ReportClientIntentStatusesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportClientIntentStatuses",
-		Query: `
+// The query or mutation executed by ReportClientIntentStatuses.
+const ReportClientIntentStatuses_Operation = `
 mutation ReportClientIntentStatuses ($statuses: [ClientIntentStatusInput!]!) {
 	reportClientIntentStatus(statuses: $statuses)
 }
-`,
+`
+
+func ReportClientIntentStatuses(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	statuses []ClientIntentStatusInput,
+) (*ReportClientIntentStatusesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportClientIntentStatuses",
+		Query:  ReportClientIntentStatuses_Operation,
 		Variables: &__ReportClientIntentStatusesInput{
 			Statuses: statuses,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportClientIntentStatusesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportClientIntentStatusesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportComponentStatus(
-	ctx context.Context,
-	client graphql.Client,
-	component ComponentType,
-) (*ReportComponentStatusResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportComponentStatus",
-		Query: `
+// The query or mutation executed by ReportComponentStatus.
+const ReportComponentStatus_Operation = `
 mutation ReportComponentStatus ($component: ComponentType!) {
 	reportIntegrationComponentStatus(component: $component)
 }
-`,
+`
+
+func ReportComponentStatus(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	component ComponentType,
+) (*ReportComponentStatusResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportComponentStatus",
+		Query:  ReportComponentStatus_Operation,
 		Variables: &__ReportComponentStatusInput{
 			Component: component,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportComponentStatusResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportComponentStatusResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportExternallyAccessibleServices(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	services []ExternallyAccessibleServiceInput,
-) (*ReportExternallyAccessibleServicesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportExternallyAccessibleServices",
-		Query: `
+// The query or mutation executed by ReportExternallyAccessibleServices.
+const ReportExternallyAccessibleServices_Operation = `
 mutation ReportExternallyAccessibleServices ($namespace: String!, $services: [ExternallyAccessibleServiceInput!]!) {
 	reportExternallyAccessibleServices(namespace: $namespace, services: $services)
 }
-`,
+`
+
+func ReportExternallyAccessibleServices(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	services []ExternallyAccessibleServiceInput,
+) (*ReportExternallyAccessibleServicesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportExternallyAccessibleServices",
+		Query:  ReportExternallyAccessibleServices_Operation,
 		Variables: &__ReportExternallyAccessibleServicesInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportExternallyAccessibleServicesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportExternallyAccessibleServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportIntentsOperatorConfiguration(
-	ctx context.Context,
-	client graphql.Client,
-	configuration IntentsOperatorConfigurationInput,
-) (*ReportIntentsOperatorConfigurationResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportIntentsOperatorConfiguration",
-		Query: `
+// The query or mutation executed by ReportIntentsOperatorConfiguration.
+const ReportIntentsOperatorConfiguration_Operation = `
 mutation ReportIntentsOperatorConfiguration ($configuration: IntentsOperatorConfigurationInput!) {
 	reportIntentsOperatorConfiguration(configuration: $configuration)
 }
-`,
+`
+
+func ReportIntentsOperatorConfiguration(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	configuration IntentsOperatorConfigurationInput,
+) (*ReportIntentsOperatorConfigurationResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportIntentsOperatorConfiguration",
+		Query:  ReportIntentsOperatorConfiguration_Operation,
 		Variables: &__ReportIntentsOperatorConfigurationInput{
 			Configuration: configuration,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportIntentsOperatorConfigurationResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportIntentsOperatorConfigurationResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportKafkaServerConfig(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	kafkaServerConfigs []KafkaServerConfigInput,
-) (*ReportKafkaServerConfigResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportKafkaServerConfig",
-		Query: `
+// The query or mutation executed by ReportKafkaServerConfig.
+const ReportKafkaServerConfig_Operation = `
 mutation ReportKafkaServerConfig ($namespace: String!, $kafkaServerConfigs: [KafkaServerConfigInput!]!) {
 	reportKafkaServerConfigs(namespace: $namespace, serverConfigs: $kafkaServerConfigs)
 }
-`,
+`
+
+func ReportKafkaServerConfig(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	kafkaServerConfigs []KafkaServerConfigInput,
+) (*ReportKafkaServerConfigResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportKafkaServerConfig",
+		Query:  ReportKafkaServerConfig_Operation,
 		Variables: &__ReportKafkaServerConfigInput{
 			Namespace:          namespace,
 			KafkaServerConfigs: kafkaServerConfigs,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportKafkaServerConfigResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportKafkaServerConfigResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportNetworkPolicies(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	policies []NetworkPolicyInput,
-) (*ReportNetworkPoliciesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportNetworkPolicies",
-		Query: `
+// The query or mutation executed by ReportNetworkPolicies.
+const ReportNetworkPolicies_Operation = `
 mutation ReportNetworkPolicies ($namespace: String!, $policies: [NetworkPolicyInput!]!) {
 	reportNetworkPolicies(namespace: $namespace, policies: $policies)
 }
-`,
+`
+
+func ReportNetworkPolicies(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	policies []NetworkPolicyInput,
+) (*ReportNetworkPoliciesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportNetworkPolicies",
+		Query:  ReportNetworkPolicies_Operation,
 		Variables: &__ReportNetworkPoliciesInput{
 			Namespace: namespace,
 			Policies:  policies,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportNetworkPoliciesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportNetworkPoliciesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportProtectedServicesSnapshot(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	services []ProtectedServiceInput,
-) (*ReportProtectedServicesSnapshotResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportProtectedServicesSnapshot",
-		Query: `
+// The query or mutation executed by ReportProtectedServicesSnapshot.
+const ReportProtectedServicesSnapshot_Operation = `
 mutation ReportProtectedServicesSnapshot ($namespace: String!, $services: [ProtectedServiceInput!]!) {
 	reportProtectedServicesSnapshot(namespace: $namespace, services: $services)
 }
-`,
+`
+
+func ReportProtectedServicesSnapshot(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	services []ProtectedServiceInput,
+) (*ReportProtectedServicesSnapshotResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportProtectedServicesSnapshot",
+		Query:  ReportProtectedServicesSnapshot_Operation,
 		Variables: &__ReportProtectedServicesSnapshotInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportProtectedServicesSnapshotResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportProtectedServicesSnapshotResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func dummy(
-	ctx context.Context,
-	client graphql.Client,
-) (*dummyResponse, error) {
-	req := &graphql.Request{
-		OpName: "dummy",
-		Query: `
+// The query or mutation executed by dummy.
+const dummy_Operation = `
 query dummy {
 	dummyError
 }
-`,
+`
+
+func dummy(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (*dummyResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "dummy",
+		Query:  dummy_Operation,
 	}
-	var err error
+	var err_ error
 
-	var data dummyResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ dummyResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }

--- a/src/shared/otterizecloud/mocks/mock_cloud_api.go
+++ b/src/shared/otterizecloud/mocks/mock_cloud_api.go
@@ -49,6 +49,20 @@ func (mr *MockCloudClientMockRecorder) ReportAppliedIntents(ctx, namespace, inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportAppliedIntents", reflect.TypeOf((*MockCloudClient)(nil).ReportAppliedIntents), ctx, namespace, intents)
 }
 
+// ReportClientIntentStatuses mocks base method.
+func (m *MockCloudClient) ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReportClientIntentStatuses", ctx, statuses)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReportClientIntentStatuses indicates an expected call of ReportClientIntentStatuses.
+func (mr *MockCloudClientMockRecorder) ReportClientIntentStatuses(ctx, statuses interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportClientIntentStatuses", reflect.TypeOf((*MockCloudClient)(nil).ReportClientIntentStatuses), ctx, statuses)
+}
+
 // ReportComponentStatus mocks base method.
 func (m *MockCloudClient) ReportComponentStatus(ctx context.Context, component graphqlclient.ComponentType) {
 	m.ctrl.T.Helper()
@@ -76,27 +90,17 @@ func (mr *MockCloudClientMockRecorder) ReportExternallyAccessibleServices(ctx, n
 }
 
 // ReportIntentEvents mocks base method.
-func (m *MockCloudClient) ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput) {
+func (m *MockCloudClient) ReportIntentEvents(ctx context.Context, events []graphqlclient.ClientIntentEventInput) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReportIntentEvents", ctx, events)
+	ret := m.ctrl.Call(m, "ReportIntentEvents", ctx, events)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ReportIntentEvents indicates an expected call of ReportIntentEvents.
 func (mr *MockCloudClientMockRecorder) ReportIntentEvents(ctx, events interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportIntentEvents", reflect.TypeOf((*MockCloudClient)(nil).ReportIntentEvents), ctx, events)
-}
-
-// ReportIntentStatuses mocks base method.
-func (m *MockCloudClient) ReportClientIntentStatuses(ctx context.Context, statuses []graphqlclient.ClientIntentStatusInput) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReportClientIntentStatuses", ctx, statuses)
-}
-
-// ReportIntentStatuses indicates an expected call of ReportIntentStatuses.
-func (mr *MockCloudClientMockRecorder) ReportIntentStatuses(ctx, statuses interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportClientIntentStatuses", reflect.TypeOf((*MockCloudClient)(nil).ReportClientIntentStatuses), ctx, statuses)
 }
 
 // ReportIntentsOperatorConfiguration mocks base method.

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -184,64 +184,70 @@ type __SendTelemetriesInput struct {
 // GetTelemetries returns __SendTelemetriesInput.Telemetries, and is useful for accessing the field via an interface.
 func (v *__SendTelemetriesInput) GetTelemetries() []TelemetryInput { return v.Telemetries }
 
-func ReportErrors(
-	ctx context.Context,
-	client graphql.Client,
-	component *Component,
-	errors []*Error,
-) (*ReportErrorsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportErrors",
-		Query: `
+// The query or mutation executed by ReportErrors.
+const ReportErrors_Operation = `
 mutation ReportErrors ($component: Component!, $errors: [Error!]!) {
 	sendErrors(component: $component, errors: $errors)
 }
-`,
+`
+
+func ReportErrors(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	component *Component,
+	errors []*Error,
+) (*ReportErrorsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportErrors",
+		Query:  ReportErrors_Operation,
 		Variables: &__ReportErrorsInput{
 			Component: component,
 			Errors:    errors,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportErrorsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportErrorsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func SendTelemetries(
-	ctx context.Context,
-	client graphql.Client,
-	telemetries []TelemetryInput,
-) (*SendTelemetriesResponse, error) {
-	req := &graphql.Request{
-		OpName: "SendTelemetries",
-		Query: `
+// The query or mutation executed by SendTelemetries.
+const SendTelemetries_Operation = `
 mutation SendTelemetries ($telemetries: [TelemetryInput!]!) {
 	sendTelemetries(telemetries: $telemetries)
 }
-`,
+`
+
+func SendTelemetries(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	telemetries []TelemetryInput,
+) (*SendTelemetriesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "SendTelemetries",
+		Query:  SendTelemetries_Operation,
 		Variables: &__SendTelemetriesInput{
 			Telemetries: telemetries,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data SendTelemetriesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ SendTelemetriesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -175,6 +175,12 @@ type AccessLogEdge {
 	accessStatuses: EdgeAccessStatuses!
 }
 
+enum AllowExternalTrafficPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
+}
+
 enum ApiFieldAction {
 """Do nothing, expose models to the REST API as id-only structs (Default behaviour)"""
 	COLLAPSE_MODEL
@@ -292,6 +298,54 @@ input ChannelInfoInput {
 
 input ClientIPConfig {
 	timeoutSeconds: Int
+}
+
+type ClientIntentEvent {
+	firstTimestamp: Time!
+	lastTimestamp: Time!
+	reportingComponent: String
+	count: Int!
+	type: String!
+	reason: String!
+	message: String!
+}
+
+input ClientIntentEventInput {
+	clientName: String!
+	clientWorkloadKind: String
+	namespace: String!
+	name: String!
+	labels: [KeyValueInput!]
+	annotations: [KeyValueInput!]
+	count: Int!
+	clientIntentName: String!
+	firstTimestamp: Time!
+	lastTimestamp: Time!
+	reportingComponent: String
+	reportingInstance: String
+	sourceComponent: String
+	type: String!
+	reason: String!
+	message: String!
+}
+
+type ClientIntentStatus {
+	clientIntentName: String!
+	generation: Int!
+	timestamp: Time!
+	observedGeneration: Int!
+	upToDate: Boolean!
+}
+
+input ClientIntentStatusInput {
+	namespace: String!
+	clientName: String!
+	clientWorkloadKind: String
+	clientIntentName: String!
+	generation: Int!
+	timestamp: Time!
+	observedGeneration: Int!
+	upToDate: Boolean!
 }
 
 type ClientIntentsFileRepresentation {
@@ -1089,6 +1143,7 @@ input IntentsOperatorConfigurationInput {
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
+	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 }
 
 type IntentsOperatorState {
@@ -1336,6 +1391,11 @@ type KeyPair {
 	certPEM: String!
 	rootCAPEM: String!
 	expiresAt: Int!
+}
+
+input KeyValueInput {
+	key: String!
+	value: String
 }
 
 enum KubernetesServiceType {
@@ -1593,6 +1653,12 @@ type Mutation {
 	reportExternallyAccessibleServices(
 		namespace: String!
 		services: [ExternallyAccessibleServiceInput!]!
+	): Boolean!
+	reportClientIntentStatus(
+		statuses: [ClientIntentStatusInput!]!
+	): Boolean!
+	reportClientIntentEvent(
+		events: [ClientIntentEventInput!]!
 	): Boolean!
 """Create user invite"""
 	createInvite(
@@ -1862,6 +1928,12 @@ type Query {
 	testDatabaseVisibilityConnection(
 		databaseInfo: DatabaseInfoInput!
 	): TestDatabaseConnectionResponse!
+	clientIntentEventsForWorkload(
+		id: ID!
+	): [ClientIntentEvent!]
+	clientIntentStatusForWorkload(
+		id: ID!
+	): ClientIntentStatus
 """List user invites"""
 	invites(
 		email: String
@@ -2071,6 +2143,7 @@ type Service {
 	azureResource: AzureResource
 	discoveredByIntegration: Integration
 	awsVisibility: AWSVisibility
+	databaseIntegration: Integration
 	tlsKeyPair: KeyPair!
 }
 
@@ -2100,6 +2173,8 @@ input ServiceBackendPortInput {
 type ServiceClientIntents {
 	asClient: ClientIntentsFiles
 	asServer: ClientIntentsFiles
+	appliedIntentStatus: ClientIntentStatus
+	appliedIntentEvents: [ClientIntentEvent!]
 }
 
 enum ServiceExternalTrafficPolicy {
@@ -2154,6 +2229,14 @@ type SlackChannelInfo {
 	channelName: String!
 }
 
+type SlackChannelIntegrationAlerts {
+	channelInfo: SlackChannelInfo!
+}
+
+input SlackChannelIntegrationAlertsInput {
+	channelInfo: ChannelInfoInput!
+}
+
 type SlackFilterPair {
 	filter: IntegrationAccessGraphFilter!
 	channelInfo: SlackChannelInfo!
@@ -2167,11 +2250,13 @@ input SlackFilterPairInput {
 type SlackSettings {
 	isActive: Boolean!
 	channelFilterPairs: [SlackFilterPair!]!
+	channelIntegrationAlerts: [SlackChannelIntegrationAlerts!]
 }
 
 input SlackSettingsInput {
 	isActive: Boolean!
 	channelFilterPairs: [SlackFilterPairInput!]!
+	channelIntegrationAlerts: [SlackChannelIntegrationAlertsInput!]
 }
 
 input StackFrame {


### PR DESCRIPTION
### Description
This PR improves the robustness of reporting ClientIntent status & events, by adding two improvements: 
- Cache events & status only after successfully reporting them to Otterize Cloud, so that in case of reporting errors, the reporting will be retried on the next reporting interval. 
- Use an expirable LRU cache, with an expiry of 1 hour. This way even in case the Cloud somehow missed the report, it will be retried in 1 hour (assuming the status & events will still be there). 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
