### PR TITLE
Add support for Azure cross-subscription access

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -330,7 +330,7 @@ func (a *Agent) ensureCustomRolesForIntents(ctx context.Context, userAssignedIde
 	a.roleMutex.Lock()
 	defer a.roleMutex.Unlock()
 
-	existingRoleAssignments, err := a.ListRoleAssignments(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -373,9 +373,9 @@ func (a *Agent) ensureCustomRoleForIntent(ctx context.Context, userAssignedIdent
 	}
 
 	customRoleName := a.GenerateCustomRoleName(userAssignedIdentity, scope)
-	role, found := a.FindCustomRoleByName(ctx, customRoleName)
+	role, found := a.FindCustomRoleByName(ctx, scope, customRoleName)
 	if found {
-		err := a.UpdateCustomRole(ctx, role, actions, dataActions)
+		err := a.UpdateCustomRole(ctx, scope, role, actions, dataActions)
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -95,7 +95,7 @@ func (a *Agent) ensureRoleAssignmentsForIntents(ctx context.Context, userAssigne
 	a.assignmentMutex.Lock()
 	defer a.assignmentMutex.Unlock()
 
-	existingRoleAssignments, err := a.ListRoleAssignments(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -199,7 +199,7 @@ func (a *Agent) DeleteRolePolicyFromIntents(ctx context.Context, intents otteriz
 		return errors.Wrap(err)
 	}
 
-	existingRoleAssignments, err := a.ListRoleAssignments(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
@@ -254,9 +254,10 @@ func (s *AzureAgentPoliciesCustomRolesSuite) TestAddRolePolicyFromIntents_Custom
 			s.expectGetUserAssignedIdentityReturnsClientID(clientId)
 
 			s.expectListKeyVaultsReturnsEmpty()
-			s.expectListSubscriptionsReturnsPager()
 
 			// Two calls - one from custom roles and one from backwards compatibility to built-in roles
+			s.expectListSubscriptionsReturnsPager()
+			s.expectListSubscriptionsReturnsPager()
 			s.expectListRoleAssignmentsReturnsEmpty()
 			s.expectListRoleAssignmentsReturnsEmpty()
 

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/google/uuid"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/shared/azureagent"
 	mock_azureagent "github.com/otterize/intents-operator/src/shared/azureagent/mocks"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +43,8 @@ type AzureAgentPoliciesCustomRolesSuite struct {
 	mockRoleAssignmentsClient              *mock_azureagent.MockAzureARMAuthorizationRoleAssignmentsClient
 	mockVaultsClient                       *mock_azureagent.MockAzureARMKeyVaultVaultsClient
 
+	subscriptionToRoleAssignmentsClient map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient
+
 	agent *Agent
 }
 
@@ -50,6 +54,20 @@ func (s *AzureAgentPoliciesCustomRolesSuite) expectGetByIDReturnsResource(scope 
 			ID: &scope,
 		},
 	}, nil)
+}
+
+func (s *AzureAgentPoliciesCustomRolesSuite) expectListSubscriptionsReturnsPager() {
+	s.mockSubscriptionsClient.EXPECT().NewListPager(nil).Return(azureagent.NewListPager[armsubscriptions.ClientListResponse](
+		armsubscriptions.ClientListResponse{
+			SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+				Value: []*armsubscriptions.Subscription{
+					{
+						SubscriptionID: lo.ToPtr(testSubscriptionID),
+					},
+				},
+			},
+		},
+	))
 }
 
 func (s *AzureAgentPoliciesCustomRolesSuite) expectListRoleDefinitionsReturnsPager(roles []*armauthorization.RoleDefinition) {
@@ -117,6 +135,9 @@ func (s *AzureAgentPoliciesCustomRolesSuite) SetupTest() {
 	s.mockRoleAssignmentsClient = mock_azureagent.NewMockAzureARMAuthorizationRoleAssignmentsClient(controller)
 	s.mockVaultsClient = mock_azureagent.NewMockAzureARMKeyVaultVaultsClient(controller)
 
+	s.subscriptionToRoleAssignmentsClient = make(map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient)
+	s.subscriptionToRoleAssignmentsClient[testSubscriptionID] = s.mockRoleAssignmentsClient
+
 	s.agent = &Agent{
 		azureagent.NewAzureAgentFromClients(
 			azureagent.Config{
@@ -137,6 +158,7 @@ func (s *AzureAgentPoliciesCustomRolesSuite) SetupTest() {
 			s.mockRoleDefinitionsClient,
 			s.mockRoleAssignmentsClient,
 			s.mockVaultsClient,
+			s.subscriptionToRoleAssignmentsClient,
 		),
 		sync.Mutex{},
 		sync.Mutex{},
@@ -232,6 +254,7 @@ func (s *AzureAgentPoliciesCustomRolesSuite) TestAddRolePolicyFromIntents_Custom
 			s.expectGetUserAssignedIdentityReturnsClientID(clientId)
 
 			s.expectListKeyVaultsReturnsEmpty()
+			s.expectListSubscriptionsReturnsPager()
 
 			// Two calls - one from custom roles and one from backwards compatibility to built-in roles
 			s.expectListRoleAssignmentsReturnsEmpty()

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_identities_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_identities_test.go
@@ -27,6 +27,8 @@ type AzureAgentIdentitiesSuite struct {
 	mockRoleAssignmentsClient              *mock_azureagent.MockAzureARMAuthorizationRoleAssignmentsClient
 	mockVaultsClient                       *mock_azureagent.MockAzureARMKeyVaultVaultsClient
 
+	subscriptionToRoleAssignmentsClient map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient
+
 	agent *Agent
 }
 
@@ -42,6 +44,9 @@ func (s *AzureAgentIdentitiesSuite) SetupTest() {
 	s.mockRoleDefinitionsClient = mock_azureagent.NewMockAzureARMAuthorizationRoleDefinitionsClient(controller)
 	s.mockRoleAssignmentsClient = mock_azureagent.NewMockAzureARMAuthorizationRoleAssignmentsClient(controller)
 	s.mockVaultsClient = mock_azureagent.NewMockAzureARMKeyVaultVaultsClient(controller)
+
+	s.subscriptionToRoleAssignmentsClient = make(map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient)
+	s.subscriptionToRoleAssignmentsClient[testSubscriptionID] = s.mockRoleAssignmentsClient
 
 	s.agent = &Agent{
 		azureagent.NewAzureAgentFromClients(
@@ -63,6 +68,7 @@ func (s *AzureAgentIdentitiesSuite) SetupTest() {
 			s.mockRoleDefinitionsClient,
 			s.mockRoleAssignmentsClient,
 			s.mockVaultsClient,
+			s.subscriptionToRoleAssignmentsClient,
 		),
 		sync.Mutex{},
 		sync.Mutex{},

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_keyvault_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_keyvault_test.go
@@ -247,9 +247,9 @@ func (s *AzureAgentPoliciesKeyVaultSuite) TestAddRolePolicyFromIntents_AzureKeyV
 			clientId := uuid.NewString()
 			s.expectGetUserAssignedIdentityReturnsClientID(clientId)
 
-			s.expectListSubscriptionsReturnsPager()
-
 			// Two calls - one from custom roles and one from backwards compatibility to built-in roles
+			s.expectListSubscriptionsReturnsPager()
+			s.expectListSubscriptionsReturnsPager()
 			s.expectListRoleAssignmentsReturnsEmpty()
 			s.expectListRoleAssignmentsReturnsEmpty()
 
@@ -305,6 +305,8 @@ func (s *AzureAgentPoliciesKeyVaultSuite) TestDeleteRolePolicyFromIntents_Clears
 	s.expectGetUserAssignedIdentityReturnsClientID(clientId)
 	s.expectListRoleAssignmentsReturnsEmpty()
 	s.expectListKeyVaultsReturnsNames(testKeyVaultName)
+
+	s.expectListSubscriptionsReturnsPager()
 
 	s.expectGetKeyVaultReturnsAccessPolicies(testKeyVaultName, []*armkeyvault.AccessPolicyEntry{
 		{

--- a/src/shared/azureagent/agent.go
+++ b/src/shared/azureagent/agent.go
@@ -170,6 +170,8 @@ func (a *Agent) AppliesOnPod(pod *corev1.Pod) bool {
 	return pod.Labels != nil && pod.Labels[AzureApplyOnPodLabel] == "true"
 }
 
+// GetRoleAssignmentClientForSubscription returns a role assignments client for the given subscription ID.
+// In order to support multiple subscriptions, we need to create a role assignments client for each subscription.
 func (a *Agent) GetRoleAssignmentClientForSubscription(subId string) (client AzureARMAuthorizationRoleAssignmentsClient, err error) {
 	client, ok := a.subscriptionToRoleAssignmentsClient[subId]
 	if !ok {

--- a/src/shared/azureagent/agent.go
+++ b/src/shared/azureagent/agent.go
@@ -29,17 +29,18 @@ type Config struct {
 }
 
 type Agent struct {
-	Conf                               Config
-	credentials                        *azidentity.DefaultAzureCredential
-	resourceClient                     AzureARMResourcesClient
-	subscriptionClient                 AzureARMSubscriptionsClient
-	resourceGroupsClient               AzureARMResourcesResourceGroupsClient
-	managedClustersClient              AzureARMContainerServiceManagedClustersClient
-	userAssignedIdentitiesClient       AzureARMMSIUserAssignedIdentitiesClient
-	federatedIdentityCredentialsClient AzureARMMSIFederatedIdentityCredentialsClient
-	roleDefinitionsClient              AzureARMAuthorizationRoleDefinitionsClient
-	roleAssignmentsClient              AzureARMAuthorizationRoleAssignmentsClient
-	vaultsClient                       AzureARMKeyVaultVaultsClient
+	Conf                                Config
+	credentials                         *azidentity.DefaultAzureCredential
+	resourceClient                      AzureARMResourcesClient
+	subscriptionClient                  AzureARMSubscriptionsClient
+	resourceGroupsClient                AzureARMResourcesResourceGroupsClient
+	managedClustersClient               AzureARMContainerServiceManagedClustersClient
+	userAssignedIdentitiesClient        AzureARMMSIUserAssignedIdentitiesClient
+	federatedIdentityCredentialsClient  AzureARMMSIFederatedIdentityCredentialsClient
+	roleDefinitionsClient               AzureARMAuthorizationRoleDefinitionsClient
+	roleAssignmentsClient               AzureARMAuthorizationRoleAssignmentsClient
+	vaultsClient                        AzureARMKeyVaultVaultsClient
+	subscriptionToRoleAssignmentsClient map[string]AzureARMAuthorizationRoleAssignmentsClient
 }
 
 func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
@@ -89,10 +90,13 @@ func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
 	subscriptionClient := armsubscriptionsClientFactory.NewClient()
 	userAssignedIdentitiesClient := armmsiClientFactory.NewUserAssignedIdentitiesClient()
 	federatedIdentityCredentialsClient := armmsiClientFactory.NewFederatedIdentityCredentialsClient()
-	roleDefinitionsClient := armauthorizationClientFactory.NewRoleDefinitionsClient()
-	roleAssignmentsClient := armauthorizationClientFactory.NewRoleAssignmentsClient()
+	roleDefinitionsClient := armauthorizationClientFactory.NewRoleDefinitionsClient() // Not using SubscriptionID
+	roleAssignmentsClient := armauthorizationClientFactory.NewRoleAssignmentsClient() // Using SubscriptionID
 	managedClustersClient := armcontainerserviceClientFactory.NewManagedClustersClient()
 	vaultsClient := armkeyvaultClientFactory.NewVaultsClient()
+
+	subscriptionToRoleAssignmentsClient := make(map[string]AzureARMAuthorizationRoleAssignmentsClient)
+	subscriptionToRoleAssignmentsClient[conf.SubscriptionID] = roleAssignmentsClient
 
 	agent := NewAzureAgentFromClients(
 		conf,
@@ -106,6 +110,7 @@ func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
 		roleDefinitionsClient,
 		roleAssignmentsClient,
 		vaultsClient,
+		subscriptionToRoleAssignmentsClient,
 	)
 
 	if err := agent.loadConfDefaults(ctx); err != nil {
@@ -115,19 +120,20 @@ func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
 	return agent, nil
 }
 
-func NewAzureAgentFromClients(conf Config, credentials *azidentity.DefaultAzureCredential, resourceClient AzureARMResourcesClient, subscriptionClient AzureARMSubscriptionsClient, resourceGroupsClient AzureARMResourcesResourceGroupsClient, managedClustersClient AzureARMContainerServiceManagedClustersClient, userAssignedIdentitiesClient AzureARMMSIUserAssignedIdentitiesClient, federatedIdentityCredentialsClient AzureARMMSIFederatedIdentityCredentialsClient, roleDefinitionsClient AzureARMAuthorizationRoleDefinitionsClient, roleAssignmentsClient AzureARMAuthorizationRoleAssignmentsClient, vaultsClient AzureARMKeyVaultVaultsClient) *Agent {
+func NewAzureAgentFromClients(conf Config, credentials *azidentity.DefaultAzureCredential, resourceClient AzureARMResourcesClient, subscriptionClient AzureARMSubscriptionsClient, resourceGroupsClient AzureARMResourcesResourceGroupsClient, managedClustersClient AzureARMContainerServiceManagedClustersClient, userAssignedIdentitiesClient AzureARMMSIUserAssignedIdentitiesClient, federatedIdentityCredentialsClient AzureARMMSIFederatedIdentityCredentialsClient, roleDefinitionsClient AzureARMAuthorizationRoleDefinitionsClient, roleAssignmentsClient AzureARMAuthorizationRoleAssignmentsClient, vaultsClient AzureARMKeyVaultVaultsClient, subscriptionToRoleAssignmentsClient map[string]AzureARMAuthorizationRoleAssignmentsClient) *Agent {
 	return &Agent{
-		Conf:                               conf,
-		credentials:                        credentials,
-		resourceClient:                     resourceClient,
-		subscriptionClient:                 subscriptionClient,
-		resourceGroupsClient:               resourceGroupsClient,
-		managedClustersClient:              managedClustersClient,
-		userAssignedIdentitiesClient:       userAssignedIdentitiesClient,
-		federatedIdentityCredentialsClient: federatedIdentityCredentialsClient,
-		roleDefinitionsClient:              roleDefinitionsClient,
-		roleAssignmentsClient:              roleAssignmentsClient,
-		vaultsClient:                       vaultsClient,
+		Conf:                                conf,
+		credentials:                         credentials,
+		resourceClient:                      resourceClient,
+		subscriptionClient:                  subscriptionClient,
+		resourceGroupsClient:                resourceGroupsClient,
+		managedClustersClient:               managedClustersClient,
+		userAssignedIdentitiesClient:        userAssignedIdentitiesClient,
+		federatedIdentityCredentialsClient:  federatedIdentityCredentialsClient,
+		roleDefinitionsClient:               roleDefinitionsClient,
+		roleAssignmentsClient:               roleAssignmentsClient,
+		vaultsClient:                        vaultsClient,
+		subscriptionToRoleAssignmentsClient: subscriptionToRoleAssignmentsClient,
 	}
 }
 
@@ -162,4 +168,19 @@ func (a *Agent) loadConfDefaults(ctx context.Context) error {
 
 func (a *Agent) AppliesOnPod(pod *corev1.Pod) bool {
 	return pod.Labels != nil && pod.Labels[AzureApplyOnPodLabel] == "true"
+}
+
+func (a *Agent) GetRoleAssignmentClientForSubscription(subId string) (client AzureARMAuthorizationRoleAssignmentsClient, err error) {
+	client, ok := a.subscriptionToRoleAssignmentsClient[subId]
+	if !ok {
+		// Create a role assignments client for the subscription
+		client, err = armauthorization.NewRoleAssignmentsClient(subId, a.credentials, nil)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+
+		a.subscriptionToRoleAssignmentsClient[subId] = client
+	}
+
+	return client, nil
 }

--- a/src/shared/azureagent/azureclients.go
+++ b/src/shared/azureagent/azureclients.go
@@ -17,6 +17,7 @@ type AzureARMResourcesClient interface {
 
 type AzureARMSubscriptionsClient interface {
 	Get(ctx context.Context, subscriptionID string, options *armsubscriptions.ClientGetOptions) (armsubscriptions.ClientGetResponse, error)
+	NewListPager(options *armsubscriptions.ClientListOptions) *runtime.Pager[armsubscriptions.ClientListResponse]
 }
 
 type AzureARMResourcesResourceGroupsClient interface {

--- a/src/shared/azureagent/customroles.go
+++ b/src/shared/azureagent/customroles.go
@@ -23,10 +23,6 @@ const (
 	OtterizeCustomRoleDescription = "This custom role was created by the Otterize intents-operator's Azure integration. For more details, go to https://otterize.com"
 )
 
-func (a *Agent) getCustomRoleScope() string {
-	return fmt.Sprintf("/subscriptions/%s", a.Conf.SubscriptionID)
-}
-
 func (a *Agent) getSubscriptionScope(scope string) string {
 	subscriptionId := strings.Split(scope, "/")[2]
 	return fmt.Sprintf("/subscriptions/%s", subscriptionId)

--- a/src/shared/azureagent/customroles.go
+++ b/src/shared/azureagent/customroles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/agentutils"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
+	"strings"
 )
 
 const (
@@ -24,6 +25,11 @@ const (
 
 func (a *Agent) getCustomRoleScope() string {
 	return fmt.Sprintf("/subscriptions/%s", a.Conf.SubscriptionID)
+}
+
+func (a *Agent) getSubscriptionScope(scope string) string {
+	subscriptionId := strings.Split(scope, "/")[2]
+	return fmt.Sprintf("/subscriptions/%s", subscriptionId)
 }
 
 func (a *Agent) GenerateCustomRoleName(uai armmsi.Identity, scope string) string {
@@ -43,7 +49,7 @@ func (a *Agent) ValidateScope(ctx context.Context, scope string) error {
 }
 
 func (a *Agent) CreateCustomRole(ctx context.Context, scope string, uai armmsi.Identity, actions []v2alpha1.AzureAction, dataActions []v2alpha1.AzureDataAction) (*armauthorization.RoleDefinition, error) {
-	roleScope := a.getCustomRoleScope()
+	roleScope := a.getSubscriptionScope(scope)
 
 	formattedActions := lo.Map(actions, func(action v2alpha1.AzureAction, _ int) *string {
 		return to.Ptr(string(action))
@@ -78,8 +84,8 @@ func (a *Agent) CreateCustomRole(ctx context.Context, scope string, uai armmsi.I
 	return &resp.RoleDefinition, nil
 }
 
-func (a *Agent) UpdateCustomRole(ctx context.Context, role *armauthorization.RoleDefinition, actions []v2alpha1.AzureAction, dataActions []v2alpha1.AzureDataAction) error {
-	roleScope := a.getCustomRoleScope()
+func (a *Agent) UpdateCustomRole(ctx context.Context, scope string, role *armauthorization.RoleDefinition, actions []v2alpha1.AzureAction, dataActions []v2alpha1.AzureDataAction) error {
+	roleScope := a.getSubscriptionScope(scope)
 
 	formattedActions := lo.Map(actions, func(action v2alpha1.AzureAction, _ int) *string {
 		return to.Ptr(string(action))
@@ -103,11 +109,11 @@ func (a *Agent) UpdateCustomRole(ctx context.Context, role *armauthorization.Rol
 	return nil
 }
 
-func (a *Agent) FindCustomRoleByName(ctx context.Context, name string) (*armauthorization.RoleDefinition, bool) {
-	scope := a.getCustomRoleScope()
+func (a *Agent) FindCustomRoleByName(ctx context.Context, scope string, name string) (*armauthorization.RoleDefinition, bool) {
+	roleScope := a.getSubscriptionScope(scope)
 	filter := fmt.Sprintf("roleName eq '%s'", name)
 
-	pager := a.roleDefinitionsClient.NewListPager(scope, &armauthorization.RoleDefinitionsClientListOptions{
+	pager := a.roleDefinitionsClient.NewListPager(roleScope, &armauthorization.RoleDefinitionsClientListOptions{
 		Filter: &filter,
 	})
 
@@ -121,10 +127,10 @@ func (a *Agent) FindCustomRoleByName(ctx context.Context, name string) (*armauth
 	return nil, false
 }
 
-func (a *Agent) DeleteCustomRole(ctx context.Context, roleDefinitionID string) error {
-	scope := a.getCustomRoleScope()
+func (a *Agent) DeleteCustomRole(ctx context.Context, scope string, roleDefinitionID string) error {
+	roleScope := a.getSubscriptionScope(scope)
 
-	_, err := a.roleDefinitionsClient.Delete(ctx, scope, roleDefinitionID, nil)
+	_, err := a.roleDefinitionsClient.Delete(ctx, roleScope, roleDefinitionID, nil)
 	if err != nil {
 		if azureerrors.IsNotFoundErr(err) {
 			return nil

--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -108,7 +108,7 @@ func (a *Agent) DeleteUserAssignedIdentity(ctx context.Context, namespace string
 		return errors.Wrap(err)
 	}
 
-	roleAssignments, err := a.ListRoleAssignments(ctx, identity)
+	roleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, identity)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/shared/azureagent/mocks/azureclients.go
+++ b/src/shared/azureagent/mocks/azureclients.go
@@ -94,6 +94,20 @@ func (mr *MockAzureARMSubscriptionsClientMockRecorder) Get(ctx, subscriptionID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockAzureARMSubscriptionsClient)(nil).Get), ctx, subscriptionID, options)
 }
 
+// NewListPager mocks base method.
+func (m *MockAzureARMSubscriptionsClient) NewListPager(options *armsubscriptions.ClientListOptions) *runtime.Pager[armsubscriptions.ClientListResponse] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewListPager", options)
+	ret0, _ := ret[0].(*runtime.Pager[armsubscriptions.ClientListResponse])
+	return ret0
+}
+
+// NewListPager indicates an expected call of NewListPager.
+func (mr *MockAzureARMSubscriptionsClientMockRecorder) NewListPager(options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListPager", reflect.TypeOf((*MockAzureARMSubscriptionsClient)(nil).NewListPager), options)
+}
+
 // MockAzureARMResourcesResourceGroupsClient is a mock of AzureARMResourcesResourceGroupsClient interface.
 type MockAzureARMResourcesResourceGroupsClient struct {
 	ctrl     *gomock.Controller

--- a/src/shared/azureagent/roleassignments.go
+++ b/src/shared/azureagent/roleassignments.go
@@ -85,8 +85,7 @@ func (a *Agent) ListRoleAssignmentsAcrossSubscriptions(ctx context.Context, user
 
 	var roleAssignments []armauthorization.RoleAssignment
 	for _, sub := range subscriptions {
-		// Create a role assignments client for the subscription
-		roleClient, err := armauthorization.NewRoleAssignmentsClient(*sub.SubscriptionID, a.credentials, nil)
+		roleClient, err := a.GetRoleAssignmentClientForSubscription(*sub.SubscriptionID)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}

--- a/src/shared/azureagent/subscriptions.go
+++ b/src/shared/azureagent/subscriptions.go
@@ -15,8 +15,8 @@ func (a *Agent) ListSubscriptions(ctx context.Context) ([]armsubscriptions.Subsc
 			return nil, errors.Wrap(err)
 		}
 
-		for _, roleAssignment := range page.Value {
-			subscriptions = append(subscriptions, *roleAssignment)
+		for _, subscription := range page.Value {
+			subscriptions = append(subscriptions, *subscription)
 		}
 	}
 

--- a/src/shared/azureagent/subscriptions.go
+++ b/src/shared/azureagent/subscriptions.go
@@ -1,0 +1,24 @@
+package azureagent
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/otterize/intents-operator/src/shared/errors"
+)
+
+func (a *Agent) ListSubscriptions(ctx context.Context) ([]armsubscriptions.Subscription, error) {
+	var subscriptions []armsubscriptions.Subscription
+	pager := a.subscriptionClient.NewListPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+
+		for _, roleAssignment := range page.Value {
+			subscriptions = append(subscriptions, *roleAssignment)
+		}
+	}
+
+	return subscriptions, nil
+}

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -603,6 +603,7 @@ enum EdgeAccessStatusReason {
 	INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT
 	INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC
 	MISSING_APPLIED_INTENT
+	MISSING_APPLIED_CLOUD_RESOURCE_INTENT
 	NOT_IN_PROTECTED_SERVICES
 	INTENTS_OPERATOR_NEVER_CONNECTED
 	NETWORK_MAPPER_NEVER_CONNECTED
@@ -710,6 +711,7 @@ input ExternallyManagedPolicyWorkloadInput {
 type FeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 type Finding {
@@ -719,8 +721,10 @@ type Finding {
 	server: BasicEntity!
 	cluster: BasicEntity!
 	intentsOperatorState: IntentsOperatorState
+	clusterRelatedServices: [Service!]
 	reason: String!
 	status: FindingStatus!
+	ignoredReason: String
 	type: FindingType!
 }
 
@@ -975,6 +979,7 @@ input InputAccessLogFilter {
 input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 """ Findings filter """
@@ -995,6 +1000,8 @@ input InputFindingFilter {
 	environmentIds: InputIDFilterValue
 """ Findings filter """
 	findingTypes: InputIDFilterValue
+""" Findings filter """
+	hashes: InputIDFilterValue
 }
 
 input InputIDFilterValue {
@@ -1606,8 +1613,15 @@ type Mutation {
 		component: Component
 		errors: [Error!]!
 	): Boolean!
-	toggleIgnoreFindings(
+	setFindingsIgnoredByHashes(
 		hashes: [String!]!
+		ignored: Boolean!
+		reason: String
+	): Boolean!
+	setFindingsIgnoredByControlIds(
+		controlIds: [RegulationCode!]!
+		ignored: Boolean!
+		reason: String
 	): Boolean!
 """Create a new generic integration"""
 	createGenericIntegration(

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -603,6 +603,7 @@ enum EdgeAccessStatusReason {
 	INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT
 	INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC
 	MISSING_APPLIED_INTENT
+	MISSING_APPLIED_CLOUD_RESOURCE_INTENT
 	NOT_IN_PROTECTED_SERVICES
 	INTENTS_OPERATOR_NEVER_CONNECTED
 	NETWORK_MAPPER_NEVER_CONNECTED
@@ -710,6 +711,7 @@ input ExternallyManagedPolicyWorkloadInput {
 type FeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 type Finding {
@@ -719,8 +721,10 @@ type Finding {
 	server: BasicEntity!
 	cluster: BasicEntity!
 	intentsOperatorState: IntentsOperatorState
+	clusterRelatedServices: [Service!]
 	reason: String!
 	status: FindingStatus!
+	ignoredReason: String
 	type: FindingType!
 }
 
@@ -975,6 +979,7 @@ input InputAccessLogFilter {
 input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 """ Findings filter """
@@ -995,6 +1000,8 @@ input InputFindingFilter {
 	environmentIds: InputIDFilterValue
 """ Findings filter """
 	findingTypes: InputIDFilterValue
+""" Findings filter """
+	hashes: InputIDFilterValue
 }
 
 input InputIDFilterValue {
@@ -1606,8 +1613,15 @@ type Mutation {
 		component: Component
 		errors: [Error!]!
 	): Boolean!
-	toggleIgnoreFindings(
+	setFindingsIgnoredByHashes(
 		hashes: [String!]!
+		ignored: Boolean!
+		reason: String
+	): Boolean!
+	setFindingsIgnoredByControlIds(
+		controlIds: [RegulationCode!]!
+		ignored: Boolean!
+		reason: String
 	): Boolean!
 """Create a new generic integration"""
 	createGenericIntegration(


### PR DESCRIPTION
### Description

Added support for cross-subscription access in Azure. A custom role with the relevant actions and data actions will be created in the resources subscription -> a new assignment will be created on the Kubernetes service managed identity pointing to that specific custom role.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
