### PR TITLE
Bugfix in AWS IAM roles anywhere integration: nextToken is not used when listing AWS IAM roles anywhere profiles

### DIFF
--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -78,7 +78,7 @@ func (a *Agent) initProfileCache(ctx context.Context) (err error) {
 		}
 
 		for nextToken != nil {
-			nextToken, err = a.loadNextProfileCachePage(ctx, nil)
+			nextToken, err = a.loadNextProfileCachePage(ctx, nextToken)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
### Description
This PR fixes a bug in the AWS IAM roles anywhere integration, where the next token is unused when listing more than 2 pages of IAM profiles. 


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
