### PR TITLE
Report Istio installation status as Istio enforcement status

### DIFF
--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -294,10 +294,8 @@ type AzureAction string
 type AzureDataAction string
 
 type KubernetesTarget struct {
-	Name string `json:"name" yaml:"name"`
-	//+optional
-	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
-	//+optional
+	Name string       `json:"name" yaml:"name"`
+	Kind string       `json:"kind" yaml:"kind"`
 	HTTP []HTTPTarget `json:"http,omitempty" yaml:"http,omitempty"`
 }
 

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -294,8 +294,10 @@ type AzureAction string
 type AzureDataAction string
 
 type KubernetesTarget struct {
-	Name string       `json:"name" yaml:"name"`
-	Kind string       `json:"kind" yaml:"kind"`
+	Name string `json:"name" yaml:"name"`
+	//+optional
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	//+optional
 	HTTP []HTTPTarget `json:"http,omitempty" yaml:"http,omitempty"`
 }
 

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -327,7 +327,7 @@ func main() {
 		logrus.WithError(err).Error("Failed to initialize Otterize Cloud client")
 	}
 	if connectedToCloud {
-		operator_cloud_client.StartPeriodicCloudReports(signalHandlerCtx, otterizeCloudClient)
+		operator_cloud_client.StartPeriodicCloudReports(signalHandlerCtx, otterizeCloudClient, mgr.GetClient())
 		intentsEventsSender, err := operator_cloud_client.NewIntentEventsSender(otterizeCloudClient, mgr)
 		if err != nil {
 			logrus.WithError(err).Panic("unable to create intent events sender")


### PR DESCRIPTION
This PR makes the intents operator report whether Istio is installed, which is automatically taken into account by Otterize Cloud to auto-hide the access statuses for Istio if not installed in the cluster.