### PR TITLE
Workaround AWS VPC CNI egress network policy agent bug: only allows traffic to ClusterIP if exact service selector is specified

### DIFF
--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -70,7 +70,6 @@ const (
 	OtterizeKafkaServerConfigServiceNameField  = "spec.service.name"
 	OtterizeProtectedServiceNameIndexField     = "spec.name"
 	OtterizeFormattedTargetServerIndexField    = "formattedTargetServer"
-	EndpointsOtterizeServiceIdIndexField       = "endpointsOtterizeServiceId"
 	OtterizePodByOwnerKindAndNameIndexField    = "podByOwnerKindAndName"
 	EndpointsPodNamesIndexField                = "endpointsPodNames"
 	IngressServiceNamesIndexField              = "ingressServiceNames"

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -70,6 +70,7 @@ const (
 	OtterizeKafkaServerConfigServiceNameField  = "spec.service.name"
 	OtterizeProtectedServiceNameIndexField     = "spec.name"
 	OtterizeFormattedTargetServerIndexField    = "formattedTargetServer"
+	EndpointsOtterizeServiceIdIndexField       = "endpointsOtterizeServiceId"
 	OtterizePodByOwnerKindAndNameIndexField    = "podByOwnerKindAndName"
 	EndpointsPodNamesIndexField                = "endpointsPodNames"
 	IngressServiceNamesIndexField              = "ingressServiceNames"

--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -366,25 +366,6 @@ func (r *IntentsReconciler) InitIntentsServerIndices(mgr ctrl.Manager) error {
 	if err != nil {
 		return errors.Wrap(err)
 	}
-	// Index endpoints by Otterize service identity.
-	err = mgr.GetCache().IndexField(
-		context.Background(),
-		&corev1.Endpoints{},
-		otterizev2alpha1.EndpointsOtterizeServiceIdIndexField,
-		func(object client.Object) []string {
-			var res []string
-			endpoints := object.(*corev1.Endpoints)
-			for _, subset := range endpoints.Subsets {
-				for _, address := range subset.Addresses {
-					if address.TargetRef == nil || address.TargetRef.Kind != "Pod" {
-						continue
-					}
-					res = append(res, address.TargetRef.Name)
-				}
-			}
-			return res
-
-		})
 
 	return nil
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
@@ -103,6 +103,11 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 			PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.OtterizeServiceLabelKey: formattedServer}},
 			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},
 		}}},
+		{To: []v1.NetworkPolicyPeer{{
+			PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{testServerServiceLabelKey: testServerServiceLabelValue}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},
+		},
+		}},
 		{Ports: []v1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80}}}, To: []v1.NetworkPolicyPeer{{
 			PodSelector:       &metav1.LabelSelector{MatchLabels: serviceSelector},
 			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},
@@ -253,6 +258,11 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKindWithKinds() {
 			PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.OtterizeServiceLabelKey: formattedServerWithoutKind}},
 			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},
 		}}},
+		{To: []v1.NetworkPolicyPeer{{
+			PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{testServerServiceLabelKey: testServerServiceLabelValue}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},
+		},
+		}},
 		{Ports: []v1.NetworkPolicyPort{{Port: &intstr.IntOrString{Type: intstr.Int, IntVal: 80}}}, To: []v1.NetworkPolicyPeer{{
 			PodSelector:       &metav1.LabelSelector{MatchLabels: serviceSelector},
 			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: serverNamespace}},

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
@@ -21,11 +21,6 @@ func NewDNSEgressNetworkPolicyBuilder() *DNSEgressNetworkPolicyBuilder {
 
 // a function that creates []NetworkPolicyEgressRule from ep
 func (r *DNSEgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effectivepolicy.ServiceEffectivePolicy) []v1.NetworkPolicyEgressRule {
-	if lo.NoneBy(ep.Calls, func(call effectivepolicy.Call) bool {
-		return call.IsTargetInCluster()
-	}) {
-		return make([]v1.NetworkPolicyEgressRule, 0)
-	}
 	egressRules := make([]v1.NetworkPolicyEgressRule, 0)
 
 	// DNS

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy_test.go
@@ -429,6 +429,22 @@ func networkPolicyEgressTemplate(
 						},
 					},
 				},
+				{
+					To: []v1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									testServerServiceLabelKey: testServerServiceLabelValue,
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									otterizev2alpha1.KubernetesStandardNamespaceNameLabelKey: targetNamespace,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"net"
@@ -76,6 +77,10 @@ func (r *InternetEgressRulesBuilder) buildRuleForIntent(intent otterizev2alpha1.
 			},
 		})
 	}
