### PR TITLE
Fix bug where "external allow" policies were created if "AllowExternalTraffic" was set to "Always" even though the enforcement was disabled

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/samber/lo"
@@ -46,7 +45,6 @@ type NetworkPolicyHandler struct {
 	allowExternalTraffic         allowexternaltraffic.Enum
 	ingressControllerIdentities  []serviceidentity.ServiceIdentity
 	ingressControllerALBAllowAll bool
-	enforcementConfig            enforcement.Config
 }
 
 func NewNetworkPolicyHandler(
@@ -62,7 +60,6 @@ func NewNetworkPolicyHandler(
 		allowExternalTraffic:         allowExternalTraffic,
 		ingressControllerIdentities:  ingressControllerIdentities,
 		ingressControllerALBAllowAll: ingressControllerALBAllowAll,
-		enforcementConfig:            enforcement.GetConfig(),
 	}
 }
 

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -48,7 +48,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/gcpagent"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -138,7 +137,6 @@ func main() {
 	probeAddr := viper.GetString(operatorconfig.ProbeAddrKey)
 	enableLeaderElection := viper.GetBool(operatorconfig.EnableLeaderElectionKey)
 	selfSignedCert := viper.GetBool(operatorconfig.SelfSignedCertKey)
-	allowExternalTraffic := allowexternaltraffic.Enum(viper.GetString(operatorconfig.AllowExternalTrafficKey))
 	watchedNamespaces := viper.GetStringSlice(operatorconfig.WatchedNamespacesKey)
 	enforcementConfig := enforcement.GetConfig()
 	disableWebhookServer := viper.GetBool(operatorconfig.DisableWebhookServerKey)
@@ -197,7 +195,7 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
 
-	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), allowExternalTraffic, operatorconfig.GetIngressControllerServiceIdentities(), viper.GetBool(operatorconfig.IngressControllerALBExemptKey))
+	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetActualExternalTrafficPolicy(), operatorconfig.GetIngressControllerServiceIdentities(), viper.GetBool(operatorconfig.IngressControllerALBExemptKey))
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), extNetpolHandler)
 	ingressRulesBuilder := builders.NewIngressNetpolBuilder()
 

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -54,7 +54,7 @@ func reportStatus(ctx context.Context, client CloudClient) {
 }
 
 func getAllowExternalConfig() graphqlclient.AllowExternalTrafficPolicy {
-	switch allowexternaltraffic.Enum(viper.GetString(operatorconfig.AllowExternalTrafficKey)) {
+	switch enforcement.GetConfig().AllowExternalTraffic {
 	case allowexternaltraffic.Always:
 		return graphqlclient.AllowExternalTrafficPolicyAlways
 	case allowexternaltraffic.Off:

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -2,7 +2,6 @@ package operatorconfig
 
 import (
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesconfig"
@@ -16,24 +15,23 @@ import (
 )
 
 const (
-	MetricsAddrKey                         = "metrics-bind-address" // The address the metric endpoint binds to
-	MetricsAddrDefault                     = ":2112"
-	ProbeAddrKey                           = "health-probe-bind-address" // The address the probe endpoint binds to
-	ProbeAddrDefault                       = ":8181"
-	PprofBindAddressKey                    = "pprof-bind-address"
-	PprofAddrDefault                       = "127.0.0.1:9001"
-	EnableLeaderElectionKey                = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
-	EnableLeaderElectionDefault            = false
-	WatchedNamespacesKey                   = "watched-namespaces"    // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
-	KafkaServerTLSCertKey                  = "kafka-server-tls-cert" // name of tls certificate file
-	KafkaServerTLSKeyKey                   = "kafka-server-tls-key"  // name of tls private key file
-	KafkaServerTLSCAKey                    = "kafka-server-tls-ca"   // name of tls ca file
-	SelfSignedCertKey                      = "self-signed-cert"      // Whether to generate and use a self signed cert as the CA for webhooks
-	SelfSignedCertDefault                  = true
-	DisableWebhookServerKey                = "disable-webhook-server" // Disable webhook validator server
-	DisableWebhookServerDefault            = false
-	AllowExternalTrafficKey                = "allow-external-traffic" // Whether to automatically create network policies for external traffic
-	AllowExternalTrafficDefault            = allowexternaltraffic.IfBlockedByOtterize
+	MetricsAddrKey              = "metrics-bind-address" // The address the metric endpoint binds to
+	MetricsAddrDefault          = ":2112"
+	ProbeAddrKey                = "health-probe-bind-address" // The address the probe endpoint binds to
+	ProbeAddrDefault            = ":8181"
+	PprofBindAddressKey         = "pprof-bind-address"
+	PprofAddrDefault            = "127.0.0.1:9001"
+	EnableLeaderElectionKey     = "leader-elect" // Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager
+	EnableLeaderElectionDefault = false
+	WatchedNamespacesKey        = "watched-namespaces"    // Namespaces that will be watched by the operator. Specify multiple values by specifying multiple times or separate with commas
+	KafkaServerTLSCertKey       = "kafka-server-tls-cert" // name of tls certificate file
+	KafkaServerTLSKeyKey        = "kafka-server-tls-key"  // name of tls private key file
+	KafkaServerTLSCAKey         = "kafka-server-tls-ca"   // name of tls ca file
+	SelfSignedCertKey           = "self-signed-cert"      // Whether to generate and use a self signed cert as the CA for webhooks
+	SelfSignedCertDefault       = true
+	DisableWebhookServerKey     = "disable-webhook-server" // Disable webhook validator server
+	DisableWebhookServerDefault = false
+
 	IntentsOperatorPodNameKey              = "pod-name"
 	IntentsOperatorPodNamespaceKey         = "pod-namespace"
 	EnvPrefix                              = "OTTERIZE"
@@ -71,7 +69,6 @@ func init() {
 	viper.SetDefault(ProbeAddrKey, ProbeAddrDefault)
 	viper.SetDefault(EnableLeaderElectionKey, EnableLeaderElectionDefault)
 	viper.SetDefault(SelfSignedCertKey, SelfSignedCertDefault)
-	viper.SetDefault(AllowExternalTrafficKey, AllowExternalTrafficDefault)
 	viper.SetDefault(DisableWebhookServerKey, DisableWebhookServerDefault)
 	viper.SetDefault(EnableAWSRolesAnywhereKey, EnableAWSRolesAnywhereDefault)
 	viper.SetDefault(TelemetryErrorsAPIKeyKey, TelemetryErrorsAPIKeyDefault)
@@ -157,9 +154,6 @@ func InitCLIFlags() {
 	pflag.Bool(EnableEgressAutoallowDNSTrafficKey, EnableEgressAutoallowDNSTrafficDefault, "Whether to automatically allow DNS traffic in egress network policies")
 	pflag.Duration(RetryDelayTimeKey, RetryDelayTimeDefault, "Default retry delay time for retrying failed requests")
 	pflag.Bool(DebugLogKey, DebugLogDefault, "Enable debug logging")
-
-	allowExternalTrafficDefault := AllowExternalTrafficDefault
-	pflag.Var(&allowExternalTrafficDefault, AllowExternalTrafficKey, "Whether to automatically create network policies for external traffic")
 	runtime.Must(viper.BindPFlags(pflag.CommandLine))
 
 	pflag.Parse()


### PR DESCRIPTION
### Description

Fix bug where "external allow" policies were created when the enforcement was disabled and "AllowExternalTraffic" was set to "Always"



### Testing


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
