### PR TITLE
Support reporting applied ClientIntents targeting Kubernetes services to the cloud

### DIFF
--- a/.github/workflows/netpol-e2e-test.yaml
+++ b/.github/workflows/netpol-e2e-test.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.REGISTRY }}_${{ github.actor }}_intents-operator_${{ github.sha }}.tar
 
@@ -155,7 +155,7 @@ jobs:
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.REGISTRY }}_${{ github.actor }}_intents-operator_${{ github.sha }}.tar
 
@@ -263,7 +263,7 @@ jobs:
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.REGISTRY }}_${{ github.actor }}_intents-operator_${{ github.sha }}.tar
 
@@ -389,7 +389,7 @@ jobs:
 
       - name: Load images from GitHub Artifacts
         if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.REGISTRY }}_${{ github.actor }}_intents-operator_${{ github.sha }}.tar
 

--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler.go
@@ -11,11 +11,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -54,12 +50,7 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 		return intents.DeletionTimestamp == nil
 	})
 
-	clientIntentsListConverted, err := r.convertK8sServicesToOtterizeIdentities(ctx, clientIntentsList)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err)
-	}
-
-	intentsInput, err := clientIntentsListConverted.FormatAsOtterizeIntents(ctx, r.Client)
+	intentsInput, err := clientIntentsList.FormatAsOtterizeIntents(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err)
 	}
@@ -75,68 +66,6 @@ func (r *OtterizeCloudReconciler) Reconcile(ctx context.Context, req reconcile.R
 	logrus.Debugf("successfully reported %d applied intents", len(clientIntentsList.Items))
 
 	return ctrl.Result{}, nil
-}
-
-func (r *OtterizeCloudReconciler) convertK8sServicesToOtterizeIdentities(
-	ctx context.Context,
-	clientIntentsList *otterizev2alpha1.ClientIntentsList) (*otterizev2alpha1.ClientIntentsList, error) {
-
-	// TODO: Remove when access graph supports Kubernetes services
-	for _, clientIntent := range clientIntentsList.Items {
-		callList := make([]otterizev2alpha1.Target, 0)
-		for _, intent := range clientIntent.GetTargetList() {
-			if !intent.IsTargetServerKubernetesService() {
-				callList = append(callList, intent)
-				continue
-			}
-			if intent.IsTargetTheKubernetesAPIServer(clientIntent.Namespace) {
-				intentCopy := intent.DeepCopy()
-				if intent.Kubernetes != nil {
-					intentCopy.Kubernetes.Name = intent.GetServerFullyQualifiedName(clientIntent.Namespace)
-				}
-				if intent.Service != nil {
-					intentCopy.Service.Name = intent.GetServerFullyQualifiedName(clientIntent.Namespace)
-				}
-				callList = append(callList, intent)
-				continue
-			}
-
-			svc := corev1.Service{}
-			kubernetesSvcName := intent.GetTargetServerName()
-			kubernetesSvcNamespace := intent.GetTargetServerNamespace(clientIntent.Namespace)
-			err := r.Get(ctx, types.NamespacedName{
-				Namespace: kubernetesSvcNamespace,
-				Name:      kubernetesSvcName,
-			}, &svc)
-			if err != nil {
-				if k8serrors.IsNotFound(err) {
-					continue
-				}
-				return nil, errors.Wrap(err)
-			}
-			podList := corev1.PodList{}
-			err = r.List(ctx, &podList, &client.ListOptions{LabelSelector: labels.SelectorFromSet(svc.Spec.Selector)})
-			if err != nil {
-				return nil, errors.Wrap(err)
-			}
-			if len(podList.Items) != 0 {
-				otterizeIdentity, err := r.serviceIdResolver.ResolvePodToServiceIdentity(ctx, &podList.Items[0])
-				if err != nil {
-					return nil, errors.Wrap(err)
-				}
-				if intent.Kubernetes != nil {
-					intent.Kubernetes.Name = otterizeIdentity.Name
-				}
-				if intent.Service != nil {
-					intent.Service.Name = otterizeIdentity.Name
-				}
-				callList = append(callList, intent)
-			}
-			clientIntent.Spec.Targets = callList
-		}
-	}
-
-	return clientIntentsList, nil
 }
 
 func (r *OtterizeCloudReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
### Description

Until this PR we were overriding Service targets with the name of the workload. Since the cloud fully supports services access this override mechanism is not necessary anymore.


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