+
+	slices.SortFunc(peers, func(a, b v1.NetworkPolicyPeer) bool {
+		return a.IPBlock.CIDR < b.IPBlock.CIDR
+	})
 
 	ports := make([]v1.NetworkPolicyPort, 0)
 	for _, port := range intent.Internet.Ports {

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
@@ -55,25 +55,42 @@ func (r *InternetEgressRulesBuilder) buildEgressRules(ep effectivepolicy.Service
 }
 
 func (r *InternetEgressRulesBuilder) buildRuleForIntent(intent otterizev2alpha1.Target, ep effectivepolicy.ServiceEffectivePolicy) ([]v1.NetworkPolicyPeer, []v1.NetworkPolicyPort, bool, error) {
-	ips := make([]string, 0)
-	ipsFromDns := r.getIpsForDNS(intent, ep)
-	ips = append(ips, ipsFromDns...)
-	ips = append(ips, intent.Internet.Ips...)
+	ips := r.getIpsForDNS(intent, ep)
+	for _, existingIp := range intent.Internet.Ips {
+		ips[existingIp] = struct{}{}
+	}
 
 	if len(ips) == 0 {
 		return nil, nil, false, nil
 	}
 
-	peers, err := r.parseIps(ips)
-	if err != nil {
-		return nil, nil, false, errors.Wrap(err)
+	peers := make([]v1.NetworkPolicyPeer, 0)
+	for ip := range ips {
+		cidr, err := getCIDR(ip)
+		if err != nil {
+			return nil, nil, false, errors.Wrap(err)
+		}
+		peers = append(peers, v1.NetworkPolicyPeer{
+			IPBlock: &v1.IPBlock{
+				CIDR: cidr,
+			},
+		})
 	}
-	ports := r.parsePorts(intent)
+
+	ports := make([]v1.NetworkPolicyPort, 0)
+	for _, port := range intent.Internet.Ports {
+		ports = append(ports, v1.NetworkPolicyPort{
+			Port: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: int32(port),
+			},
+		})
+	}
 	return peers, ports, true, nil
 }
 
-func (r *InternetEgressRulesBuilder) getIpsForDNS(intent otterizev2alpha1.Target, ep effectivepolicy.ServiceEffectivePolicy) []string {
-	ipsFromDns := make([]string, 0)
+func (r *InternetEgressRulesBuilder) getIpsForDNS(intent otterizev2alpha1.Target, ep effectivepolicy.ServiceEffectivePolicy) map[string]struct{} {
+	ipsFromDns := make(map[string]struct{})
 
 	for _, dns := range intent.Internet.Domains {
 		dnsResolvedIps, found := lo.Find(ep.ClientIntentsStatus.ResolvedIPs, func(resolvedIPs otterizev2alpha1.ResolvedIPs) bool {
@@ -84,44 +101,12 @@ func (r *InternetEgressRulesBuilder) getIpsForDNS(intent otterizev2alpha1.Target
 			continue
 		}
 
-		ipsFromDns = append(ipsFromDns, dnsResolvedIps.IPs...)
+		for _, ip := range dnsResolvedIps.IPs {
+			ipsFromDns[ip] = struct{}{}
+		}
 	}
 
 	return ipsFromDns
-}
-func (r *InternetEgressRulesBuilder) parseIps(ips []string) ([]v1.NetworkPolicyPeer, error) {
-	var cidrs []string
-	for _, ipStr := range ips {
-		cidr, err := getCIDR(ipStr)
-		if err != nil {
-			return nil, errors.Wrap(err)
-		}
-
-		cidrs = append(cidrs, cidr)
-	}
-
-	peers := make([]v1.NetworkPolicyPeer, 0)
-	for _, cidr := range cidrs {
-		peers = append(peers, v1.NetworkPolicyPeer{
-			IPBlock: &v1.IPBlock{
-				CIDR: cidr,
-			},
-		})
-	}
-	return peers, nil
-}
-
-func (r *InternetEgressRulesBuilder) parsePorts(intent otterizev2alpha1.Target) []v1.NetworkPolicyPort {
-	ports := make([]v1.NetworkPolicyPort, 0)
-	for _, port := range intent.Internet.Ports {
-		ports = append(ports, v1.NetworkPolicyPort{
-			Port: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: int32(port),
-			},
-		})
-	}
-	return ports
 }
 
 func (r *InternetEgressRulesBuilder) Build(_ context.Context, ep effectivepolicy.ServiceEffectivePolicy) ([]v1.NetworkPolicyEgressRule, error) {

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -3,7 +3,6 @@ package builders
 import (
 	"context"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
-	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -662,7 +661,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestUpdateNetworkPolicy() {
 		})
 
 	// Update NetworkPolicy
-	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(newPolicy), intents_reconcilers.MatchPatch(client.MergeFrom(existingBadPolicy))).Return(nil)
+	s.Client.EXPECT().Update(gomock.Any(), gomock.Eq(newPolicy)).Return(nil)
 
 	res, err := s.EPIntentsReconciler.Reconcile(context.Background(), req)
 	s.Require().NoError(err)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -3,6 +3,7 @@ package builders
 import (
 	"context"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
+	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
@@ -111,12 +112,12 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 						},
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: ips[2] + "/128",
+								CIDR: ips[3], // 3 is before 2 due to sorting
 							},
 						},
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: ips[3],
+								CIDR: ips[2] + "/128",
 							},
 						},
 					},
