### PR TITLE
Fixed possible panic caused by calling wrong event recorder when handling effective policy for Linkerd

### DIFF
--- a/src/operator/controllers/intents_reconcilers/linkerd_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/linkerd_reconciler.go
@@ -39,7 +39,9 @@ func NewLinkerdReconciler(c client.Client, s *runtime.Scheme, namespaces []strin
 	return linkerdreconciler
 }
 
-func (r *LinkerdReconciler) InjectRecorder(recorder record.EventRecorder) {}
+func (r *LinkerdReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
 
 func (r *LinkerdReconciler) ReconcileEffectivePolicies(ctx context.Context, eps []effectivepolicy.ServiceEffectivePolicy) (int, []error) {
 	installed, err := linkerdmanager.IsLinkerdInstalled(ctx, r.Client)

--- a/src/operator/controllers/intents_reconcilers/linkerd_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/linkerd_reconciler.go
@@ -2,6 +2,7 @@ package intents_reconcilers
 
 import (
 	"context"
+	"fmt"
 	"github.com/amit7itz/goset"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	linkerdmanager "github.com/otterize/intents-operator/src/operator/controllers/linkerd"
@@ -88,9 +89,9 @@ func (r *LinkerdReconciler) applyLinkerdServiceEffectivePolicy(
 	pods, ok, err := r.serviceIdResolver.ResolveServiceIdentityToPodSlice(ctx, ep.Service)
 	if err != nil {
 		if errors.Is(err, serviceidresolver.ErrPodNotFound) {
-			ep.ClientIntentsEventRecorder.RecordWarningEventf(consts.ReasonPodsNotFound,
-				"Could not find non-terminating pods for service %s in namespace %s. Intents could not be reconciled now, but will be reconciled if pods appear later.",
-				ep.Service.Name, ep.Service.Namespace)
+			r.RecordAgnosticWarningEvent(ep, consts.ReasonPodsNotFound,
+				fmt.Sprintf("Could not find non-terminating pods for service %s in namespace %s. Intents could not be reconciled now, but will be reconciled if pods appear later.",
+					ep.Service.Name, ep.Service.Namespace))
 		}
 		return nil, errors.Wrap(err)
 	}
@@ -102,9 +103,9 @@ func (r *LinkerdReconciler) applyLinkerdServiceEffectivePolicy(
 
 	clientServiceAccountName := pod.Spec.ServiceAccountName
 	if !linkerdmanager.IsPodPartOfLinkerdMesh(pod) {
-		ep.ClientIntentsEventRecorder.RecordWarningEventf(linkerdmanager.ReasonNotPartOfLinkerdMesh,
-			"Pod %s in namespace %s is not part of the Linkerd mesh, skipped policy creation",
-			pod.Name, pod.Namespace)
+		r.RecordAgnosticWarningEvent(ep, linkerdmanager.ReasonNotPartOfLinkerdMesh,
+			fmt.Sprintf("Pod %s in namespace %s is not part of the Linkerd mesh, skipped policy creation", pod.Name, pod.Namespace))
+
 		logrus.Warningf("Pod %s.%s is not part of the Linkerd mesh, skipping policy creation", pod.Name, pod.Namespace)
 		return nil, ErrNotPartOfMesh
 	}
@@ -125,4 +126,13 @@ func (r *LinkerdReconciler) handleApplyErrors(err error, errorList []error) []er
 		return errorList
 	}
 	return append(errorList, err)
+}
+
+func (r *LinkerdReconciler) RecordAgnosticWarningEvent(ep effectivepolicy.ServiceEffectivePolicy, reason, msg string) {
+	// Record event on ClientIntents if the service is the Caller, otherwise record on ClientIntents for those who call the service
+	if len(ep.Calls) > 0 {
+		ep.ClientIntentsEventRecorder.RecordWarningEvent(reason, msg)
+	} else {
+		ep.RecordOnClientsWarningEventf(reason, msg)
+	}
 }


### PR DESCRIPTION
### Description
Fixed possible panic caused by calling wrong event recorder when handling effective policy for Linkerd