### PR TITLE
Allow TCP port 53 when creating an allow all NetworkPolicy to kube-dns - to support TCP DNS

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy.go
@@ -30,6 +30,10 @@ func (r *DNSEgressNetworkPolicyBuilder) buildNetworkPolicyEgressRules(ep effecti
 				Protocol: lo.ToPtr(corev1.ProtocolUDP),
 				Port:     lo.ToPtr(intstr.FromInt32(53)),
 			},
+			{
+				Protocol: lo.ToPtr(corev1.ProtocolTCP),
+				Port:     lo.ToPtr(intstr.FromInt32(53)),
+			},
 		},
 	})
 	return egressRules

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/dns_egress_network_policy_test.go
@@ -164,6 +164,10 @@ func networkPolicyDNSEgressTemplate(
 							Protocol: lo.ToPtr(corev1.ProtocolUDP),
 							Port:     lo.ToPtr(intstr.FromInt32(53)),
 						},
+						{
+							Protocol: lo.ToPtr(corev1.ProtocolTCP),
+							Port:     lo.ToPtr(intstr.FromInt32(53)),
+						},
 					},
 				},
 			},

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy.go
@@ -29,10 +29,16 @@ func (r *IngressDNSServerAutoAllowNetpolBuilder) buildIngressRulesFromServiceEff
 		return ingressRules
 	}
 	ingressRules = append(ingressRules, v1.NetworkPolicyIngressRule{
-		Ports: []v1.NetworkPolicyPort{{
-			Protocol: lo.ToPtr(corev1.ProtocolUDP),
-			Port:     lo.ToPtr(intstr.FromInt32(53)),
-		}},
+		Ports: []v1.NetworkPolicyPort{
+			{
+				Protocol: lo.ToPtr(corev1.ProtocolUDP),
+				Port:     lo.ToPtr(intstr.FromInt32(53)),
+			},
+			{
+				Protocol: lo.ToPtr(corev1.ProtocolTCP),
+				Port:     lo.ToPtr(intstr.FromInt32(53)),
+			},
+		},
 	})
 	return ingressRules
 }

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/ingress_dns_server_allow_network_policy_test.go
@@ -104,10 +104,16 @@ func ingressDNSnetworkPolicyIngressTemplate(
 ) *v1.NetworkPolicy {
 	ingressRules := lo.Map(intentsObjNamespaces, func(namespace string, _ int) v1.NetworkPolicyIngressRule {
 		return v1.NetworkPolicyIngressRule{
-			Ports: []v1.NetworkPolicyPort{{
-				Protocol: lo.ToPtr(v12.ProtocolUDP),
-				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
-			}},
+			Ports: []v1.NetworkPolicyPort{
+				{
+					Protocol: lo.ToPtr(v12.ProtocolUDP),
+					Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+				},
+				{
+					Protocol: lo.ToPtr(v12.ProtocolTCP),
+					Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+				},
+			},
 		}
 	})
 	return &v1.NetworkPolicy{


### PR DESCRIPTION
### Description

Up until this PR if the kubernetes DNS server was mentioned in a `clientIntents` resource as a target, we added to its network policy an "allow all UDP port 53 rule", in this PR we added an "allow all TCP port 53" rule so it will auto allow TCP DNS.


### Testing

changed existing tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