@@ -661,7 +662,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestUpdateNetworkPolicy() {
 		})
 
 	// Update NetworkPolicy
-	s.Client.EXPECT().Update(gomock.Any(), gomock.Eq(newPolicy)).Return(nil)
+	s.Client.EXPECT().Patch(gomock.Any(), gomock.Eq(newPolicy), intents_reconcilers.MatchPatch(client.MergeFrom(existingBadPolicy))).Return(nil)
 
 	res, err := s.EPIntentsReconciler.Reconcile(context.Background(), req)
 	s.Require().NoError(err)

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -9,6 +9,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/networkpolicy"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -25,9 +26,11 @@ import (
 )
 
 const (
-	testNamespace       = "test-namespace"
-	testServerNamespace = "test-server-namespace"
-	testClientNamespace = "test-client-namespace"
+	testNamespace               = "test-namespace"
+	testServerNamespace         = "test-server-namespace"
+	testClientNamespace         = "test-client-namespace"
+	testServerServiceLabelKey   = "app"
+	testServerServiceLabelValue = "server"
 )
 
 type RulesBuilderTestSuiteBase struct {
@@ -125,6 +128,9 @@ func (s *RulesBuilderTestSuiteBase) expectRemoveOrphanFindsPolicies(netpols []v1
 
 func (s *RulesBuilderTestSuiteBase) expectGetAllEffectivePolicies(clientIntents []otterizev2alpha1.ClientIntents) {
 	var intentsList otterizev2alpha1.ClientIntentsList
+	for _, clientIntentsEntry := range clientIntents {
+		s.expectKubernetesServicesReferencingPodsIndirectly(clientIntentsEntry)
+	}
 
 	s.Client.EXPECT().List(gomock.Any(), &intentsList).DoAndReturn(func(_ context.Context, intents *otterizev2alpha1.ClientIntentsList, _ ...any) error {
 		intents.Items = append(intents.Items, clientIntents...)
@@ -146,11 +152,10 @@ func (s *RulesBuilderTestSuiteBase) expectGetAllEffectivePolicies(clientIntents 
 		}
 	}
 
-	matchFieldsPtr := &client.MatchingFields{}
 	s.Client.EXPECT().List(
 		gomock.Any(),
 		&otterizev2alpha1.ClientIntentsList{},
-		gomock.AssignableToTypeOf(matchFieldsPtr),
+		gomock.AssignableToTypeOf(&client.MatchingFields{}),
 	).DoAndReturn(func(_ context.Context, intents *otterizev2alpha1.ClientIntentsList, args ...any) error {
 		matchFields := args[0].(*client.MatchingFields)
 		intents.Items = services[(*matchFields)[otterizev2alpha1.OtterizeFormattedTargetServerIndexField]]
@@ -183,4 +188,63 @@ func (s *RulesBuilderTestSuiteBase) addExpectedKubernetesServiceCall(serviceName
 		}).AnyTimes()
 
 	return &svcObject
+}
+
+func (s *RulesBuilderTestSuiteBase) expectKubernetesServicesReferencingPodsIndirectly(clientIntents otterizev2alpha1.ClientIntents) {
+	podList := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-server",
+				Namespace: testClientNamespace,
+				Labels: map[string]string{
+					testServerServiceLabelKey: testServerServiceLabelValue,
+				},
+			},
+		},
+	}
+	for _, target := range clientIntents.Spec.Targets {
+		if target.GetTargetServerKind() == serviceidentity.KindOtterizeLegacy {
+			s.Client.EXPECT().List(
+				gomock.Any(),
+				&corev1.PodList{},
+				client.MatchingLabels{otterizev2alpha1.OtterizeServiceLabelKey: target.ToServiceIdentity(clientIntents.Namespace).GetFormattedOtterizeIdentityWithoutKind()},
+			).DoAndReturn(func(ctx context.Context, outPodList *corev1.PodList, _ client.ListOption) error {
+				outPodList.Items = podList
+				return nil
+			}).AnyTimes()
+		} else {
+			s.Client.EXPECT().List(
+				gomock.Any(),
+				&corev1.PodList{},
+				client.MatchingLabels{otterizev2alpha1.OtterizeServiceLabelKey: target.ToServiceIdentity(clientIntents.Namespace).GetFormattedOtterizeIdentityWithoutKind(),
+					otterizev2alpha1.OtterizeOwnerKindLabelKey: target.GetTargetServerKind()}).DoAndReturn(func(ctx context.Context, outPodList *corev1.PodList, _ client.ListOption) error {
+				outPodList.Items = podList
+				return nil
+			}).AnyTimes()
+		}
+
+		// Expect service list
+		serviceList := []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-server",
+					Namespace: testClientNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						testServerServiceLabelKey: testServerServiceLabelValue,
+					},
+				},
+			},
+		}
+		var emptyServiceList corev1.ServiceList
+		s.Client.EXPECT().List(
+			gomock.Any(),
+			&emptyServiceList,
+			client.InNamespace(testClientNamespace),
+		).DoAndReturn(func(ctx context.Context, outServiceList *corev1.ServiceList, _ client.ListOption) error {
+			outServiceList.Items = serviceList
+			return nil
+		}).AnyTimes()
+	}
 }

