### PR TITLE
Align error type check when deleting a user assigned identity

### DIFF
--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -102,7 +102,7 @@ func (a *Agent) DeleteUserAssignedIdentity(ctx context.Context, namespace string
 	// Delete roles assigned to the identity
 	identity, err := a.FindUserAssignedIdentity(ctx, namespace, accountName)
 	if err != nil {
-		if azureerrors.IsNotFoundErr(err) {
+		if errors.Is(err, ErrUserIdentityNotFound) {
 			return nil
 		}
 		return errors.Wrap(err)


### PR DESCRIPTION
### Description

The error type returned by "FindUserAssignedIdentity" is swapped from azure error to a sentinel error. align the calling function error checking to the sentinel error.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
