### PR TITLE
Improve CPU consumption by skipping `populateReferencedKubernetesServices` logic when egress enforcement is disabled

### DIFF
--- a/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/builders/test_base.go
@@ -8,6 +8,7 @@ import (
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/networkpolicy"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -43,6 +44,7 @@ type RulesBuilderTestSuiteBase struct {
 
 func (s *RulesBuilderTestSuiteBase) SetupTest() {
 	logrus.SetLevel(logrus.DebugLevel)
+	viper.Set(enforcement.EnableEgressNetworkPolicyReconcilersKey, true)
 	s.MocksSuiteBase.SetupTest()
 	s.externalNetpolHandler = mocks.NewMockExternalNetpolHandler(s.Controller)
 	restrictToNamespaces := make([]string, 0)

--- a/src/operator/effectivepolicy/types.go
+++ b/src/operator/effectivepolicy/types.go
@@ -16,6 +16,8 @@ type ClientCall struct {
 
 type Call struct {
 	v2alpha1.Target
+	// This is here as a workaround to make egress policies work in AWS VPC CNI which requires a rule matching the service's selector exactly in order to allow traffic to ClusterIP.
+	// it will be populated only if egress is enabled
 	ReferencingKubernetesServices []v1.Service
 	EventRecorder                 *injectablerecorder.ObjectEventRecorder
 }


### PR DESCRIPTION
### Description

When building serviceEffectivePolicies - `populateReferencedKubernetesServices` logic is the heaviest part regarding CPU consumption. This logic is relevant only for egress policies (to work around AWS CNI limitation). Therefore, in this PR we changed it so it will only run if egress is enabled.

