### PR TITLE
Changed MergeFrom to StrategicMergeFrom when patching pod labels to try and fix forbidden fields error on pod patching

### DIFF
--- a/src/operator/controllers/pod_reconcilers/pods.go
+++ b/src/operator/controllers/pod_reconcilers/pods.go
@@ -270,7 +270,7 @@ func (p *PodWatcher) addOtterizePodLabels(ctx context.Context, req ctrl.Request,
 	}
 
 	if hasUpdates {
-		err = p.Patch(ctx, updatedPod, client.MergeFrom(&pod))
+		err = p.Patch(ctx, updatedPod, client.StrategicMergeFrom(&pod))
 		if client.IgnoreNotFound(err) != nil {
 			return errors.Errorf("failed updating Otterize labels for pod %s in namespace %s: %w", pod.Name, pod.Namespace, err)
 		}


### PR DESCRIPTION
### Description
Changed `MergeFrom` to `StrategicMergeFrom` when patching pod labels to try and fix forbidden fields error on pod patching