### PR TITLE
Bugfix: fix wrong handling of non-existing PostgreSQL users when attempting to alter their passwords

### DIFF
--- a/src/shared/databaseconfigurator/postgres/postgres.go
+++ b/src/shared/databaseconfigurator/postgres/postgres.go
@@ -501,10 +501,11 @@ func (p *PostgresConfigurator) AlterUserPassword(ctx context.Context, username s
 	}
 	batch.Queue(stmt)
 	if err := p.sendBatch(ctx, &batch); err != nil {
+		if errors.Is(err, ErrUndefinedObject) {
+			logrus.WithField("username", username).Debug("User does not exist, skipping password update")
+			return nil
+		}
 		return errors.Wrap(err)
-	}
-	if errors.Is(err, ErrUndefinedObject) {
-		logrus.WithField("username", username).Debug("User does not exist, skipping password update")
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
This PR changes a bug in the PostgreSQL integration, where non-existing PG users should be ignored when attempting to alter their passwords. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
