### PR TITLE
Fix Azure API version error when applying Azure ClientIntents on KeyVault scopes, by querying for supported API versions by resource type

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/otterize/lox v0.0.0-20220525164329-9ca2bf91c3dd
 	github.com/otterize/nilable v0.0.0-20240410132629-f242bb6f056f
 	github.com/prometheus/client_golang v1.18.0
-	github.com/samber/lo v1.33.0
+	github.com/samber/lo v1.47.0
 	github.com/simukti/sqldb-logger v0.0.0-20230108155151-646c1a075551
 	github.com/simukti/sqldb-logger/logadapter/logrusadapter v0.0.0-20230108155151-646c1a075551
 	github.com/sirupsen/logrus v1.9.3

--- a/src/go.sum
+++ b/src/go.sum
@@ -478,6 +478,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.33.0 h1:2aKucr+rQV6gHpY3bpeZu69uYoQOzVhGT3J22Op6Cjk=
 github.com/samber/lo v1.33.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -128,6 +128,10 @@ func (a *Agent) ensureRoleAssignmentsForIntents(ctx context.Context, userAssigne
 		}
 		expectedScopes = append(expectedScopes, scope)
 
+		if err := a.ValidateScope(ctx, scope); err != nil {
+			return errors.Wrap(err)
+		}
+
 		roleNames := intent.Azure.Roles
 		existingRoleAssignmentsForScope := existingRoleAssignmentsByScope[scope]
 

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -128,10 +128,6 @@ func (a *Agent) ensureRoleAssignmentsForIntents(ctx context.Context, userAssigne
 		}
 		expectedScopes = append(expectedScopes, scope)
 
