### PR TITLE
Align linkerd RBAC permissions for the intents-operator cluster role with the helm-chart

### DIFF
--- a/src/operator/config/rbac/manifests-patched.yaml
+++ b/src/operator/config/rbac/manifests-patched.yaml
@@ -254,6 +254,71 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy.linkerd.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - meshtlsauthentications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - networkauthentications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - servers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security.istio.io
   resources:
   - authorizationpolicies

--- a/src/operator/config/rbac/role.yaml
+++ b/src/operator/config/rbac/role.yaml
@@ -254,6 +254,71 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy.linkerd.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - meshtlsauthentications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - networkauthentications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.linkerd.io
+  resources:
+  - servers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security.istio.io
   resources:
   - authorizationpolicies

--- a/src/operator/controllers/linkerd/linkerd_manager.go
+++ b/src/operator/controllers/linkerd/linkerd_manager.go
@@ -47,7 +47,12 @@ const (
 	LinkerdContainer                      = "linkerd-proxy"
 )
 
-//+kubebuilder:rbac:groups="policy.linkerd.io",resources=*,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=authorizationpolicies,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=meshtlsauthentications,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=networkauthentications,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=servers,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=httproutes,verbs=get;update;patch;list;watch;delete;create;deletecollection
+//+kubebuilder:rbac:groups="policy.linkerd.io",resources=httproutes,verbs=get;update;patch;list;watch;delete;create;deletecollection
 
 type LinkerdPolicyManager interface {
 	DeleteOutdatedResources(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy, validResources LinkerdResourceMapping) error


### PR DESCRIPTION
### Description

Align permissions with those installed by the helm chart

### References

https://github.com/otterize/helm-charts/blob/main/intents-operator/templates/intents-operator-manager-clusterrole.yaml

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
