### PR TITLE
Fix ConcurrentModification errors for aws policies

### DIFF
--- a/src/shared/awsagent/agent.go
+++ b/src/shared/awsagent/agent.go
@@ -3,6 +3,7 @@ package awsagent
 import (
 	"context"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -238,4 +239,12 @@ func getCurrentEKSCluster(ctx context.Context, config aws.Config) (*eksTypes.Clu
 	}
 
 	return describeClusterOutput.Cluster, nil
+}
+
+// AWSRetriesOptions adds retry options for AWS SDK operations that may fail due to concurrency issues.
+// ref - https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws/retry
+func AWSBackoffRetryerOptions(options *iam.Options) {
+	options.Retryer = retry.NewStandard(func(o *retry.StandardOptions) {
+		o.MaxAttempts = 5
+	})
 }

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -228,7 +228,7 @@ func (a *Agent) createPolicy(ctx context.Context, role *types.Role, namespace st
 		PolicyDocument: aws.String(policyDoc),
 		PolicyName:     aws.String(fullPolicyName),
 		Tags:           tags,
-	})
+	}, AWSBackoffRetryerOptions)
 
 	if err != nil {
 		if isEntityAlreadyExistsException(err) {
@@ -258,7 +258,7 @@ func (a *Agent) updatePolicy(ctx context.Context, policy *types.Policy, statemen
 		_, err = a.iamClient.UntagPolicy(ctx, &iam.UntagPolicyInput{
 			PolicyArn: policy.Arn,
 			TagKeys:   []string{softDeletedTagKey},
-		})
+		}, AWSBackoffRetryerOptions)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -269,7 +269,7 @@ func (a *Agent) updatePolicy(ctx context.Context, policy *types.Policy, statemen
 		_, err = a.iamClient.UntagPolicy(ctx, &iam.UntagPolicyInput{
 			PolicyArn: policy.Arn,
 			TagKeys:   []string{softDeletionStrategyTagKey},
-		})
+		}, AWSBackoffRetryerOptions)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -280,7 +280,7 @@ func (a *Agent) updatePolicy(ctx context.Context, policy *types.Policy, statemen
 		_, err = a.iamClient.TagPolicy(ctx, &iam.TagPolicyInput{
 			PolicyArn: policy.Arn,
 			Tags:      []types.Tag{{Key: aws.String(softDeletionStrategyTagKey), Value: aws.String(softDeletionStrategyTagValue)}},
-		})
+		}, AWSBackoffRetryerOptions)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -304,7 +304,7 @@ func (a *Agent) updatePolicy(ctx context.Context, policy *types.Policy, statemen
 		PolicyArn:      policy.Arn,
 		PolicyDocument: aws.String(policyDoc),
 		SetAsDefault:   true,
-	})
+	}, AWSBackoffRetryerOptions)
 
 	if err != nil {
 		return errors.Wrap(err)
@@ -318,7 +318,7 @@ func (a *Agent) updatePolicy(ctx context.Context, policy *types.Policy, statemen
 				Value: aws.String(policyHash),
 			},
 		},
-	})
+	}, AWSBackoffRetryerOptions)
 
 	if err != nil {
 		return errors.Wrap(err)
@@ -348,7 +348,7 @@ func (a *Agent) deleteOldestPolicyVersion(ctx context.Context, policy *types.Pol
 	_, err = a.iamClient.DeletePolicyVersion(ctx, &iam.DeletePolicyVersionInput{
 		PolicyArn: policy.Arn,
 		VersionId: oldest.VersionId,
-	})
+	}, AWSBackoffRetryerOptions)
 
 	if err != nil {
 		return errors.Wrap(err)
@@ -361,7 +361,7 @@ func (a *Agent) attachPolicy(ctx context.Context, role *types.Role, policy *type
 	_, err := a.iamClient.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
 		PolicyArn: policy.Arn,
 		RoleName:  role.RoleName,
-	})
+	}, AWSBackoffRetryerOptions)
 
 	return errors.Wrap(err)
 }


### PR DESCRIPTION
### Description

Added retryer to AWS policy-related actiions to avoid the "ConcurrentModification: The previous tagging operation is still ongoing" error

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
