### PR TITLE
Prevent nil pointer access in otterize crds

### DIFF
--- a/src/operator/controllers/custom_resource_definition_controller.go
+++ b/src/operator/controllers/custom_resource_definition_controller.go
@@ -73,7 +73,7 @@ func (r *CustomResourceDefinitionsReconciler) Reconcile(ctx context.Context, req
 	}
 	resourceCopy := crd.DeepCopy()
 	resourceCopy.Spec = baseCRD.Spec
-	if resourceCopy.Spec.Conversion == nil || resourceCopy.Spec.Conversion.Webhook == nil || resourceCopy.Spec.Conversion.Webhook.ClientConfig == nil {
+	if resourceCopy.Spec.Conversion == nil || resourceCopy.Spec.Conversion.Webhook == nil || resourceCopy.Spec.Conversion.Webhook.ClientConfig == nil || resourceCopy.Spec.Conversion.Webhook.ClientConfig.Service == nil {
 		return ctrl.Result{}, errors.Errorf("CRD does not contain a proper conversion webhook definition")
 	}
 	if bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, r.certPem) && crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace == r.namespace {


### PR DESCRIPTION
### Description

Prevent nil pointer access in otterize crds


### References

Bugsnag: runtime error: invalid memory address or nil pointer dereference

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
