### PR TITLE
Bugfix in ClientIntent events reporting: mute NotFound errors on querying IntentEvents for ClientIntents that were already deleted

### DIFF
--- a/src/shared/operator_cloud_client/intent_events_sender.go
+++ b/src/shared/operator_cloud_client/intent_events_sender.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
@@ -181,7 +182,9 @@ func (ies *IntentEventsPeriodicReporter) queryIntentEvents(ctx context.Context) 
 		intent := v2alpha1.ClientIntents{}
 		err := ies.k8sClient.Get(ctx, client.ObjectKey{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}, &intent)
 		if err != nil {
-			logrus.Errorf("Failed to get intent %s/%s: %v", event.InvolvedObject.Namespace, event.InvolvedObject.Name, err)
+			if !k8errors.IsNotFound(err) {
+				logrus.Errorf("Failed to get intent %s/%s: %v", event.InvolvedObject.Namespace, event.InvolvedObject.Name, err)
+			}
 			return IntentEvent{}, false
 		}
 


### PR DESCRIPTION
### Description
This PR fixes a faulty error report on the ClientIntent event reporting loop: when querying for intents associated with the event, we can simply ignore intents that have already been deleted, rather than reporting the NotFound error. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
