### PR TITLE
Support grouping internet network policies by /24 CIDR to reduce number of IP addresses per policy

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/bugsnag/bugsnag-go/v2 v2.2.0
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/go-test/deep v1.1.1
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.5.0
@@ -96,7 +97,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-test/deep v1.1.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
@@ -9,7 +9,9 @@ import (
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
 	"github.com/samber/lo"
+	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -136,7 +138,11 @@ func getCIDR(ipStr string) (*net.IPNet, error) {
 		if isV6 {
 			cidr = fmt.Sprintf("%s/128", ip)
 		} else {
-			cidr = fmt.Sprintf("%s/16", ip)
+			if viper.GetBool(operatorconfig.EnableGroupInternetIPsByCIDRKey) {
+				cidr = fmt.Sprintf("%s/24", ip)
+			} else {
+				cidr = fmt.Sprintf("%s/32", ip)
+			}
 		}
 	}
 

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy.go
@@ -121,7 +121,6 @@ func (r *InternetEgressRulesBuilder) Build(_ context.Context, ep effectivepolicy
 }
 
 func getIPsAsPeers(ips map[string]struct{}, groupBySubnet bool) ([]v1.NetworkPolicyPeer, error) {
-	peers := make([]v1.NetworkPolicyPeer, 0)
 	cidrSet := goset.NewSet[string]()
 	for ip := range ips {
 		cidr, err := getCIDR(ip, groupBySubnet)
@@ -131,7 +130,7 @@ func getIPsAsPeers(ips map[string]struct{}, groupBySubnet bool) ([]v1.NetworkPol
 		cidrSet.Add(cidr.String())
 	}
 
-	peers = lo.Map(cidrSet.Items(), func(cidrStr string, _ int) v1.NetworkPolicyPeer {
+	peers := lo.Map(cidrSet.Items(), func(cidrStr string, _ int) v1.NetworkPolicyPeer {
 		return v1.NetworkPolicyPeer{
 			IPBlock: &v1.IPBlock{
 				CIDR: cidrStr,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -1013,6 +1013,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestNoIpFoundForAnyDNS() {
 
 func (s *InternetNetworkPolicyReconcilerTestSuite) TestIPsToCIDRConsolidation() {
 	viper.Set(operatorconfig.EnableGroupInternetIPsByCIDRKey, true)
+	viper.Set(operatorconfig.EnableGroupInternetIPsByCIDRPeersLimitKey, 2) // just under len(ips)
 	clientIntentsName := "client-intents"
 	policyName := "test-client-access"
 	serviceName := "test-client"

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -46,7 +46,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 	serviceName := "test-client"
 	clientNamespace := testClientNamespace
 	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
-	ips := []string{"10.1.2.2", "254.3.4.0/24", "2620:0:860:ed1a::1", "2607:f8b0:4001:c05::63/64"}
+	ips := []string{"10.1.2.2", "254.3.4.0/24", "2620:0:860:ed1a::1", "2607:f8b0:4001:c05::/64"}
 
 	namespacedName := types.NamespacedName{
 		Namespace: testClientNamespace,

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -101,7 +101,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 					To: []v1.NetworkPolicyPeer{
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: "10.1.0.0" + "/16",
+								CIDR: "10.1.2.0" + "/24",
 							},
 						},
 						{
@@ -143,8 +143,8 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestIPsToCIDRConsolidation() 
 	clientNamespace := testClientNamespace
 	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
 	dns := "wiki.otters.com"
-	ips := []string{"10.1.2.4", "10.1.2.5", "10.1.2.6", "10.1.10.10", "10.1.200.200"}
-	expectedCIDRs := []string{"10.1.0.0"}
+	ips := []string{"10.1.2.4", "10.1.2.5", "10.1.2.6", "10.1.200.200"}
+	expectedCIDRs := []string{"10.1.2.0", "10.1.200.0"}
 
 	namespacedName := types.NamespacedName{
 		Namespace: testClientNamespace,
@@ -212,7 +212,12 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestIPsToCIDRConsolidation() 
 					To: []v1.NetworkPolicyPeer{
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: expectedCIDRs[0] + "/16",
+								CIDR: expectedCIDRs[0] + "/24",
+							},
+						},
+						{
+							IPBlock: &v1.IPBlock{
+								CIDR: expectedCIDRs[1] + "/24",
 							},
 						},
 					},

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -44,7 +44,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 	serviceName := "test-client"
 	clientNamespace := testClientNamespace
 	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
-	ips := []string{"10.1.2.2", "254.3.4.0/24", "2620:0:860:ed1a::1", "2607:f8b0:4001:c05::63/64"}
+	ips := []string{"10.1.2.2", "254.3.4.0/24", "2620:0:860:ed1a::1", "2607:f8b0:4001:c05::/64"}
 
 	namespacedName := types.NamespacedName{
 		Namespace: testClientNamespace,
@@ -101,7 +101,7 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 					To: []v1.NetworkPolicyPeer{
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: ips[0] + "/32",
+								CIDR: "10.1.0.0" + "/16",
 							},
 						},
 						{
@@ -136,14 +136,15 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicySingle
 	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
 }
 
-func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForDNS() {
+func (s *InternetNetworkPolicyReconcilerTestSuite) TestIPsToCIDRConsolidation() {
 	clientIntentsName := "client-intents"
 	policyName := "test-client-access"
 	serviceName := "test-client"
 	clientNamespace := testClientNamespace
 	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
 	dns := "wiki.otters.com"
-	ips := []string{"10.1.2.2", "254.3.4.0", "2620:0:860:ed1a::1"}
+	ips := []string{"10.1.2.4", "10.1.2.5", "10.1.2.6", "10.1.10.10", "10.1.200.200"}
+	expectedCIDRs := []string{"10.1.0.0"}
 
 	namespacedName := types.NamespacedName{
 		Namespace: testClientNamespace,
@@ -211,12 +212,108 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForDNS
 					To: []v1.NetworkPolicyPeer{
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: ips[0] + "/32",
+								CIDR: expectedCIDRs[0] + "/16",
+							},
+						},
+					},
+					Ports: []v1.NetworkPolicyPort{},
+				},
+			},
+		},
+	}
+	s.Client.EXPECT().Create(gomock.Any(), gomock.Eq(newPolicy))
+	s.externalNetpolHandler.EXPECT().HandlePodsByLabelSelector(gomock.Any(), gomock.Any(), gomock.Any())
+
+	s.ignoreRemoveOrphan()
+
+	res, err := s.EPIntentsReconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
+}
+
+func (s *InternetNetworkPolicyReconcilerTestSuite) TestCreateNetworkPolicyForDNS() {
+	clientIntentsName := "client-intents"
+	policyName := "test-client-access"
+	serviceName := "test-client"
+	clientNamespace := testClientNamespace
+	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
+	dns := "wiki.otters.com"
+	ips := []string{"10.1.2.2", "254.3.4.0", "2620:0:860:ed1a::1"}
+	expectedCIDRs := []string{"10.1.0.0", "254.3.0.0"}
+
+	namespacedName := types.NamespacedName{
+		Namespace: testClientNamespace,
+		Name:      clientIntentsName,
+	}
+	req := ctrl.Request{
+		NamespacedName: namespacedName,
+	}
+
+	intentsSpec := &otterizev2alpha1.IntentsSpec{
+		Workload: otterizev2alpha1.Workload{Name: serviceName},
+		Targets: []otterizev2alpha1.Target{
+			{
+				Internet: &otterizev2alpha1.Internet{
+					Domains: []string{dns},
+				},
+			},
+		},
+	}
+
+	intentsStatus := otterizev2alpha1.IntentsStatus{
+		ResolvedIPs: []otterizev2alpha1.ResolvedIPs{
+			{
+				DNS: dns,
+				IPs: ips,
+			},
+		},
+	}
+	clientIntents := otterizev2alpha1.ClientIntents{
+		Spec:   intentsSpec,
+		Status: intentsStatus,
+	}
+	clientIntents.Namespace = clientNamespace
+	clientIntents.Name = clientIntentsName
+	s.expectGetAllEffectivePolicies([]otterizev2alpha1.ClientIntents{clientIntents})
+
+	// Search for existing NetworkPolicy
+	emptyNetworkPolicy := &v1.NetworkPolicy{}
+	networkPolicyNamespacedName := types.NamespacedName{
+		Namespace: clientNamespace,
+		Name:      policyName,
+	}
+	s.Client.EXPECT().Get(gomock.Any(), networkPolicyNamespacedName, gomock.Eq(emptyNetworkPolicy)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, networkPolicy *v1.NetworkPolicy, options ...client.ListOption) error {
+			return apierrors.NewNotFound(v1.Resource("networkpolicy"), name.Name)
+		})
+
+	newPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: clientNamespace,
+			Labels: map[string]string{
+				otterizev2alpha1.OtterizeNetworkPolicy: formattedTargetClient,
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
+				},
+			},
+			Egress: []v1.NetworkPolicyEgressRule{
+				{
+					To: []v1.NetworkPolicyPeer{
+						{
+							IPBlock: &v1.IPBlock{
+								CIDR: expectedCIDRs[0] + "/16",
 							},
 						},
 						{
 							IPBlock: &v1.IPBlock{
-								CIDR: ips[1] + "/32",
+								CIDR: expectedCIDRs[1] + "/16",
 							},
 						},
 						{

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/internet_network_policy_test.go
@@ -5,6 +5,8 @@ import (
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/networking/v1"
@@ -1007,6 +1009,103 @@ func (s *InternetNetworkPolicyReconcilerTestSuite) TestNoIpFoundForAnyDNS() {
 	s.Require().NoError(err)
 	s.Require().Empty(res)
 	s.ExpectEvent(consts.ReasonInternetEgressNetworkPolicyCreationWaitingUnresolvedDNS)
+}
+
+func (s *InternetNetworkPolicyReconcilerTestSuite) TestIPsToCIDRConsolidation() {
+	viper.Set(operatorconfig.EnableGroupInternetIPsByCIDRKey, true)
+	clientIntentsName := "client-intents"
+	policyName := "test-client-access"
+	serviceName := "test-client"
+	clientNamespace := testClientNamespace
+	formattedTargetClient := "test-client-test-client-namespac-edb3a2"
+	dns := "wiki.otters.com"
+	ips := []string{"10.1.2.4", "10.1.2.5", "10.1.2.6"}
+	expectedCIDRs := []string{"10.1.2.0"}
+
+	namespacedName := types.NamespacedName{
+		Namespace: testClientNamespace,
+		Name:      clientIntentsName,
+	}
+	req := ctrl.Request{
+		NamespacedName: namespacedName,
+	}
+
+	intentsSpec := &otterizev2alpha1.IntentsSpec{
+		Workload: otterizev2alpha1.Workload{Name: serviceName},
+		Targets: []otterizev2alpha1.Target{
+			{
+				Internet: &otterizev2alpha1.Internet{
+					Domains: []string{dns},
+				},
+			},
+		},
+	}
+
+	intentsStatus := otterizev2alpha1.IntentsStatus{
+		ResolvedIPs: []otterizev2alpha1.ResolvedIPs{
+			{
+				DNS: dns,
+				IPs: ips,
+			},
+		},
+	}
+	clientIntents := otterizev2alpha1.ClientIntents{
+		Spec:   intentsSpec,
+		Status: intentsStatus,
+	}
+	clientIntents.Namespace = clientNamespace
+	clientIntents.Name = clientIntentsName
+	s.expectGetAllEffectivePolicies([]otterizev2alpha1.ClientIntents{clientIntents})
+
+	// Search for existing NetworkPolicy
+	emptyNetworkPolicy := &v1.NetworkPolicy{}
+	networkPolicyNamespacedName := types.NamespacedName{
+		Namespace: clientNamespace,
+		Name:      policyName,
+	}
+	s.Client.EXPECT().Get(gomock.Any(), networkPolicyNamespacedName, gomock.Eq(emptyNetworkPolicy)).DoAndReturn(
+		func(ctx context.Context, name types.NamespacedName, networkPolicy *v1.NetworkPolicy, options ...client.ListOption) error {
+			return apierrors.NewNotFound(v1.Resource("networkpolicy"), name.Name)
+		})
+
+	newPolicy := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: clientNamespace,
+			Labels: map[string]string{
+				otterizev2alpha1.OtterizeNetworkPolicy: formattedTargetClient,
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeEgress},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					otterizev2alpha1.OtterizeServiceLabelKey: formattedTargetClient,
+				},
+			},
+			Egress: []v1.NetworkPolicyEgressRule{
+				{
+					To: []v1.NetworkPolicyPeer{
+						{
+							IPBlock: &v1.IPBlock{
+								CIDR: expectedCIDRs[0] + "/24",
+							},
+						},
+					},
+					Ports: []v1.NetworkPolicyPort{},
+				},
+			},
+		},
+	}
+	s.Client.EXPECT().Create(gomock.Any(), gomock.Eq(newPolicy))
+	s.externalNetpolHandler.EXPECT().HandlePodsByLabelSelector(gomock.Any(), gomock.Any(), gomock.Any())
+
+	s.ignoreRemoveOrphan()
+
+	res, err := s.EPIntentsReconciler.Reconcile(context.Background(), req)
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+	s.ExpectEvent(consts.ReasonCreatedEgressNetworkPolicies)
 }
 
 func TestInternetNetworkPolicyReconcilerTestSuite(t *testing.T) {

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -33,39 +33,41 @@ const (
 	DisableWebhookServerKey     = "disable-webhook-server" // Disable webhook validator server
 	DisableWebhookServerDefault = false
 
-	IntentsOperatorPodNameKey                 = "pod-name"
-	IntentsOperatorPodNamespaceKey            = "pod-namespace"
-	EnvPrefix                                 = "OTTERIZE"
-	RetryDelayTimeKey                         = "retry-delay-time" // Default retry delay time for retrying failed requests
-	RetryDelayTimeDefault                     = 5 * time.Second
-	DebugLogKey                               = "debug" // Whether to enable debug logging
-	DebugLogDefault                           = false
-	EnableEgressAutoallowDNSTrafficKey        = "enable-egress-autoallow-dns-traffic" // Whether to automatically allow DNS traffic in egress network policies
-	EnableEgressAutoallowDNSTrafficDefault    = true
-	EnableGroupInternetIPsByCIDRKey           = "enable-group-internet-ips-by-cidr"
-	EnableGroupInternetIPsByCIDRDefault       = false
-	EnableAWSRolesAnywhereKey                 = "enable-aws-iam-rolesanywhere"
-	EnableAWSRolesAnywhereDefault             = false
-	AzureSubscriptionIDKey                    = "azure-subscription-id"
-	AzureResourceGroupKey                     = "azure-resource-group"
-	AzureAKSClusterNameKey                    = "azure-aks-cluster-name"
-	EKSClusterNameOverrideKey                 = "eks-cluster-name-override"
-	AWSRolesAnywhereClusterNameKey            = "rolesanywhere-cluster-name"
-	AWSRolesAnywhereCertDirKey                = "rolesanywhere-cert-dir"
-	AWSRolesAnywhereCertDirDefault            = "/aws-config"
-	AWSRolesAnywherePrivKeyFilenameKey        = "rolesanywhere-priv-key-filename"
-	AWSRolesAnywhereCertFilenameKey           = "rolesanywhere-cert-filename"
-	AWSRolesAnywherePrivKeyFilenameDefault    = "tls.key"
-	AWSRolesAnywhereCertFilenameDefault       = "tls.crt"
-	TelemetryErrorsAPIKeyKey                  = "telemetry-errors-api-key"
-	TelemetryErrorsAPIKeyDefault              = "60a78208a2b4fe714ef9fb3d3fdc0714"
-	AWSAccountsKey                            = "aws"
-	IngressControllerALBExemptKey             = "ingress-controllers-exempt-alb"
-	IngressControllerALBExemptDefault         = false
-	IngressControllerConfigKey                = "ingressControllers"
-	SeparateNetpolsForIngressAndEgress        = "separate-netpols-for-ingress-and-egress"
-	SeparateNetpolsForIngressAndEgressDefault = false
-	ExternallyManagedPolicyWorkloadsKey       = "externallyManagedPolicyWorkloads"
+	IntentsOperatorPodNameKey                     = "pod-name"
+	IntentsOperatorPodNamespaceKey                = "pod-namespace"
+	EnvPrefix                                     = "OTTERIZE"
+	RetryDelayTimeKey                             = "retry-delay-time" // Default retry delay time for retrying failed requests
+	RetryDelayTimeDefault                         = 5 * time.Second
+	DebugLogKey                                   = "debug" // Whether to enable debug logging
+	DebugLogDefault                               = false
+	EnableEgressAutoallowDNSTrafficKey            = "enable-egress-autoallow-dns-traffic" // Whether to automatically allow DNS traffic in egress network policies
+	EnableEgressAutoallowDNSTrafficDefault        = true
+	EnableGroupInternetIPsByCIDRKey               = "enable-group-internet-ips-by-cidr"
+	EnableGroupInternetIPsByCIDRDefault           = false
+	EnableGroupInternetIPsByCIDRPeersLimitKey     = "enable-group-by-cidr-peers-limit"
+	EnableGroupInternetIPsByCIDRPeersLimitDefault = 50
+	EnableAWSRolesAnywhereKey                     = "enable-aws-iam-rolesanywhere"
+	EnableAWSRolesAnywhereDefault                 = false
+	AzureSubscriptionIDKey                        = "azure-subscription-id"
+	AzureResourceGroupKey                         = "azure-resource-group"
+	AzureAKSClusterNameKey                        = "azure-aks-cluster-name"
+	EKSClusterNameOverrideKey                     = "eks-cluster-name-override"
+	AWSRolesAnywhereClusterNameKey                = "rolesanywhere-cluster-name"
+	AWSRolesAnywhereCertDirKey                    = "rolesanywhere-cert-dir"
+	AWSRolesAnywhereCertDirDefault                = "/aws-config"
+	AWSRolesAnywherePrivKeyFilenameKey            = "rolesanywhere-priv-key-filename"
+	AWSRolesAnywhereCertFilenameKey               = "rolesanywhere-cert-filename"
+	AWSRolesAnywherePrivKeyFilenameDefault        = "tls.key"
+	AWSRolesAnywhereCertFilenameDefault           = "tls.crt"
+	TelemetryErrorsAPIKeyKey                      = "telemetry-errors-api-key"
+	TelemetryErrorsAPIKeyDefault                  = "60a78208a2b4fe714ef9fb3d3fdc0714"
+	AWSAccountsKey                                = "aws"
+	IngressControllerALBExemptKey                 = "ingress-controllers-exempt-alb"
+	IngressControllerALBExemptDefault             = false
+	IngressControllerConfigKey                    = "ingressControllers"
+	SeparateNetpolsForIngressAndEgress            = "separate-netpols-for-ingress-and-egress"
+	SeparateNetpolsForIngressAndEgressDefault     = false
+	ExternallyManagedPolicyWorkloadsKey           = "externallyManagedPolicyWorkloads"
 )
 
 func init() {
@@ -89,6 +91,7 @@ func init() {
 	viper.SetDefault(DebugLogKey, DebugLogDefault)
 	viper.SetDefault(SeparateNetpolsForIngressAndEgress, SeparateNetpolsForIngressAndEgressDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
+	viper.SetDefault(EnableGroupInternetIPsByCIDRPeersLimitKey, EnableGroupInternetIPsByCIDRPeersLimitDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -42,6 +42,8 @@ const (
 	DebugLogDefault                           = false
 	EnableEgressAutoallowDNSTrafficKey        = "enable-egress-autoallow-dns-traffic" // Whether to automatically allow DNS traffic in egress network policies
 	EnableEgressAutoallowDNSTrafficDefault    = true
+	EnableGroupInternetIPsByCIDRKey           = "enable-group-internet-ips-by-cidr"
+	EnableGroupInternetIPsByCIDRDefault       = false
 	EnableAWSRolesAnywhereKey                 = "enable-aws-iam-rolesanywhere"
 	EnableAWSRolesAnywhereDefault             = false
 	AzureSubscriptionIDKey                    = "azure-subscription-id"
@@ -86,6 +88,7 @@ func init() {
 	viper.SetDefault(RetryDelayTimeKey, RetryDelayTimeDefault)
 	viper.SetDefault(DebugLogKey, DebugLogDefault)
 	viper.SetDefault(SeparateNetpolsForIngressAndEgress, SeparateNetpolsForIngressAndEgressDefault)
+	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
### Description
ClientIntents with DNS names are eventually translated into Egress network policies with IP addresses. The number of IPs per policy could get quite big, causing unexpected behavior in multiple CNIs. This change adds a feature flag for consolidating IPs to `/24` networks to reduce the number of addresses per policy.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality