### PR TITLE
Pass version down to error reporter code

### DIFF
--- a/src/shared/telemetries/errorreporter/errorreporter.go
+++ b/src/shared/telemetries/errorreporter/errorreporter.go
@@ -15,7 +15,7 @@ func Init(componentType telemetriesgql.TelemetryComponentType, version string) {
 		logrus.Info("error reporting disabled")
 	}
 
-	initSender(componentType)
+	initSender(componentType, version)
 
 	hook, err := NewErrorReportingHook()
 	if err != nil {

--- a/src/shared/telemetries/errorreporter/errorsender.go
+++ b/src/shared/telemetries/errorreporter/errorsender.go
@@ -43,7 +43,7 @@ func (s *ErrorSender) SendSync(errs []*telemetriesgql.Error) error {
 	return nil
 }
 
-func New(componentType telemetriesgql.TelemetryComponentType) *ErrorSender {
+func New(componentType telemetriesgql.TelemetryComponentType, version string) *ErrorSender {
 	enabled := telemetriesconfig.IsErrorTelemetryEnabled()
 	maxBatchSize := viper.GetInt(telemetriesconfig.TelemetryMaxBatchSizeKey)
 	interval := viper.GetInt(telemetriesconfig.TelemetryIntervalKey)
@@ -52,7 +52,7 @@ func New(componentType telemetriesgql.TelemetryComponentType) *ErrorSender {
 	sender := &ErrorSender{
 		gqlClient: gqlClient,
 		enabled:   enabled,
-		component: currentComponent(componentType),
+		component: currentComponent(componentType, version),
 	}
 
 	sender.errorBatcher = basicbatch.NewBatcher(sender.SendSync, time.Duration(interval)*time.Second, maxBatchSize, 5000)

--- a/src/shared/telemetries/errorreporter/global_sender.go
+++ b/src/shared/telemetries/errorreporter/global_sender.go
@@ -7,7 +7,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/otterizecloud/otterizecloudclient"
 	"github.com/otterize/intents-operator/src/shared/telemetries/componentinfo"
 	"github.com/otterize/intents-operator/src/shared/telemetries/telemetriesgql"
-	"github.com/otterize/intents-operator/src/shared/version"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -83,18 +82,18 @@ func sendErrorSync(err *bugsnagerrors.Error, metadata map[string]string) error {
 	return nil
 }
 
-func currentComponent(componentType telemetriesgql.TelemetryComponentType) telemetriesgql.Component {
+func currentComponent(componentType telemetriesgql.TelemetryComponentType, version string) telemetriesgql.Component {
 	return telemetriesgql.Component{
 		CloudClientId:       viper.GetString(otterizecloudclient.ApiClientIdKey),
 		ComponentType:       componentType,
 		ComponentInstanceId: componentinfo.GlobalComponentInstanceId(),
 		ContextId:           componentinfo.GlobalContextId(),
-		Version:             version.Version(),
+		Version:             version,
 	}
 }
 
-func initSender(componentType telemetriesgql.TelemetryComponentType) {
-	sender = New(componentType)
+func initSender(componentType telemetriesgql.TelemetryComponentType, version string) {
+	sender = New(componentType, version)
 	if componentinfo.IsRunningUnderTest() {
 		logrus.Infof("Disabling error sender because this is a test")
 		sender.enabled = false


### PR DESCRIPTION
### Description

Pass version string in shared code instead of loading from the file system - this fails on other applications that don't have the same file structure.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
