### PR TITLE
Add failsafe timeouts to various steps when reconciling ServiceEffectivePolicy into network policies, to prevent and recover from pathological failure modes caused by bad network performance

### DIFF
--- a/src/operator/controllers/intents_controller.go
+++ b/src/operator/controllers/intents_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"time"
 )
 
 var intentsLegacyFinalizers = []string{
@@ -149,7 +150,10 @@ func (r *IntentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	result, err := r.group.Reconcile(ctx, req)
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 60*time.Second, errors.Errorf("timeout while reconciling client intents %s", req.NamespacedName))
+	defer cancel()
+
+	result, err := r.group.Reconcile(timeoutCtx, req)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
+	"time"
 )
 
 type EgressRuleBuilder interface {
@@ -107,6 +108,10 @@ func (r *Reconciler) InjectRecorder(recorder record.EventRecorder) {
 
 // ReconcileEffectivePolicies Gets current state of effective policies and returns number of network policies
 func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy) (int, []error) {
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.Errorf("timeout while reconciling already-built list of service effective policies"))
+	defer cancel()
+	ctx = timeoutCtx
+
 	currentPolicies := goset.NewSet[types.NamespacedName]()
 	errorList := make([]error, 0)
 	for _, ep := range eps {
@@ -134,7 +139,11 @@ func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effec
 	}
 
 	// We do it to make sure any excess external allow policies are removed
-	err = r.extNetpolHandler.HandleAllPods(ctx)
+	extTimeoutCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.Errorf("timeout while handling external traffic netpols"))
+	defer cancel()
+	ctx = timeoutCtx
+
+	err = r.extNetpolHandler.HandleAllPods(extTimeoutCtx)
 	if err != nil {
 		return currentPolicies.Len(), []error{errors.Wrap(err)}
 	}
@@ -143,6 +152,9 @@ func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effec
 }
 
 func (r *Reconciler) applyServiceEffectivePolicy(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy) ([]types.NamespacedName, bool, error) {
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 5*time.Second, errors.Errorf("timeout while reconciling single service effective policy"))
+	defer cancel()
+	ctx = timeoutCtx
 	if !r.EnableNetworkPolicyCreation {
 		logrus.Debugf("Network policy creation is disabled, skipping network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
 		if len(ep.Calls) > 0 && len(r.egressRuleBuilders) > 0 {
@@ -445,6 +457,9 @@ func (r *Reconciler) updateExistingPolicy(ctx context.Context, ep effectivepolic
 }
 
 func (r *Reconciler) removeNetworkPoliciesThatShouldNotExist(ctx context.Context, netpolNamesThatShouldExist *goset.Set[types.NamespacedName]) error {
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 5*time.Second, errors.Errorf("timeout while removing orphaned network policies"))
+	defer cancel()
+	ctx = timeoutCtx
 	logrus.Debug("Searching for orphaned network policies")
 	networkPolicyList := &v1.NetworkPolicyList{}
 	selector, err := matchAccessNetworkPolicy()

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -141,7 +141,6 @@ func (r *Reconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effec
 	// We do it to make sure any excess external allow policies are removed
 	extTimeoutCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.Errorf("timeout while handling external traffic netpols"))
 	defer cancel()
-	ctx = timeoutCtx
 
 	err = r.extNetpolHandler.HandleAllPods(extTimeoutCtx)
 	if err != nil {

--- a/src/operator/effectivepolicy/groupreconciler.go
+++ b/src/operator/effectivepolicy/groupreconciler.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 )
 
 type reconciler interface {
@@ -53,6 +54,9 @@ func (g *GroupReconciler) InjectRecorder(recorder record.EventRecorder) {
 }
 
 func (g *GroupReconciler) Reconcile(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 45*time.Second, errors.Errorf("timeout while reconciling service effective policies"))
+	defer cancel()
+	ctx = timeoutCtx
 	eps, err := g.getAllServiceEffectivePolicies(ctx)
 	if err != nil {
 		return errors.Wrap(err)
@@ -71,6 +75,9 @@ func (g *GroupReconciler) Reconcile(ctx context.Context) error {
 }
 
 func (g *GroupReconciler) getAllServiceEffectivePolicies(ctx context.Context) ([]ServiceEffectivePolicy, error) {
+	timeoutCtx, cancel := context.WithTimeoutCause(ctx, 10*time.Second, errors.Errorf("timeout while building list of service effective policies"))
+	defer cancel()
+	ctx = timeoutCtx
 	var intentsList v2alpha1.ClientIntentsList
 
 	err := g.Client.List(ctx, &intentsList)


### PR DESCRIPTION
Prior to this PR, a very long reconcile time would still go through, as long as it didn't fail. This ensures reconciles complete in a timely manner, otherwise they return an error and get requeued with an exponential backoff, allowing other reconciles to go through.