### PR TITLE
Fix a rare bug where external network policies were not deleted due to a race condition when the enforcement was turned off

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy_reconciler.go
+++ b/src/operator/controllers/external_traffic/network_policy_reconciler.go
@@ -1,0 +1,53 @@
+package external_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/networking/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+//+kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs=get;update;patch;list;watch;delete;create
+
+type NetworkPolicyReconciler struct {
+	client.Client
+	extNetpolHandler *NetworkPolicyHandler
+	injectablerecorder.InjectableRecorder
+}
+
+func NewNetworkPolicyReconciler(
+	client client.Client,
+	extNetpolHandler *NetworkPolicyHandler,
+) *NetworkPolicyReconciler {
+	return &NetworkPolicyReconciler{
+		Client:           client,
+		extNetpolHandler: extNetpolHandler,
+	}
+}
+
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.NetworkPolicy{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+// Reconcile handles network policy creation, update and delete. In all of these cases, it calls the NetworkPolicyHandler
+// to handle the pods in the namespace of the network policy.
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logrus.Info("Handling external for NetworkPolicy for namespace: ", req.Namespace)
+	err := r.extNetpolHandler.HandlePodsByNamespace(ctx, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/intents_reconcilers/mocks/mock_external_netpol_handler.go
+++ b/src/operator/controllers/intents_reconcilers/mocks/mock_external_netpol_handler.go
@@ -36,6 +36,20 @@ func (m *MockExternalNetpolHandler) EXPECT() *MockExternalNetpolHandlerMockRecor
 	return m.recorder
 }
 
+// HandleAllPods mocks base method.
+func (m *MockExternalNetpolHandler) HandleAllPods(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleAllPods", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleAllPods indicates an expected call of HandleAllPods.
+func (mr *MockExternalNetpolHandlerMockRecorder) HandleAllPods(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAllPods", reflect.TypeOf((*MockExternalNetpolHandler)(nil).HandleAllPods), arg0)
+}
+
 // HandleBeforeAccessPolicyRemoval mocks base method.
 func (m *MockExternalNetpolHandler) HandleBeforeAccessPolicyRemoval(arg0 context.Context, arg1 *v1.NetworkPolicy) error {
 	m.ctrl.T.Helper()

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -66,6 +66,7 @@ func (s *RulesBuilderTestSuiteBase) SetupTest() {
 
 	epReconciler.InjectableRecorder.Recorder = s.Recorder
 	s.EPIntentsReconciler.Recorder = s.Recorder
+	s.externalNetpolHandler.EXPECT().HandleAllPods(gomock.Any()).AnyTimes()
 }
 
 func (s *RulesBuilderTestSuiteBase) TearDownTest() {

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -336,6 +336,7 @@ func main() {
 
 	externalPolicySvcReconciler := external_traffic.NewServiceReconciler(mgr.GetClient(), extNetpolHandler)
 	ingressReconciler := external_traffic.NewIngressReconciler(mgr.GetClient(), extNetpolHandler)
+	netpolReconciler := external_traffic.NewNetworkPolicyReconciler(mgr.GetClient(), extNetpolHandler)
 
 	if !enforcementConfig.EnforcementDefaultState {
 		logrus.Infof("Running with enforcement disabled globally, won't perform any enforcement")
@@ -422,6 +423,10 @@ func main() {
 
 	if err = ingressReconciler.SetupWithManager(mgr); err != nil {
 		logrus.WithError(err).Panic("unable to create controller", "controller", "Ingress")
+	}
+
+	if err = netpolReconciler.SetupWithManager(mgr); err != nil {
+		logrus.WithError(err).Panic("unable to create controller", "controller", "NetworkPolicy")
 	}
 
 	kafkaServerConfigReconciler := controllers.NewKafkaServerConfigReconciler(

--- a/src/shared/operator_cloud_client/cloud_api.go
+++ b/src/shared/operator_cloud_client/cloud_api.go
@@ -110,7 +110,7 @@ func (c *CloudClientImpl) ReportExternallyAccessibleServices(ctx context.Context
 func (c *CloudClientImpl) ReportProtectedServices(ctx context.Context, namespace string, protectedServices []graphqlclient.ProtectedServiceInput) error {
 	logrus.WithField("namespace", namespace).
 		WithField("count", len(protectedServices)).
-		Infof("Reporting protected services")
+		Info("Reporting protected services")
 
 	_, err := graphqlclient.ReportProtectedServicesSnapshot(ctx, c.client, namespace, protectedServices)
 	return errors.Wrap(err)

--- a/src/shared/operator_cloud_client/cloud_api.go
+++ b/src/shared/operator_cloud_client/cloud_api.go
@@ -110,7 +110,7 @@ func (c *CloudClientImpl) ReportExternallyAccessibleServices(ctx context.Context
 func (c *CloudClientImpl) ReportProtectedServices(ctx context.Context, namespace string, protectedServices []graphqlclient.ProtectedServiceInput) error {
 	logrus.WithField("namespace", namespace).
 		WithField("count", len(protectedServices)).
-		Infof("Reporting network policies")
+		Infof("Reporting protected services")
 
 	_, err := graphqlclient.ReportProtectedServicesSnapshot(ctx, c.client, namespace, protectedServices)
 	return errors.Wrap(err)


### PR DESCRIPTION

### Description

This situation probably happened due to a race when two operators were running. I fixed it by:
1. Calling `externalPolicyHandler.HandleAllPods` for every run of the effective policy reconciler.
2. Add a netpol reconciler that triggers `externalPolicyHandler.HandlePodsInNamespace`