-		if err := a.ValidateScope(ctx, scope); err != nil {
-			return errors.Wrap(err)
-		}
-
 		roleNames := intent.Azure.Roles
 		existingRoleAssignmentsForScope := existingRoleAssignmentsByScope[scope]
 

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -377,12 +377,6 @@ func (a *Agent) ensureCustomRoleForIntent(ctx context.Context, userAssignedIdent
 	actions := intent.Azure.Actions
 	dataActions := intent.Azure.DataActions
 
-	if err := a.ValidateScope(ctx, scope); err != nil {
-		// Prevent using non-existing scopes for custom roles,
-		// as they may cause issues when deleting the custom role
-		return errors.Wrap(err)
-	}
-
 	customRoleName := a.GenerateCustomRoleName(userAssignedIdentity, scope)
 	role, found := a.FindCustomRoleByName(ctx, scope, customRoleName)
 	if found {
@@ -391,6 +385,12 @@ func (a *Agent) ensureCustomRoleForIntent(ctx context.Context, userAssignedIdent
 			return errors.Wrap(err)
 		}
 	} else {
+		if err := a.ValidateScope(ctx, scope); err != nil {
+			// Prevent using non-existing scopes for custom roles,
+			// as they may cause issues when deleting the custom role
+			return errors.Wrap(err)
+		}
+
 		newRole, err := a.CreateCustomRole(ctx, scope, userAssignedIdentity, actions, dataActions)
 		if err != nil {
 			return errors.Wrap(err)

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_identities_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_identities_test.go
@@ -20,6 +20,7 @@ type AzureAgentIdentitiesSuite struct {
 	suite.Suite
 
 	mockResourcesClient                    *mock_azureagent.MockAzureARMResourcesClient
+	mockProviderResourceTypesClient        *mock_azureagent.MockAzureARMResourcesProviderResourceTypesClient
 	mockSubscriptionsClient                *mock_azureagent.MockAzureARMSubscriptionsClient
 	mockResourceGroupsClient               *mock_azureagent.MockAzureARMResourcesResourceGroupsClient
 	mockManagedClustersClient              *mock_azureagent.MockAzureARMContainerServiceManagedClustersClient
@@ -39,6 +40,7 @@ func (s *AzureAgentIdentitiesSuite) SetupTest() {
 	controller := gomock.NewController(s.T())
 
 	s.mockResourcesClient = mock_azureagent.NewMockAzureARMResourcesClient(controller)
+	s.mockProviderResourceTypesClient = mock_azureagent.NewMockAzureARMResourcesProviderResourceTypesClient(controller)
 	s.mockSubscriptionsClient = mock_azureagent.NewMockAzureARMSubscriptionsClient(controller)
 	s.mockResourceGroupsClient = mock_azureagent.NewMockAzureARMResourcesResourceGroupsClient(controller)
 	s.mockManagedClustersClient = mock_azureagent.NewMockAzureARMContainerServiceManagedClustersClient(controller)
@@ -66,6 +68,7 @@ func (s *AzureAgentIdentitiesSuite) SetupTest() {
 			},
 			nil,
 			s.mockResourcesClient,
+			s.mockProviderResourceTypesClient,
 			s.mockSubscriptionsClient,
 			s.mockResourceGroupsClient,
 			s.mockManagedClustersClient,

--- a/src/shared/azureagent/azureclients.go
+++ b/src/shared/azureagent/azureclients.go
@@ -16,6 +16,10 @@ type AzureARMResourcesClient interface {
 	NewListPager(options *armresources.ClientListOptions) *runtime.Pager[armresources.ClientListResponse]
 }
 
+type AzureARMResourcesProviderResourceTypesClient interface {
+	List(ctx context.Context, resourceProviderNamespace string, options *armresources.ProviderResourceTypesClientListOptions) (armresources.ProviderResourceTypesClientListResponse, error)
+}
+
 type AzureARMSubscriptionsClient interface {
 	Get(ctx context.Context, subscriptionID string, options *armsubscriptions.ClientGetOptions) (armsubscriptions.ClientGetResponse, error)
 	NewListPager(options *armsubscriptions.ClientListOptions) *runtime.Pager[armsubscriptions.ClientListResponse]

--- a/src/shared/azureagent/mocks/azureclients.go
+++ b/src/shared/azureagent/mocks/azureclients.go
@@ -70,6 +70,44 @@ func (mr *MockAzureARMResourcesClientMockRecorder) NewListPager(options interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListPager", reflect.TypeOf((*MockAzureARMResourcesClient)(nil).NewListPager), options)
 }
 
+// MockAzureARMResourcesProviderResourceTypesClient is a mock of AzureARMResourcesProviderResourceTypesClient interface.
+type MockAzureARMResourcesProviderResourceTypesClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockAzureARMResourcesProviderResourceTypesClientMockRecorder
+}
+
+// MockAzureARMResourcesProviderResourceTypesClientMockRecorder is the mock recorder for MockAzureARMResourcesProviderResourceTypesClient.
+type MockAzureARMResourcesProviderResourceTypesClientMockRecorder struct {
+	mock *MockAzureARMResourcesProviderResourceTypesClient
+}
+
+// NewMockAzureARMResourcesProviderResourceTypesClient creates a new mock instance.
+func NewMockAzureARMResourcesProviderResourceTypesClient(ctrl *gomock.Controller) *MockAzureARMResourcesProviderResourceTypesClient {
+	mock := &MockAzureARMResourcesProviderResourceTypesClient{ctrl: ctrl}
+	mock.recorder = &MockAzureARMResourcesProviderResourceTypesClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAzureARMResourcesProviderResourceTypesClient) EXPECT() *MockAzureARMResourcesProviderResourceTypesClientMockRecorder {
+	return m.recorder
+}
+
+// List mocks base method.
+func (m *MockAzureARMResourcesProviderResourceTypesClient) List(ctx context.Context, resourceProviderNamespace string, options *armresources.ProviderResourceTypesClientListOptions) (armresources.ProviderResourceTypesClientListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", ctx, resourceProviderNamespace, options)
+	ret0, _ := ret[0].(armresources.ProviderResourceTypesClientListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List.
+func (mr *MockAzureARMResourcesProviderResourceTypesClientMockRecorder) List(ctx, resourceProviderNamespace, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAzureARMResourcesProviderResourceTypesClient)(nil).List), ctx, resourceProviderNamespace, options)
+}
+
 // MockAzureARMSubscriptionsClient is a mock of AzureARMSubscriptionsClient interface.
 type MockAzureARMSubscriptionsClient struct {
 	ctrl     *gomock.Controller

--- a/src/shared/azureagent/resources.go
+++ b/src/shared/azureagent/resources.go
@@ -6,11 +6,60 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/samber/lo"
+	"regexp"
 	"strings"
 )
 
+var ResourceProviderNamespaceRegex = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/([^/]+)/([^/]+).*$`)
+
+const defaultAPIVersion = "2022-09-01"
+
+func (a *Agent) loadProviderResourceTypes(ctx context.Context, provider string) (map[string]armresources.ProviderResourceType, error) {
+	if providerResourceTypes, ok := a.providerResourceTypesCache.Get(provider); ok {
+		return providerResourceTypes, nil
+	}
+
+	res, err := a.providerResourceTypesClient.List(ctx, provider, nil)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	providerResourceTypesList := lo.FromSlicePtr(res.ProviderResourceTypeListResult.Value)
+	providerResourceTypes := lo.SliceToMap(providerResourceTypesList, func(r armresources.ProviderResourceType) (string, armresources.ProviderResourceType) {
+		return lo.FromPtr(r.ResourceType), r
+	})
+	a.providerResourceTypesCache.Add(provider, providerResourceTypes)
+	return providerResourceTypes, nil
+}
+
+func (a *Agent) getResourceAPIVersion(ctx context.Context, provider string, resourceName string) (string, error) {
+	providerResourceTypes, err := a.loadProviderResourceTypes(ctx, provider)
+	if err != nil {
+		return "", errors.Wrap(err)
+	}
+
+	resourceType, found := providerResourceTypes[resourceName]
+	if !found {
+		return "", errors.Errorf("resource type %s not found for provider %s", resourceName, provider)
+	}
+
+	return lo.FromPtr(resourceType.DefaultAPIVersion), nil
+}
+
 func (a *Agent) ValidateScope(ctx context.Context, scope string) error {
-	res, err := a.resourceClient.GetByID(ctx, scope, "2022-09-01", nil)
+	apiVersion := defaultAPIVersion
+	if match := ResourceProviderNamespaceRegex.FindStringSubmatch(scope); len(match) > 1 {
+		provider := match[1]
+		resourceName := match[2]
+		resourceAPIVersion, err := a.getResourceAPIVersion(ctx, provider, resourceName)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		apiVersion = resourceAPIVersion
+	}
+
+	res, err := a.resourceClient.GetByID(ctx, scope, apiVersion, nil)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -899,310 +899,340 @@ type dummyResponse struct {
 // GetDummyError returns dummyResponse.DummyError, and is useful for accessing the field via an interface.
 func (v *dummyResponse) GetDummyError() UserErrorType { return v.DummyError }
 
+// The query or mutation executed by ReportAppliedKubernetesIntents.
+const ReportAppliedKubernetesIntents_Operation = `
+mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
+	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
+}
+`
+
 func ReportAppliedKubernetesIntents(
-	ctx context.Context,
-	client graphql.Client,
+	ctx_ context.Context,
+	client_ graphql.Client,
 	namespace *string,
 	intents []*IntentInput,
 	clusterId *string,
 ) (*ReportAppliedKubernetesIntentsResponse, error) {
-	req := &graphql.Request{
+	req_ := &graphql.Request{
 		OpName: "ReportAppliedKubernetesIntents",
-		Query: `
-mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
-	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
-}
-`,
+		Query:  ReportAppliedKubernetesIntents_Operation,
 		Variables: &__ReportAppliedKubernetesIntentsInput{
 			Namespace: namespace,
 			Intents:   intents,
 			ClusterId: clusterId,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportAppliedKubernetesIntentsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportAppliedKubernetesIntentsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportClientIntentEvents(
-	ctx context.Context,
-	client graphql.Client,
-	events []ClientIntentEventInput,
-) (*ReportClientIntentEventsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportClientIntentEvents",
-		Query: `
+// The query or mutation executed by ReportClientIntentEvents.
+const ReportClientIntentEvents_Operation = `
 mutation ReportClientIntentEvents ($events: [ClientIntentEventInput!]!) {
 	reportClientIntentEvent(events: $events)
 }
-`,
+`
+
+func ReportClientIntentEvents(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	events []ClientIntentEventInput,
+) (*ReportClientIntentEventsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportClientIntentEvents",
+		Query:  ReportClientIntentEvents_Operation,
 		Variables: &__ReportClientIntentEventsInput{
 			Events: events,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportClientIntentEventsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportClientIntentEventsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportClientIntentStatuses(
-	ctx context.Context,
-	client graphql.Client,
-	statuses []ClientIntentStatusInput,
-) (*ReportClientIntentStatusesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportClientIntentStatuses",
-		Query: `
+// The query or mutation executed by ReportClientIntentStatuses.
+const ReportClientIntentStatuses_Operation = `
 mutation ReportClientIntentStatuses ($statuses: [ClientIntentStatusInput!]!) {
 	reportClientIntentStatus(statuses: $statuses)
 }
-`,
+`
+
+func ReportClientIntentStatuses(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	statuses []ClientIntentStatusInput,
+) (*ReportClientIntentStatusesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportClientIntentStatuses",
+		Query:  ReportClientIntentStatuses_Operation,
 		Variables: &__ReportClientIntentStatusesInput{
 			Statuses: statuses,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportClientIntentStatusesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportClientIntentStatusesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportComponentStatus(
-	ctx context.Context,
-	client graphql.Client,
-	component ComponentType,
-) (*ReportComponentStatusResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportComponentStatus",
-		Query: `
+// The query or mutation executed by ReportComponentStatus.
+const ReportComponentStatus_Operation = `
 mutation ReportComponentStatus ($component: ComponentType!) {
 	reportIntegrationComponentStatus(component: $component)
 }
-`,
+`
+
+func ReportComponentStatus(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	component ComponentType,
+) (*ReportComponentStatusResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportComponentStatus",
+		Query:  ReportComponentStatus_Operation,
 		Variables: &__ReportComponentStatusInput{
 			Component: component,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportComponentStatusResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportComponentStatusResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportExternallyAccessibleServices(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	services []ExternallyAccessibleServiceInput,
-) (*ReportExternallyAccessibleServicesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportExternallyAccessibleServices",
-		Query: `
+// The query or mutation executed by ReportExternallyAccessibleServices.
+const ReportExternallyAccessibleServices_Operation = `
 mutation ReportExternallyAccessibleServices ($namespace: String!, $services: [ExternallyAccessibleServiceInput!]!) {
 	reportExternallyAccessibleServices(namespace: $namespace, services: $services)
 }
-`,
+`
+
+func ReportExternallyAccessibleServices(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	services []ExternallyAccessibleServiceInput,
+) (*ReportExternallyAccessibleServicesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportExternallyAccessibleServices",
+		Query:  ReportExternallyAccessibleServices_Operation,
 		Variables: &__ReportExternallyAccessibleServicesInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportExternallyAccessibleServicesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportExternallyAccessibleServicesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportIntentsOperatorConfiguration(
-	ctx context.Context,
-	client graphql.Client,
-	configuration IntentsOperatorConfigurationInput,
-) (*ReportIntentsOperatorConfigurationResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportIntentsOperatorConfiguration",
-		Query: `
+// The query or mutation executed by ReportIntentsOperatorConfiguration.
+const ReportIntentsOperatorConfiguration_Operation = `
 mutation ReportIntentsOperatorConfiguration ($configuration: IntentsOperatorConfigurationInput!) {
 	reportIntentsOperatorConfiguration(configuration: $configuration)
 }
-`,
+`
+
+func ReportIntentsOperatorConfiguration(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	configuration IntentsOperatorConfigurationInput,
+) (*ReportIntentsOperatorConfigurationResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportIntentsOperatorConfiguration",
+		Query:  ReportIntentsOperatorConfiguration_Operation,
 		Variables: &__ReportIntentsOperatorConfigurationInput{
 			Configuration: configuration,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportIntentsOperatorConfigurationResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportIntentsOperatorConfigurationResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportKafkaServerConfig(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	kafkaServerConfigs []KafkaServerConfigInput,
-) (*ReportKafkaServerConfigResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportKafkaServerConfig",
-		Query: `
+// The query or mutation executed by ReportKafkaServerConfig.
+const ReportKafkaServerConfig_Operation = `
 mutation ReportKafkaServerConfig ($namespace: String!, $kafkaServerConfigs: [KafkaServerConfigInput!]!) {
 	reportKafkaServerConfigs(namespace: $namespace, serverConfigs: $kafkaServerConfigs)
 }
-`,
+`
+
+func ReportKafkaServerConfig(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	kafkaServerConfigs []KafkaServerConfigInput,
+) (*ReportKafkaServerConfigResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportKafkaServerConfig",
+		Query:  ReportKafkaServerConfig_Operation,
 		Variables: &__ReportKafkaServerConfigInput{
 			Namespace:          namespace,
 			KafkaServerConfigs: kafkaServerConfigs,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportKafkaServerConfigResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportKafkaServerConfigResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportNetworkPolicies(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	policies []NetworkPolicyInput,
-) (*ReportNetworkPoliciesResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportNetworkPolicies",
-		Query: `
+// The query or mutation executed by ReportNetworkPolicies.
+const ReportNetworkPolicies_Operation = `
 mutation ReportNetworkPolicies ($namespace: String!, $policies: [NetworkPolicyInput!]!) {
 	reportNetworkPolicies(namespace: $namespace, policies: $policies)
 }
-`,
+`
+
+func ReportNetworkPolicies(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	policies []NetworkPolicyInput,
+) (*ReportNetworkPoliciesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportNetworkPolicies",
+		Query:  ReportNetworkPolicies_Operation,
 		Variables: &__ReportNetworkPoliciesInput{
 			Namespace: namespace,
 			Policies:  policies,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportNetworkPoliciesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportNetworkPoliciesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func ReportProtectedServicesSnapshot(
-	ctx context.Context,
-	client graphql.Client,
-	namespace string,
-	services []ProtectedServiceInput,
-) (*ReportProtectedServicesSnapshotResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportProtectedServicesSnapshot",
-		Query: `
+// The query or mutation executed by ReportProtectedServicesSnapshot.
+const ReportProtectedServicesSnapshot_Operation = `
 mutation ReportProtectedServicesSnapshot ($namespace: String!, $services: [ProtectedServiceInput!]!) {
 	reportProtectedServicesSnapshot(namespace: $namespace, services: $services)
 }
-`,
+`
+
+func ReportProtectedServicesSnapshot(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	namespace string,
+	services []ProtectedServiceInput,
+) (*ReportProtectedServicesSnapshotResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportProtectedServicesSnapshot",
+		Query:  ReportProtectedServicesSnapshot_Operation,
 		Variables: &__ReportProtectedServicesSnapshotInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportProtectedServicesSnapshotResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportProtectedServicesSnapshotResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func dummy(
-	ctx context.Context,
-	client graphql.Client,
-) (*dummyResponse, error) {
-	req := &graphql.Request{
-		OpName: "dummy",
-		Query: `
+// The query or mutation executed by dummy.
+const dummy_Operation = `
 query dummy {
 	dummyError
 }
-`,
+`
+
+func dummy(
+	ctx_ context.Context,
+	client_ graphql.Client,
+) (*dummyResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "dummy",
+		Query:  dummy_Operation,
 	}
-	var err error
+	var err_ error
 
-	var data dummyResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ dummyResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -309,6 +309,13 @@ input ClientIPConfig {
 	timeoutSeconds: Int
 }
 
+type ClientIntentAccessStatus {
+	total: Int!
+	allowed: Int!
+	blocked: Int!
+	wouldBeBlocked: Int!
+}
+
 type ClientIntentEvent {
 	firstTimestamp: Time
 	lastTimestamp: Time
@@ -720,6 +727,7 @@ type FeatureFlags {
 	useClientIntentsV2: Boolean
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
+	enableInternetIntentsSuggestions: Boolean
 }
 
 type Finding {
@@ -991,6 +999,7 @@ input InputFeatureFlags {
 	useClientIntentsV2: Boolean
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
+	enableInternetIntentsSuggestions: Boolean
 }
 
 """ Findings filter """
@@ -1939,6 +1948,7 @@ input NetworkPolicySpecInput {
 type Organization {
 	id: ID!
 	name: String!
+	uniqueName: String!
 	imageURL: String
 	settings: OrganizationSettings!
 	created: Time!
@@ -2356,6 +2366,8 @@ input ServiceBackendPortInput {
 type ServiceClientIntents {
 	asClient: ClientIntentsFiles
 	asServer: ClientIntentsFiles
+	asClientStatus: ClientIntentAccessStatus
+	asServerStatus: ClientIntentAccessStatus
 	appliedIntentStatus: ClientIntentStatus
 	appliedIntentEvents: [ClientIntentEvent!]
 }

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -184,64 +184,70 @@ type __SendTelemetriesInput struct {
 // GetTelemetries returns __SendTelemetriesInput.Telemetries, and is useful for accessing the field via an interface.
 func (v *__SendTelemetriesInput) GetTelemetries() []TelemetryInput { return v.Telemetries }
 
-func ReportErrors(
-	ctx context.Context,
-	client graphql.Client,
-	component *Component,
-	errors []*Error,
-) (*ReportErrorsResponse, error) {
-	req := &graphql.Request{
-		OpName: "ReportErrors",
-		Query: `
+// The query or mutation executed by ReportErrors.
+const ReportErrors_Operation = `
 mutation ReportErrors ($component: Component!, $errors: [Error!]!) {
 	sendErrors(component: $component, errors: $errors)
 }
-`,
+`
+
+func ReportErrors(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	component *Component,
+	errors []*Error,
+) (*ReportErrorsResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "ReportErrors",
+		Query:  ReportErrors_Operation,
 		Variables: &__ReportErrorsInput{
 			Component: component,
 			Errors:    errors,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data ReportErrorsResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ ReportErrorsResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }
 
-func SendTelemetries(
-	ctx context.Context,
-	client graphql.Client,
-	telemetries []TelemetryInput,
-) (*SendTelemetriesResponse, error) {
-	req := &graphql.Request{
-		OpName: "SendTelemetries",
-		Query: `
+// The query or mutation executed by SendTelemetries.
+const SendTelemetries_Operation = `
 mutation SendTelemetries ($telemetries: [TelemetryInput!]!) {
 	sendTelemetries(telemetries: $telemetries)
 }
-`,
+`
+
+func SendTelemetries(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	telemetries []TelemetryInput,
+) (*SendTelemetriesResponse, error) {
+	req_ := &graphql.Request{
+		OpName: "SendTelemetries",
+		Query:  SendTelemetries_Operation,
 		Variables: &__SendTelemetriesInput{
 			Telemetries: telemetries,
 		},
 	}
-	var err error
+	var err_ error
 
-	var data SendTelemetriesResponse
-	resp := &graphql.Response{Data: &data}
+	var data_ SendTelemetriesResponse
+	resp_ := &graphql.Response{Data: &data_}
 
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
 	)
 
-	return &data, err
+	return &data_, err_
 }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -309,6 +309,13 @@ input ClientIPConfig {
 	timeoutSeconds: Int
 }
 
+type ClientIntentAccessStatus {
+	total: Int!
+	allowed: Int!
+	blocked: Int!
+	wouldBeBlocked: Int!
+}
+
 type ClientIntentEvent {
 	firstTimestamp: Time
 	lastTimestamp: Time
@@ -720,6 +727,7 @@ type FeatureFlags {
 	useClientIntentsV2: Boolean
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
+	enableInternetIntentsSuggestions: Boolean
 }
 
 type Finding {
@@ -991,6 +999,7 @@ input InputFeatureFlags {
 	useClientIntentsV2: Boolean
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
+	enableInternetIntentsSuggestions: Boolean
 }
 
 """ Findings filter """
@@ -1939,6 +1948,7 @@ input NetworkPolicySpecInput {
 type Organization {
 	id: ID!
 	name: String!
+	uniqueName: String!
 	imageURL: String
 	settings: OrganizationSettings!
 	created: Time!
@@ -2356,6 +2366,8 @@ input ServiceBackendPortInput {
 type ServiceClientIntents {
 	asClient: ClientIntentsFiles
 	asServer: ClientIntentsFiles
+	asClientStatus: ClientIntentAccessStatus
+	asServerStatus: ClientIntentAccessStatus
 	appliedIntentStatus: ClientIntentStatus
 	appliedIntentEvents: [ClientIntentEvent!]
 }


### PR DESCRIPTION
### Description
This PR fixes an error which occured when applying Azure ClientIntents on KeyVault scopes, such as this: 
```
apiVersion: k8s.otterize.com/v2alpha1
kind: ClientIntents
metadata:
  name: client-intents-for-client
  namespace: otterize-tutorial-azure-iam
spec:
  workload:
    name: client
    kind: Deployment
  targets:
    - azure:
        scope: /subscriptions/SUBSCRIPTION/resourceGroups/RESOURCEGROUP/providers/Microsoft.KeyVault/vaults/VAULTNAME
        roles: 
          - Key Vault Secrets User
```

This resulted in the following API error when attempting to reconcile the intents:
```
 {                                                                                                                                                                                                                                                
   "error": {                                                                                                                                                                                                                                     
     "code": "NoRegisteredProviderFound",                                                                                                                                                                                                         
     "message": "No registered resource provider found for location 'eastus' and API version '2022-09-01' for type 'vaults'. The supported api-versions are '2014-12-19-preview, 2015-06-01, 2016-10-01, 2018-02-14-preview, 2018-02-14, 2019-09- 
 01, 2020-04-01-preview, 2021-04-01-preview, 2021-06-01-preview, 2021-10-01, 2021-11-01-preview, 2022-02-01-preview, 2022-07-01, 2022-11-01, 2023-02-01, 2023-07-01, 2023-08-01-PREVIEW, 2024-04-01-preview, 2024-11-01, 2024-12-01-preview'. The 
  supported locations are 'northcentralus, eastus, northeurope, westeurope, eastasia, southeastasia, eastus2, centralus, southcentralus, westus, japaneast, japanwest, australiaeast, australiasoutheast, brazilsouth, centralindia, southindia,  
 westindia, canadacentral, canadaeast, uksouth, ukwest, westcentralus, westus2, koreacentral, koreasouth, francecentral, australiacentral, uaenorth, southafricanorth, switzerlandnorth, germanywestcentral, norwayeast, westus3, jioindiawest, s 
 wedencentral, qatarcentral, polandcentral, italynorth, israelcentral, mexicocentral, spaincentral, newzealandnorth'."                                                                                                                            
   }                                                                                                                                                                                                                                              
 }
```

The cause for this is, when applying Azure intents, the intents operator attempted to validate the scope existence using a fixed API version `2022-09-01`. This API version is not supported by KeyVault. 
This was fixed by querying for the specific default API version required for each Azure resource type, and using it to validate the scope existence. 
Moreover, scope existence check will from now on be only performed for scopes attached to Otterize-managed custom role definitions. They are not required for built-in roles (which can support non-existing scopes). 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
