### PR TITLE
Catch "already exists" error to avoid unnecessary error events

### DIFF
--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -124,7 +124,7 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	err = r.policyManager.Create(ctx, intents, clientServiceAccountName)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
+		if k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, errors.Wrap(err)

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -402,10 +402,9 @@ func (c *PolicyManagerImpl) createOrUpdatePolicies(
 
 		err = c.client.Create(ctx, newPolicy)
 		if err != nil {
-			if k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err) {
-				continue
+			if !(k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err)) {
+				c.recorder.RecordWarningEventf(clientIntents, ReasonCreatingIstioPolicyFailed, "Failed to create Istio policy: %s", err.Error())
 			}
-			c.recorder.RecordWarningEventf(clientIntents, ReasonCreatingIstioPolicyFailed, "Failed to create Istio policy: %s", err.Error())
 			return nil, errors.Wrap(err)
 		}
 		createdAnyPolicies = true

--- a/src/operator/controllers/istiopolicy/policy_manager.go
+++ b/src/operator/controllers/istiopolicy/policy_manager.go
@@ -402,7 +402,7 @@ func (c *PolicyManagerImpl) createOrUpdatePolicies(
 
 		err = c.client.Create(ctx, newPolicy)
 		if err != nil {
-			if k8serrors.IsConflict(err) {
+			if k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err) {
 				continue
 			}
 			c.recorder.RecordWarningEventf(clientIntents, ReasonCreatingIstioPolicyFailed, "Failed to create Istio policy: %s", err.Error())

--- a/src/shared/reconcilergroup/reconcilergroup.go
+++ b/src/shared/reconcilergroup/reconcilergroup.go
@@ -70,7 +70,7 @@ func (g *Group) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, e
 
 	err = g.ensureFinalizer(ctx, resourceObject)
 	if err != nil {
-		if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) {
+		if k8serrors.IsConflict(err) || k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) || k8serrors.IsAlreadyExists(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, errors.Wrap(err)


### PR DESCRIPTION

### Description

Catch "already exists" error to avoid unnecessary error events

