### PR TITLE
Bugfix: increase ClientIntent events cache first sync time limit to 60 seconds to prevent errors on large environments

### DIFF
--- a/src/shared/operator_cloud_client/intent_events_sender.go
+++ b/src/shared/operator_cloud_client/intent_events_sender.go
@@ -112,7 +112,7 @@ func (ies *IntentEventsPeriodicReporter) startReportLoop(ctx context.Context) {
 func (ies *IntentEventsPeriodicReporter) waitForCacheSync(ctx context.Context) {
 	for {
 		ok := func() bool {
-			timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 			return ies.k8sClusterManager.GetCache().WaitForCacheSync(timeoutCtx)
 		}()


### PR DESCRIPTION
### Description
This PR fixes an error that may be reported from intent-operators running on large environments, which may have a lot of ClientIntent objects & events. The internal cache for ClientIntent events may take a longer time to sync on startup. 

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
