### PR TITLE
Solve a potential race on AWS IAM integration where policy deletion would error because the related IAM role was not found

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iam_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iam_reconciler.go
@@ -5,6 +5,7 @@ import (
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/iam/iampolicyagents"
+	"github.com/otterize/intents-operator/src/shared/awsagent"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -83,6 +84,9 @@ func (r *IAMIntentsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	}
 
 	if err := r.applyTypedIAMIntents(ctx, pod, intents, r.agent); err != nil {
+		if errors.Is(err, awsagent.ErrRoleNotFound) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		return ctrl.Result{}, errors.Wrap(err)
 	}
 

--- a/src/operator/controllers/intents_reconcilers/iam/iam_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iam_reconciler.go
@@ -5,7 +5,7 @@ import (
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/consts"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/iam/iampolicyagents"
-	"github.com/otterize/intents-operator/src/shared/awsagent"
+	"github.com/otterize/intents-operator/src/shared/agentutils"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -84,7 +84,7 @@ func (r *IAMIntentsReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	}
 
 	if err := r.applyTypedIAMIntents(ctx, pod, intents, r.agent); err != nil {
-		if errors.Is(err, awsagent.ErrRoleNotFound) {
+		if errors.Is(err, agentutils.ErrRoleNotFound) {
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, errors.Wrap(err)

--- a/src/shared/agentutils/agentutils.go
+++ b/src/shared/agentutils/agentutils.go
@@ -3,6 +3,7 @@ package agentutils
 import (
 	"crypto/sha256"
 	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 )
@@ -10,6 +11,8 @@ import (
 const (
 	truncatedHashLength = 6
 )
+
+var ErrRoleNotFound = errors.NewSentinelError("role not found")
 
 // TruncateHashName truncates the given name to the given max length and appends a hash to it.
 func TruncateHashName(fullName string, maxLen int) string {

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -8,13 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/otterize/intents-operator/src/shared/agentutils"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"time"
 )
-
-var ErrRoleNotFound = errors.NewSentinelError("role not found")
 
 func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, intentsServiceName string, statements []StatementEntry) error {
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
@@ -26,7 +25,7 @@ func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName
 	if !exists {
 		// Allow sentinel comparison + dynamic error message
 		roleName := a.generateRoleName(namespace, accountName)
-		return fmt.Errorf("%w: %s", ErrRoleNotFound, roleName)
+		return errors.Errorf("%w: %s", agentutils.ErrRoleNotFound, roleName)
 	}
 
 	softDeletionStrategyEnabled := HasSoftDeleteStrategyTagSet(role.Tags)

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -14,6 +14,8 @@ import (
 	"time"
 )
 
+var ErrRoleNotFound = errors.NewSentinelError("role not found")
+
 func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, intentsServiceName string, statements []StatementEntry) error {
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
 
@@ -22,7 +24,9 @@ func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName
 	}
 
 	if !exists {
-		return errors.Errorf("role not found: %s", a.generateRoleName(namespace, accountName))
+		// Allow sentinel comparison + dynamic error message
+		roleName := a.generateRoleName(namespace, accountName)
+		return fmt.Errorf("%w: %s", ErrRoleNotFound, roleName)
 	}
 
 	softDeletionStrategyEnabled := HasSoftDeleteStrategyTagSet(role.Tags)


### PR DESCRIPTION
### Description

In cases when AWS roles were already deleted (possibly by the credentials operator) in a race condition, re-queue the event for another attempt.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
