### PR TITLE
Bugfix on external policy reconciler: catch NotFound errors when attempting to delete a network policy

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -226,6 +226,9 @@ func (r *NetworkPolicyHandler) HandleBeforeAccessPolicyRemoval(ctx context.Conte
 	for _, externalPolicy := range externalPolicyList.Items {
 		err := r.client.Delete(ctx, externalPolicy.DeepCopy())
 		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
 			return errors.Wrap(err)
 		}
 	}


### PR DESCRIPTION
### Description
This PR fixes a wrongly reported NotFound error that occurs when the intents-operator attempts to delete an already deleted network policy.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
