### PR TITLE
Fix bug where network policies were patched even though the change was a no-op

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/builders_test.go
@@ -123,7 +123,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 		Spec: v1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.OtterizeServiceLabelKey: formattedClient}},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
-			Ingress:     make([]v1.NetworkPolicyIngressRule, 0),
 			Egress:      egressRules,
 		},
 	}
@@ -146,7 +145,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.OtterizeServiceLabelKey: formattedServer}},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
 			Ingress:     ingressRulesNotSVC,
-			Egress:      make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 
@@ -169,7 +167,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKind() {
 			PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
 			Ingress:     ingressRulesToSVC,
-			Egress:      make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 
@@ -429,7 +426,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKindWithKinds() {
 		Spec: v1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{otterizev2alpha1.OtterizeServiceLabelKey: formattedClientWithoutKind, otterizev2alpha1.OtterizeOwnerKindLabelKey: "Deployment"}},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
-			Ingress:     make([]v1.NetworkPolicyIngressRule, 0),
 			Egress:      egressRules,
 		},
 	}
@@ -457,7 +453,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKindWithKinds() {
 			},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
 			Ingress:     ingressRulesNotSVC,
-			Egress:      make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 
@@ -480,7 +475,6 @@ func (s *AllBuildersTestSuite) TestCreateEveryRuleKindWithKinds() {
 			PodSelector: metav1.LabelSelector{MatchLabels: serviceSelector},
 			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
 			Ingress:     ingressRulesToSVC,
-			Egress:      make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
@@ -157,7 +157,6 @@ func networkPolicyDNSEgressTemplate(
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					Ports: []v1.NetworkPolicyPort{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/egress_network_policy_test.go
@@ -411,7 +411,6 @@ func networkPolicyEgressTemplate(
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy_test.go
@@ -126,7 +126,6 @@ func ingressDNSnetworkPolicyIngressTemplate(
 				},
 			},
 			Ingress: ingressRules,
-			Egress:  make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_network_policy_test.go
@@ -569,7 +569,6 @@ func networkPolicyIngressTemplate(
 				},
 			},
 			Ingress: ingressRules,
-			Egress:  make([]v1.NetworkPolicyEgressRule, 0),
 		},
 	}
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -96,7 +96,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -207,7 +206,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForDNS
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -316,7 +314,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyFromDN
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -418,7 +415,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyMultip
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -531,7 +527,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestNetworkPolicyDeletedClean
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -621,7 +616,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestUpdateNetworkPolicy() {
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -732,7 +726,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestRemoveOrphanNetworkPolicy
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -742,7 +735,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestRemoveOrphanNetworkPolicy
 							},
 						},
 					},
-					Ports: []v1.NetworkPolicyPort{},
 				},
 			},
 		},
@@ -765,7 +757,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestRemoveOrphanNetworkPolicy
 					otterizev2alpha1.OtterizeServiceLabelKey: nonExistingClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -775,7 +766,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestRemoveOrphanNetworkPolicy
 							},
 						},
 					},
-					Ports: []v1.NetworkPolicyPort{},
 				},
 			},
 		},
@@ -949,7 +939,6 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestNoIpFoundForOneDNSButFoun
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_egress_network_policy_test.go
@@ -61,7 +61,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) networkPolicyTemplate(
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -322,7 +321,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForA
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{
@@ -472,7 +470,6 @@ func (s *PortEgressNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForA
 					otterizev2alpha1.OtterizeServiceLabelKey: formattedClient,
 				},
 			},
-			Ingress: make([]v1.NetworkPolicyIngressRule, 0),
 			Egress: []v1.NetworkPolicyEgressRule{
 				{
 					To: []v1.NetworkPolicyPeer{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/port_network_policy_test.go
@@ -146,7 +146,6 @@ func (s *PortNetworkPolicyReconcilerTestSuite) networkPolicyTemplate(
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: svcObject.Spec.Selector,
 			},
-			Egress: make([]v1.NetworkPolicyEgressRule, 0),
 			Ingress: []v1.NetworkPolicyIngressRule{
 				{
 					From: []v1.NetworkPolicyPeer{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -354,8 +354,8 @@ func (r *Reconciler) buildSinglePolicy(ep effectivepolicy.ServiceEffectivePolicy
 		Spec: v1.NetworkPolicySpec{
 			PodSelector: podSelector,
 			PolicyTypes: policyTypes,
-			Egress:      egressRules,
-			Ingress:     ingressRules,
+			Egress:      lo.Ternary(len(egressRules) > 0, egressRules, nil),
+			Ingress:     lo.Ternary(len(ingressRules) > 0, ingressRules, nil),
 		},
 	}
 }
@@ -415,7 +415,13 @@ func (r *Reconciler) createNetworkPolicy(ctx context.Context, ep effectivepolicy
 }
 
 func (r *Reconciler) updateExistingPolicy(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy, existingPolicy *v1.NetworkPolicy, newPolicy *v1.NetworkPolicy) error {
-	if reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec) {
+	// PAY ATTENTION: deepEqual is sensitive the differance between nil and empty slice
+	// therefore, we marshal and unmarshal to nullify empty slices of the new policy
+	newPolicyForComparison, err := marshalUnmarshalNetpol(newPolicy)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if reflect.DeepEqual(existingPolicy.Spec, newPolicyForComparison.Spec) {
 		return nil
 	}
 
@@ -424,7 +430,7 @@ func (r *Reconciler) updateExistingPolicy(ctx context.Context, ep effectivepolic
 	policyCopy.Annotations = newPolicy.Annotations
 	policyCopy.Spec = newPolicy.Spec
 
-	err := r.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
+	err = r.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -599,4 +605,17 @@ func matchAccessNetworkPolicy() (labels.Selector, error) {
 		isNotExternalTrafficPolicy,
 		isNotDefaultDenyPolicy,
 	}})
+}
+
+func marshalUnmarshalNetpol(netpol *v1.NetworkPolicy) (v1.NetworkPolicy, error) {
+	data, err := netpol.Marshal()
+	if err != nil {
+		return v1.NetworkPolicy{}, errors.Wrap(err)
+	}
+	newNetpol := v1.NetworkPolicy{}
+	err = newNetpol.Unmarshal(data)
+	if err != nil {
+		return v1.NetworkPolicy{}, errors.Wrap(err)
+	}
+	return newNetpol, nil
 }

--- a/src/shared/reconcilergroup/reconcilergroup.go
+++ b/src/shared/reconcilergroup/reconcilergroup.go
@@ -148,6 +148,8 @@ func (g *Group) runGroup(ctx context.Context, req ctrl.Request, finalErr error, 
 		if err != nil {
 			if finalErr == nil {
 				finalErr = err
+			} else {
+				logrus.WithError(err).Errorf("Error during reconciliation cycle for %T", reconciler)
 			}
 		}
 		if !res.IsZero() {


### PR DESCRIPTION
### Description

Incorrect use of `reflect.deepEqual` function caused false-updates of network policies and spam events.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
