### PR TITLE
Fix bug where AWS IAM roles could be created for a particular workload even when disabled for that particular workload

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/multi_account_aws_policy_agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/awspolicyagent/multi_account_aws_policy_agent.go
@@ -3,7 +3,6 @@ package awspolicyagent
 import (
 	"context"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
-	"github.com/otterize/intents-operator/src/shared/awsagent"
 	"github.com/otterize/intents-operator/src/shared/awsagent/multi_account_aws_agent"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig"
@@ -27,7 +26,7 @@ func (m *MultiaccountAWSPolicyAgent) IntentType() otterizev2alpha1.IntentType {
 }
 
 func (m *MultiaccountAWSPolicyAgent) AppliesOnPod(pod *corev1.Pod) bool {
-	return awsagent.AppliesOnPod(pod)
+	return multi_account_aws_agent.AppliesOnPod(pod)
 }
 
 func (m *MultiaccountAWSPolicyAgent) AddRolePolicyFromIntents(ctx context.Context, namespace string, accountName string, intentsServiceName string, intents []otterizev2alpha1.Target, pod corev1.Pod) error {

--- a/src/shared/awsagent/agent.go
+++ b/src/shared/awsagent/agent.go
@@ -95,7 +95,7 @@ type Agent struct {
 	profileCacheOnce    sync.Once
 }
 
-const ApplyOnPodLabel = "credentials-operator.otterize.com/create-aws-role"
+const AWSApplyOnPodLabel = "credentials-operator.otterize.com/create-aws-role"
 
 // ServiceAccountAWSAccountIDAnnotation is used by Otterize to indicate that this service account should result in a role in the specified AWS account.
 const ServiceAccountAWSAccountIDAnnotation = "credentials-operator.otterize.com/aws-account"
@@ -113,15 +113,7 @@ func WithSoftDeleteStrategy() Option {
 }
 
 func (a *Agent) AppliesOnPod(pod *corev1.Pod) bool {
-	return AppliesOnPod(pod)
-}
-
-func AppliesOnPod(pod *corev1.Pod) bool {
-	if pod.Labels == nil {
-		return false
-	}
-	_, foundLabel := pod.Labels[ApplyOnPodLabel]
-	return foundLabel
+	return pod.Labels != nil && pod.Labels[AWSApplyOnPodLabel] == "true"
 }
 
 func WithRolesAnywhere(account operatorconfig.AWSAccount, clusterName string, keyPath string, certPath string) Option {

--- a/src/shared/awsagent/multi_account_aws_agent/account_getters.go
+++ b/src/shared/awsagent/multi_account_aws_agent/account_getters.go
@@ -3,10 +3,22 @@ package multi_account_aws_agent
 import (
 	"github.com/otterize/intents-operator/src/shared/awsagent"
 	corev1 "k8s.io/api/core/v1"
+	"regexp"
 )
 
+var AWSAccountIDRegex = regexp.MustCompile(`^(\d{12})$`)
+
+func AppliesOnPod(pod *corev1.Pod) bool {
+	if pod.Labels == nil {
+		return false
+	}
+	value, found := pod.Labels[awsagent.AWSApplyOnPodLabel]
+	// in multi-account-mode, the 'ApplyOnPodLabel' is used to specify the account ID
+	return found && AWSAccountIDRegex.MatchString(value)
+}
+
 func AccountFromPod(pod *corev1.Pod) (string, bool) {
-	value, found := pod.Labels[awsagent.ApplyOnPodLabel]
+	value, found := pod.Labels[awsagent.AWSApplyOnPodLabel]
 	if !found {
 		return "", false
 	}


### PR DESCRIPTION
### Description
This PR fixes an issue with the AWS IAM integration, where pods labeled with `credentials-operator.otterize.com/create-aws-role` were assigned an Otterize-generated IAM role, ignoring the label value. Meaning that if a pod was labeled with `credentials-operator.otterize.com/create-aws-role=false`, the integration would still create and assign an IAM role for it, possibly overriding any other user-managed role assigned to it. 

### References
https://github.com/otterize/credentials-operator/pull/178
https://github.com/otterize/intents-operator/pull/549


### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
