### PR TITLE
Bugfix: solve "Invalid signature" error on AWS IAM Roles Anywhere

### DIFF
--- a/src/shared/awsagent/rolesanywhere_creds/credentials_provider.go
+++ b/src/shared/awsagent/rolesanywhere_creds/credentials_provider.go
@@ -57,6 +57,12 @@ func getCredentials(keyPath string, certPath string, roleARN string, account ope
 
 	leaf := certs[0]
 	intermediates := certs[1:]
+	if len(intermediates) == 0 {
+		// awssh.CreateSignFunction compares the intermediates slice to nil to check if the 'X-Amz-X509-Chain' header should be added to the request,
+		// and starting at some point, the AWS API started rejecting requests with an existing-yet-empty 'X-Amz-X509-Chain' header.
+		// To avoid this, we set the intermediates slice to nil if it's empty.
+		intermediates = nil
+	}
 
 	privKey, err := os.ReadFile(keyPath)
 	if err != nil {


### PR DESCRIPTION
### Description

This fixes a bug in AWS IAM Roles Anywhere, caused due to a regression in AWS API. 
Prior to this fix, an empty `X-Amz-X509-Chain` header was added to AWS Roles Anywhere `CreateSession` request. This recently started failing the request, due to a change in the AWS API. 
This happens when the slice of intermediate CAs is empty. However, by passing a `nil` slice into the AWS roles anywhere signing helper, we make it avoid adding the empty header, which solves the issue. 

### References

- Relevant line in rolesanywhere aws_signing_helper: https://github.com/aws/rolesanywhere-credential-helper/blob/v1.0.3/aws_signing_helper/signer.go#L213

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