--- a/src/operator/effectivepolicy/types.go
+++ b/src/operator/effectivepolicy/types.go
@@ -5,6 +5,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 )
 
 type ClientCall struct {
@@ -15,7 +16,8 @@ type ClientCall struct {
 
 type Call struct {
 	v2alpha1.Target
-	EventRecorder *injectablerecorder.ObjectEventRecorder
+	ReferencingKubernetesServices []v1.Service
+	EventRecorder                 *injectablerecorder.ObjectEventRecorder
 }
 
 type ServiceEffectivePolicy struct {

--- a/src/shared/operator_cloud_client/intent_events_sender.go
+++ b/src/shared/operator_cloud_client/intent_events_sender.go
@@ -82,7 +82,7 @@ func (ies *IntentEventsPeriodicReporter) Start(ctx context.Context) error {
 	go func() {
 		defer errorreporter.AutoNotify()
 		// Wait for caches to sync
-		ies.waitForCacheSync(ctx)
+		ies.k8sClusterManager.GetCache().WaitForCacheSync(ctx)
 
 		ies.startReportLoop(ctx)
 	}()
@@ -106,21 +106,6 @@ func (ies *IntentEventsPeriodicReporter) startReportLoop(ctx context.Context) {
 		case <-statusReportTicker.C:
 			ies.reportIntentStatuses(ctx)
 		}
-	}
-}
-
-func (ies *IntentEventsPeriodicReporter) waitForCacheSync(ctx context.Context) {
-	for {
-		ok := func() bool {
-			timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
-			return ies.k8sClusterManager.GetCache().WaitForCacheSync(timeoutCtx)
-		}()
-		if !ok {
-			logrus.Error("Intents Event Sender - Failed waiting for caches to sync")
-			continue
-		}
-		break
 	}
 }
 

--- a/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
+++ b/src/shared/serviceidresolver/serviceidentity/serviceidentity.go
@@ -25,34 +25,34 @@ type ServiceIdentity struct {
 const KindService = "Service"
 const KindOtterizeLegacy = "OttrLegacy"
 
-func (si *ServiceIdentity) GetFormattedOtterizeIdentityWithoutKind() string {
+func (si ServiceIdentity) GetFormattedOtterizeIdentityWithoutKind() string {
 	return getFormattedOtterizeIdentity(si.Name, si.Namespace)
 }
 
-func (si *ServiceIdentity) GetFormattedOtterizeIdentityWithKind() string {
+func (si ServiceIdentity) GetFormattedOtterizeIdentityWithKind() string {
 	if si.Kind == "" || si.Kind == KindOtterizeLegacy {
 		return getFormattedOtterizeIdentity(si.Name, si.Namespace)
 	}
 	return getFormattedOtterizeIdentityWithKind(si.Name, si.Namespace, si.Kind)
 }
 
-func (si *ServiceIdentity) GetName() string {
+func (si ServiceIdentity) GetName() string {
 	return si.Name
 }
 
-func (si *ServiceIdentity) GetNameAsServer() string {
+func (si ServiceIdentity) GetNameAsServer() string {
 	return fmt.Sprintf("%s.%s", si.Name, si.Namespace)
 }
 
-func (si *ServiceIdentity) GetNameWithKind() string {
+func (si ServiceIdentity) GetNameWithKind() string {
 	return lo.Ternary(si.Kind == "" || si.Kind == KindOtterizeLegacy, si.Name, fmt.Sprintf("%s-%s", si.Name, strings.ToLower(si.Kind)))
 }
 
-func (si *ServiceIdentity) Equals(other ServiceIdentity) bool {
+func (si ServiceIdentity) Equals(other ServiceIdentity) bool {
 	return si.Name == other.Name && si.Namespace == other.Namespace && si.Kind == other.Kind
 }
 
-func (si *ServiceIdentity) String() string {
+func (si ServiceIdentity) String() string {
 	return fmt.Sprintf("%s/%s/%s", si.Kind, si.Namespace, si.Name)
 }
 


### PR DESCRIPTION
### Description

This works around an issue with the AWS VPC CNI where it does not allow traffic to the ClusterIP of a Service unless the NetworkPolicy uses the exact selector used by the Service.

Also fixes an unrelated issue where DNS traffic was not automatically allowed if the only targets were Internet intents.

This Pod has two sets of labels:
```
❯ kubectl get pods -n otterize-tutorial-iam -l intents.otterize.com/service=server-otterize-tutorial-ia-68873b
NAME                      READY   STATUS    RESTARTS   AGE
server-6dbbc4666f-nncjf   1/1     Running   0          85m
 ❯ kubectl get pods -n otterize-tutorial-iam -l app=server
NAME                      READY   STATUS    RESTARTS   AGE
server-6dbbc4666f-nncjf   1/1     Running   0          85m
```
app=server is the one used by the Service.
This network policy doesn't work:
```
  egress:
  - to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: otterize-tutorial-iam
      podSelector:
        matchLabels:
          intents.otterize.com/service: server-otterize-tutorial-ia-68873b
```
The traffic is denied. The VPC CNI log shows that the traffic is to the ClusterIP of the Service, rather than directly to the pod (which makes sense, but it should not be denied, since the correct Pod is selected).
```
{"level":"info","ts":"2024-09-20T12:55:01.282Z","logger":"ebpf-client","caller":"events/events.go:193","msg":"Flow Info:  ","Src IP":"192.168.169.89","Src Port":46652,"Dest IP":"10.100.204.247","Dest Port":80,"Proto":"TCP","Verdict":"DENY"}
```
If we also add this rule to the network policy, it starts working, because it is the exact label used by the Service with the ClusterIP 10.100.204.247. It looks like they don't correctly resolve Services, unless the exact label used by the Service is used.

```
  egress:
  - to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: otterize-tutorial-iam
      podSelector:
        matchLabels:
          app: server
```

```
"level":"info","ts":"2024-09-20T13:16:54.050Z","logger":"ebpf-client","caller":"events/events.go:193","msg":"Flow Info:  ","Src IP":"192.168.169.89","Src Port":37750,"Dest IP":"10.100.204.247","Dest Port":80,"Proto":"TCP","Verdict":"ACCEPT"}
```


### References

AWS support case 172678650700597. Will be updated with link if made public by AWS.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality