### PR TITLE
Fix Kubernetes API 'Forbidden' errors during update, being wrongly reported as errors on the resource

### DIFF
--- a/src/operator/controllers/custom_resource_definition_controller.go
+++ b/src/operator/controllers/custom_resource_definition_controller.go
@@ -86,7 +86,7 @@ func (r *CustomResourceDefinitionsReconciler) Reconcile(ctx context.Context, req
 
 	// Use optimistic locking to avoid using "mergeFrom" with an outdated resource
 	if err := r.Patch(ctx, resourceCopy, client.MergeFromWithOptions(crd, client.MergeFromWithOptimisticLock{})); err != nil {
-		if k8serrors.IsConflict(err) {
+		if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 			logrus.Debugf("Conflict while updating CustomResourceDefinition: %s", resourceCopy.Name)
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -80,9 +80,6 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if !intents.DeletionTimestamp.IsZero() {
 		err := r.policyManager.DeleteAll(ctx, intents)
 		if err != nil {
-			return ctrl.Result{}, errors.Wrap(err)
-		}
-		if err != nil {
 			if k8serrors.IsConflict(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}

--- a/src/operator/controllers/intents_reconcilers/pods.go
+++ b/src/operator/controllers/intents_reconcilers/pods.go
@@ -51,8 +51,7 @@ func (r *PodLabelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !intents.DeletionTimestamp.IsZero() {
 		err := r.removeLabelsFromPods(ctx, intents)
 		if err != nil {
-			// TODO: check IsConflict error next to the actual client call
-			if k8serrors.IsConflict(err) {
+			if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			r.RecordWarningEventf(intents, ReasonRemovingPodLabelsFailed, "could not remove pod labels: %s", err.Error())

--- a/src/shared/gcpagent/config_conector.go
+++ b/src/shared/gcpagent/config_conector.go
@@ -49,7 +49,7 @@ func (a *Agent) AnnotateGKENamespace(ctx context.Context, namespaceName string) 
 	logger.Debugf("annotating namespace %s with gcp workload identity tag", namespaceName)
 	err = a.client.Patch(ctx, updatedNamespace, client.MergeFrom(&namespace))
 	if err != nil {
-		if apierrors.IsConflict(err) {
+		if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 			return true, nil
 		}
 		return false, errors.Wrap(err)

--- a/src/shared/reconcilergroup/reconcilergroup.go
+++ b/src/shared/reconcilergroup/reconcilergroup.go
@@ -70,7 +70,7 @@ func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, e
 
 	err = g.ensureFinalizer(ctx, resourceObject)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, errors.Wrap(err)
@@ -78,7 +78,7 @@ func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, e
 
 	err = g.removeLegacyFinalizers(ctx, resourceObject)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, errors.Wrap(err)
@@ -90,7 +90,7 @@ func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, e
 	if objectBeingDeleted && finalErr == nil && finalRes.IsZero() {
 		err = g.removeFinalizer(ctx, resourceObject)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
 				return ctrl.Result{Requeue: true}, nil
 			}
 			return ctrl.Result{}, errors.Wrap(err)


### PR DESCRIPTION
### Description
This PR fixes an issue with handling Kubernetes API 'Forbidden' errors during update, which are being wrongly reported as errors in the logs and on the Kubernetes resource. These errors are expected during the normal workflow of a reconciler, e.g. when the resource in question is already being deleted. They should be caught and the flow should be requeued (similar to 'Conflict' errors). 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
