### PR TITLE
Fix wrong handling of k8s errors causing wrong handling of applying netpols on non-existing namespaces

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -369,8 +369,10 @@ func (r *NetworkPolicyHandler) handleEndpointsWithIngressList(ctx context.Contex
 	foundOtterizeNetpolsAffectingPods := false
 	for _, address := range addresses {
 		pod, err := r.getAffectedPod(ctx, address)
-		if k8serrors.IsNotFound(errors.Unwrap(err)) {
-			continue
+		if k8sErr := &(k8serrors.StatusError{}); errors.As(err, &k8sErr) {
+			if k8serrors.IsNotFound(k8sErr) {
+				continue
+			}
 		}
 
 		if err != nil {

--- a/src/operator/controllers/intents_reconcilers/istio_policy.go
+++ b/src/operator/controllers/intents_reconcilers/istio_policy.go
@@ -124,9 +124,10 @@ func (r *IstioPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	err = r.policyManager.Create(ctx, intents, clientServiceAccountName)
 	if err != nil {
-		errUnwrap := errors.Unwrap(err)
-		if k8serrors.IsConflict(errUnwrap) || k8serrors.IsAlreadyExists(errUnwrap) {
-			return ctrl.Result{Requeue: true}, nil
+		if k8sErr := &(k8serrors.StatusError{}); errors.As(err, &k8sErr) {
+			if k8serrors.IsConflict(k8sErr) || k8serrors.IsAlreadyExists(k8sErr) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 		return ctrl.Result{}, errors.Wrap(err)
 	}

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -578,22 +578,23 @@ func (r *Reconciler) handleExistingPolicyRetry(ctx context.Context, ep effective
 
 func (r *Reconciler) handleCreationErrors(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy, netpol *v1.NetworkPolicy, err error) error {
 	errStr := err.Error()
-	errUnwrap := errors.Unwrap(err)
-	if k8serrors.IsAlreadyExists(errUnwrap) {
-		// Ideally we would just return {Requeue: true} but it is not possible without a mini-refactor
-		return r.handleExistingPolicyRetry(ctx, ep, netpol)
-	}
+	if k8sErr := &(k8serrors.StatusError{}); errors.As(err, &k8sErr) {
+		if k8serrors.IsAlreadyExists(k8sErr) {
+			// Ideally we would just return {Requeue: true} but it is not possible without a mini-refactor
+			return r.handleExistingPolicyRetry(ctx, ep, netpol)
+		}
 
-	if k8serrors.IsForbidden(errUnwrap) && strings.Contains(errStr, "is being terminated") {
-		// Namespace is being deleted, nothing to do further
-		logrus.Debugf("Namespace %s is being terminated, ignoring api server error", netpol.Namespace)
-		return nil
-	}
+		if k8serrors.IsForbidden(k8sErr) && strings.Contains(errStr, "is being terminated") {
+			// Namespace is being deleted, nothing to do further
+			logrus.Debugf("Namespace %s is being terminated, ignoring api server error", netpol.Namespace)
+			return nil
+		}
 
-	if k8serrors.IsNotFound(errUnwrap) && strings.Contains(errStr, netpol.Namespace) {
-		// Namespace was deleted since we started .Create() logic, nothing to do further
-		logrus.Debugf("Namespace %s was deleted, ignoring api server error", netpol.Namespace)
-		return nil
+		if k8serrors.IsNotFound(k8sErr) && strings.Contains(errStr, netpol.Namespace) {
+			// Namespace was deleted since we started .Create() logic, nothing to do further
+			logrus.Debugf("Namespace %s was deleted, ignoring api server error", netpol.Namespace)
+			return nil
+		}
 	}
 
 	return errors.Wrap(err)

--- a/src/shared/reconcilergroup/reconcilergroup.go
+++ b/src/shared/reconcilergroup/reconcilergroup.go
@@ -172,8 +172,11 @@ func (g *Group) InjectRecorder(recorder record.EventRecorder) {
 }
 
 func isKubernetesRaceRelatedError(err error) bool {
-	errUnwrap := errors.Unwrap(err)
-	return k8serrors.IsConflict(errUnwrap) || k8serrors.IsNotFound(errUnwrap) || k8serrors.IsForbidden(errUnwrap) || k8serrors.IsAlreadyExists(errUnwrap)
+	if k8sErr := &(k8serrors.StatusError{}); errors.As(err, &k8sErr) {
+		return k8serrors.IsConflict(k8sErr) || k8serrors.IsNotFound(k8sErr) || k8serrors.IsForbidden(k8sErr) || k8serrors.IsAlreadyExists(k8sErr)
+	}
+
+	return false
 }
 
 func shortestRequeue(a, b reconcile.Result) reconcile.Result {


### PR DESCRIPTION
### Description
This PR is a follow-up on a previous fix, made in https://github.com/otterize/intents-operator/pull/502. 
In some cases, where the inspected error was not wrapped using `errors.Wrap`, the code in the previous PR was wrongly Unwrapping it, causing the intents-operator missing common cases such as namespace not exist when creating network policies, and reporting them as errors. 
This is resolved by using `errors.As` rather than `errors.Unwrap`. 

### References
https://github.com/otterize/intents-operator/pull/502

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
