### PR TITLE
Fail health check if intents reconcile starts and doesn't finish within 30s

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/database"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/protected_services"
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
+	"github.com/otterize/intents-operator/src/operator/health"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
@@ -149,6 +150,8 @@ func (r *IntentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	health.UpdateLastReconcileStartTime()
+
 	result, err := r.group.Reconcile(ctx, req)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
@@ -161,6 +164,7 @@ func (r *IntentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.client.Status().Patch(ctx, intentsCopy, client.MergeFrom(intents)); err != nil {
 			return ctrl.Result{}, errors.Wrap(err)
 		}
+		health.UpdateLastReconcileEndTime()
 	}
 
 	return result, nil

--- a/src/operator/health/reconciletime.go
+++ b/src/operator/health/reconciletime.go
@@ -1,0 +1,42 @@
+package health
+
+import (
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+)
+
+var lastReconcileStartTime = time.Time{}
+var lastReconcileEndTime = time.Time{}
+
+func UpdateLastReconcileStartTime() {
+	lastReconcileStartTime = time.Now()
+}
+
+func UpdateLastReconcileEndTime() {
+	lastReconcileEndTime = time.Now()
+}
+
+func ElapsedTimeSinceReconcileStartWithoutSuccessfulReconcile() time.Duration {
+	if lastReconcileStartTime.IsZero() {
+		return time.Duration(0)
+	}
+
+	// Successful reconcile
+	if lastReconcileEndTime.After(lastReconcileStartTime) {
+		return time.Duration(0)
+	}
+
+	return time.Since(lastReconcileStartTime)
+}
+
+func Checker(*http.Request) error {
+	if ElapsedTimeSinceReconcileStartWithoutSuccessfulReconcile() > 30*time.Second {
+		err := errors.Errorf("last reconcile took more than 5 minutes - failing healthcheck")
+		logrus.WithError(err).Error("Health check failed due to long reconcile time - may be normal if just enabled enforcement for the first time on a large cluster, if it recovers")
+		return err
+	}
+
+	return nil
+}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -525,8 +525,6 @@ func main() {
 		logrus.WithError(err).Panic("unable to set up health check")
 	}
 
-	health.Checker(nil)
-
 	logrus.Info("starting manager")
 	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeStarted, 0)
 	telemetrysender.IntentsOperatorRunActiveReporter(signalHandlerCtx)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/kafkaacls"
 	"github.com/otterize/intents-operator/src/operator/controllers/pod_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
+	"github.com/otterize/intents-operator/src/operator/health"
 	"github.com/otterize/intents-operator/src/operator/otterizecrds"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
 	"github.com/otterize/intents-operator/src/shared"
@@ -498,6 +499,7 @@ func main() {
 		healthChecker = mgr.GetWebhookServer().StartedChecker()
 		readyChecker = mgr.GetWebhookServer().StartedChecker()
 	}
+
 	cacheHealthChecker := func(_ *http.Request) error {
 		timeoutCtx, cancel := context.WithTimeout(signalHandlerCtx, 1*time.Second)
 		defer cancel()
@@ -518,6 +520,12 @@ func main() {
 	if err := mgr.AddHealthzCheck("cache", cacheHealthChecker); err != nil {
 		logrus.WithError(err).Panic("unable to set up cache health check")
 	}
+
+	if err := mgr.AddHealthzCheck("intentsReconcile", health.Checker); err != nil {
+		logrus.WithError(err).Panic("unable to set up health check")
+	}
+
+	health.Checker(nil)
 
 	logrus.Info("starting manager")
 	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeStarted, 0)


### PR DESCRIPTION
Prior to this PR, slow reconcile performance due to limited CPU or due to IO (slow network, slow responses from the control plane) could cause the operator to function slowly. If this is slow enough, then the operator is essentially not functioning properly -- if it can't reconcile in a timely manner, in practice it's not reconciling successfully, even if ultimately it does succeed.

The operator will now fail its health check if a reconcile starts and does not complete within 30 seconds, which will cause it to restart and perhaps self-heal the issue, but also indicate to the cluster operators that something is wrong and needs to be investigated, long before the issue materializes some other way.