### PR TITLE
Periodically Check and cleanup orphaned resources in azure

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent.go
@@ -106,7 +106,7 @@ func (a *Agent) ensureRoleAssignmentsForIntents(ctx context.Context, userAssigne
 	a.assignmentMutex.Lock()
 	defer a.assignmentMutex.Unlock()
 
-	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, &userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -210,7 +210,7 @@ func (a *Agent) DeleteRolePolicyFromIntents(ctx context.Context, intents otteriz
 		return errors.Wrap(err)
 	}
 
-	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, &userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -341,7 +341,7 @@ func (a *Agent) ensureCustomRolesForIntents(ctx context.Context, userAssignedIde
 	a.roleMutex.Lock()
 	defer a.roleMutex.Unlock()
 
-	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, userAssignedIdentity)
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, &userAssignedIdentity)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -397,7 +397,7 @@ func (a *Agent) ensureCustomRoleForIntent(ctx context.Context, userAssignedIdent
 		}
 
 		// create a role assignment for the custom role
-		err = a.CreateRoleAssignment(ctx, scope, userAssignedIdentity, *newRole, to.Ptr(azureagent.OtterizeCustomRoleTag))
+		err = a.CreateRoleAssignment(ctx, scope, userAssignedIdentity, *newRole, to.Ptr(azureagent.OtterizeRoleAssignmentTag))
 		if err != nil {
 			// TODO: handle case when custom role is created and role assignment fails
 			return errors.Wrap(err)

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_customroles_test.go
@@ -26,7 +26,7 @@ type AzureCustomRoleTestCase struct {
 	Roles                  []string
 	Actions                []otterizev2alpha1.AzureAction
 	DataActions            []otterizev2alpha1.AzureDataAction
-	ExisingRoles           []*armauthorization.RoleDefinition
+	ExistingRoles          []*armauthorization.RoleDefinition
 	UpdateExpected         bool
 	ShouldCreateAssignment bool
 }
@@ -194,7 +194,7 @@ var azureCustomRoleTestCases = []AzureCustomRoleTestCase{
 			"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
 			"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
 		},
-		ExisingRoles:           nil,
+		ExistingRoles:          nil,
 		UpdateExpected:         true,
 		ShouldCreateAssignment: true,
 	},
@@ -204,7 +204,7 @@ var azureCustomRoleTestCases = []AzureCustomRoleTestCase{
 			"Microsoft.Storage/storageAccounts/blobServices/containers/read",
 			"Microsoft.Storage/storageAccounts/blobServices/containers/write",
 		},
-		ExisingRoles: []*armauthorization.RoleDefinition{
+		ExistingRoles: []*armauthorization.RoleDefinition{
 			{
 				Name: to.Ptr("otterizeCustomRole"),
 				Properties: &armauthorization.RoleDefinitionProperties{
@@ -229,7 +229,7 @@ var azureCustomRoleTestCases = []AzureCustomRoleTestCase{
 		Roles: []string{
 			"Storage Blob Data Reader",
 		},
-		ExisingRoles: []*armauthorization.RoleDefinition{
+		ExistingRoles: []*armauthorization.RoleDefinition{
 			{
 				ID:   to.Ptr("Storage Blob Data Reader"),
 				Name: to.Ptr("Storage Blob Data Reader"),
@@ -278,12 +278,12 @@ func (s *AzureAgentPoliciesCustomRolesSuite) TestAddRolePolicyFromIntents_Custom
 			s.expectListRoleAssignmentsReturnsEmpty()
 
 			// CustomRole related calls
-			s.expectListRoleDefinitionsReturnsPager(testCase.ExisingRoles)
+			s.expectListRoleDefinitionsReturnsPager(testCase.ExistingRoles)
 			if testCase.ShouldCreateAssignment {
 				s.expectCreateRoleAssignmentReturnsEmpty()
 			}
 
-			if testCase.ExisingRoles == nil {
+			if testCase.ExistingRoles == nil {
 				s.expectGetByIDReturnsResource(targetScope)
 			}
 

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_periodic_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/agent_periodic_test.go
@@ -1,0 +1,251 @@
+package azurepolicyagent
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/otterize/intents-operator/src/shared/azureagent"
+	mock_azureagent "github.com/otterize/intents-operator/src/shared/azureagent/mocks"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"sync"
+	"testing"
+)
+
+type AzureCleanupCustomRolesTestCase struct {
+	Name                string
+	ExistingRoles       []*armauthorization.RoleDefinition
+	ExistingAssignments []*armauthorization.RoleAssignment
+	CleanupRole         *string
+	CleanupAssignment   *string
+}
+
+type AzureAgentPeriodicTasksSuite struct {
+	suite.Suite
+
+	mockResourcesClient                    *mock_azureagent.MockAzureARMResourcesClient
+	mockProviderResourceTypesClient        *mock_azureagent.MockAzureARMResourcesProviderResourceTypesClient
+	mockSubscriptionsClient                *mock_azureagent.MockAzureARMSubscriptionsClient
+	mockResourceGroupsClient               *mock_azureagent.MockAzureARMResourcesResourceGroupsClient
+	mockManagedClustersClient              *mock_azureagent.MockAzureARMContainerServiceManagedClustersClient
+	mockUserAssignedIdentitiesClient       *mock_azureagent.MockAzureARMMSIUserAssignedIdentitiesClient
+	mockFederatedIdentityCredentialsClient *mock_azureagent.MockAzureARMMSIFederatedIdentityCredentialsClient
+	mockRoleDefinitionsClient              *mock_azureagent.MockAzureARMAuthorizationRoleDefinitionsClient
+	mockRoleAssignmentsClient              *mock_azureagent.MockAzureARMAuthorizationRoleAssignmentsClient
+	mockVaultsClient                       *mock_azureagent.MockAzureARMKeyVaultVaultsClient
+
+	subscriptionToResourceClient        map[string]azureagent.AzureARMResourcesClient
+	subscriptionToRoleAssignmentsClient map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient
+
+	agent *Agent
+}
+
+func (s *AzureAgentPeriodicTasksSuite) expectListSubscriptionsReturnsPager() {
+	s.mockSubscriptionsClient.EXPECT().NewListPager(nil).Return(azureagent.NewListPager[armsubscriptions.ClientListResponse](
+		armsubscriptions.ClientListResponse{
+			SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+				Value: []*armsubscriptions.Subscription{
+					{
+						ID:             lo.ToPtr(testSubscriptionID),
+						SubscriptionID: lo.ToPtr(testSubscriptionID),
+					},
+				},
+			},
+		},
+	))
+}
+
+func (s *AzureAgentPeriodicTasksSuite) expectListRoleDefinitionsReturnsPager(roles []*armauthorization.RoleDefinition) {
+	s.mockRoleDefinitionsClient.EXPECT().NewListPager(gomock.Any(), gomock.Any()).Return(azureagent.NewListPager[armauthorization.RoleDefinitionsClientListResponse](
+		armauthorization.RoleDefinitionsClientListResponse{
+			RoleDefinitionListResult: armauthorization.RoleDefinitionListResult{
+				Value: roles,
+			},
+		},
+	))
+}
+
+func (s *AzureAgentPeriodicTasksSuite) expectListRoleAssignmentsReturnsPager(assignments []*armauthorization.RoleAssignment) {
+	s.mockRoleAssignmentsClient.EXPECT().NewListForSubscriptionPager(nil).Return(azureagent.NewListPager[armauthorization.RoleAssignmentsClientListForSubscriptionResponse](
+		armauthorization.RoleAssignmentsClientListForSubscriptionResponse{
+			RoleAssignmentListResult: armauthorization.RoleAssignmentListResult{
+				Value: assignments,
+			},
+		},
+	))
+}
+
+func (s *AzureAgentPeriodicTasksSuite) expectDeleteRoleAssignmentSuccess(scope string) {
+	s.mockRoleAssignmentsClient.EXPECT().Delete(gomock.Any(), scope, gomock.Any(), gomock.Any()).Return(
+		armauthorization.RoleAssignmentsClientDeleteResponse{}, nil,
+	)
+}
+
+func (s *AzureAgentPeriodicTasksSuite) expectDeleteCustomRoleDefinitionSuccess(roleDefinitionID string) {
+	s.mockRoleDefinitionsClient.EXPECT().Delete(gomock.Any(), gomock.Any(), roleDefinitionID, nil).Return(
+		armauthorization.RoleDefinitionsClientDeleteResponse{}, nil,
+	)
+}
+
+func (s *AzureAgentPeriodicTasksSuite) SetupTest() {
+	controller := gomock.NewController(s.T())
+
+	s.mockResourcesClient = mock_azureagent.NewMockAzureARMResourcesClient(controller)
+	s.mockProviderResourceTypesClient = mock_azureagent.NewMockAzureARMResourcesProviderResourceTypesClient(controller)
+	s.mockSubscriptionsClient = mock_azureagent.NewMockAzureARMSubscriptionsClient(controller)
+	s.mockResourceGroupsClient = mock_azureagent.NewMockAzureARMResourcesResourceGroupsClient(controller)
+	s.mockManagedClustersClient = mock_azureagent.NewMockAzureARMContainerServiceManagedClustersClient(controller)
+	s.mockUserAssignedIdentitiesClient = mock_azureagent.NewMockAzureARMMSIUserAssignedIdentitiesClient(controller)
+	s.mockFederatedIdentityCredentialsClient = mock_azureagent.NewMockAzureARMMSIFederatedIdentityCredentialsClient(controller)
+	s.mockRoleDefinitionsClient = mock_azureagent.NewMockAzureARMAuthorizationRoleDefinitionsClient(controller)
+	s.mockRoleAssignmentsClient = mock_azureagent.NewMockAzureARMAuthorizationRoleAssignmentsClient(controller)
+	s.mockVaultsClient = mock_azureagent.NewMockAzureARMKeyVaultVaultsClient(controller)
+
+	s.subscriptionToResourceClient = make(map[string]azureagent.AzureARMResourcesClient)
+	s.subscriptionToResourceClient[testSubscriptionID] = s.mockResourcesClient
+
+	s.subscriptionToRoleAssignmentsClient = make(map[string]azureagent.AzureARMAuthorizationRoleAssignmentsClient)
+	s.subscriptionToRoleAssignmentsClient[testSubscriptionID] = s.mockRoleAssignmentsClient
+
+	s.agent = &Agent{
+		azureagent.NewAzureAgentFromClients(
+			azureagent.Config{
+				SubscriptionID:          testSubscriptionID,
+				ResourceGroup:           testResourceGroup,
+				AKSClusterName:          testAKSClusterName,
+				TenantID:                testTenantID,
+				Location:                testLocation,
+				AKSClusterOIDCIssuerURL: testOIDCIssuerURL,
+			},
+			nil,
+			s.mockResourcesClient,
+			s.mockProviderResourceTypesClient,
+			s.mockSubscriptionsClient,
+			s.mockResourceGroupsClient,
+			s.mockManagedClustersClient,
+			s.mockUserAssignedIdentitiesClient,
+			s.mockFederatedIdentityCredentialsClient,
+			s.mockRoleDefinitionsClient,
+			s.mockRoleAssignmentsClient,
+			s.mockVaultsClient,
+			s.subscriptionToResourceClient,
+			s.subscriptionToRoleAssignmentsClient,
+		),
+		sync.Mutex{},
+		sync.Mutex{},
+	}
+}
+
+var cleanupCustomRolesTestCases = []AzureCleanupCustomRolesTestCase{
+	{
+		Name:                "Nothing to clean up - empty list of custom roles",
+		ExistingRoles:       nil,
+		ExistingAssignments: nil,
+		CleanupRole:         nil,
+		CleanupAssignment:   nil,
+	},
+	{
+		Name: "Nothing to clean up - all custom roles are in use",
+		ExistingRoles: []*armauthorization.RoleDefinition{
+			{
+				ID:   to.Ptr("definition-1"),
+				Name: to.Ptr("otterizeCustomRole"),
+				Properties: &armauthorization.RoleDefinitionProperties{
+					Permissions: []*armauthorization.Permission{
+						{
+							Actions: []*string{
+								to.Ptr("Microsoft.Storage/storageAccounts/blobServices/containers/read"),
+							},
+						},
+					},
+					Description: lo.ToPtr(azureagent.OtterizeCustomRoleTag),
+					RoleType:    lo.ToPtr(azureagent.AzureCustomRole),
+				},
+			},
+		},
+		ExistingAssignments: []*armauthorization.RoleAssignment{
+			{
+				ID:   to.Ptr("1"),
+				Name: to.Ptr("otterizeCustomRole"),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr("/subscriptions/scope"),
+					Description:      lo.ToPtr(azureagent.OtterizeRoleAssignmentTag),
+					RoleDefinitionID: to.Ptr("definition-1"),
+				},
+			},
+		},
+		CleanupRole:       nil,
+		CleanupAssignment: nil,
+	},
+	{
+		Name:          "Cleanup role assignment - no connected custom role",
+		ExistingRoles: []*armauthorization.RoleDefinition{},
+		ExistingAssignments: []*armauthorization.RoleAssignment{
+			{
+				ID:   to.Ptr("assignment-1"),
+				Name: to.Ptr("otterizeCustomRole"),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr("/subscriptions/scope/storage/container"),
+					Description:      lo.ToPtr(azureagent.OtterizeRoleAssignmentTag),
+					RoleDefinitionID: to.Ptr("/subscriptions/scope/role/definition-1"),
+				},
+			},
+		},
+		CleanupRole:       lo.ToPtr("definition-1"),
+		CleanupAssignment: lo.ToPtr("/subscriptions/scope/storage/container"),
+	},
+	{
+		Name: "Cleanup custom role - no assignment found",
+		ExistingRoles: []*armauthorization.RoleDefinition{
+			{
+				ID:   to.Ptr("/subscriptions/scope/role/definition-1"),
+				Name: to.Ptr("otterizeCustomRole"),
+				Properties: &armauthorization.RoleDefinitionProperties{
+					Permissions: []*armauthorization.Permission{
+						{
+							Actions: []*string{
+								to.Ptr("Microsoft.Storage/storageAccounts/blobServices/containers/read"),
+							},
+						},
+					},
+					Description: lo.ToPtr(azureagent.OtterizeCustomRoleTag),
+					RoleType:    lo.ToPtr(azureagent.AzureCustomRole),
+				},
+			},
+		},
+		ExistingAssignments: []*armauthorization.RoleAssignment{},
+		CleanupRole:         lo.ToPtr("definition-1"),
+		CleanupAssignment:   nil,
+	},
+}
+
+func (s *AzureAgentPeriodicTasksSuite) TestCleanupCustomRoles() {
+	for _, testCase := range cleanupCustomRolesTestCases {
+		s.Run(testCase.Name, func() {
+			//  List otterize custom roles across all subscriptions
+			s.expectListSubscriptionsReturnsPager()
+			s.expectListRoleDefinitionsReturnsPager(testCase.ExistingRoles)
+
+			// List otterize role assignments across all subscriptions
+			s.expectListSubscriptionsReturnsPager()
+			s.expectListRoleAssignmentsReturnsPager(testCase.ExistingAssignments)
+
+			if testCase.CleanupAssignment != nil {
+				s.expectDeleteRoleAssignmentSuccess(*testCase.CleanupAssignment)
+			}
+
+			if testCase.CleanupRole != nil {
+				s.expectDeleteCustomRoleDefinitionSuccess(*testCase.CleanupRole)
+			}
+
+			err := s.agent.CleanupCustomRoles(context.Background())
+			s.Require().NoError(err)
+		})
+	}
+}
+
+func TestAzureAgentPeriodicTasksSuiteSuite(t *testing.T) {
+	suite.Run(t, new(AzureAgentPeriodicTasksSuite))
+}

--- a/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/periodic.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iampolicyagents/azurepolicyagent/periodic.go
@@ -64,6 +64,7 @@ func (a *Agent) CleanupCustomRoles(ctx context.Context) error {
 			roleScope := a.GetSubscriptionScope(roleID)
 			roleDefinitionID := roleID[strings.LastIndex(roleID, "/")+1:]
 
+			logrus.Warnf("Deleting custom role %s", roleID)
 			err := a.DeleteCustomRole(ctx, roleScope, roleDefinitionID)
 			if err != nil {
 				return errors.Wrap(err)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -301,7 +301,7 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Panic("could not initialize Azure agent")
 		}
-		azureIntentsAgent := azurepolicyagent.NewAzurePolicyAgent(azureAgent)
+		azureIntentsAgent := azurepolicyagent.NewAzurePolicyAgent(signalHandlerCtx, azureAgent)
 
 		iamAgents = append(iamAgents, azureIntentsAgent)
 	}

--- a/src/shared/azureagent/agent.go
+++ b/src/shared/azureagent/agent.go
@@ -13,7 +13,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
 )
 
@@ -130,9 +129,6 @@ func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
 	if err := agent.loadConfDefaults(ctx); err != nil {
 		return nil, errors.Wrap(err)
 	}
-
-	// Start periodic tasks goroutine
-	go wait.Forever(agent.PeriodicTasks, 5*time.Hour)
 
 	return agent, nil
 }

--- a/src/shared/azureagent/agent.go
+++ b/src/shared/azureagent/agent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
 )
 
@@ -130,6 +131,9 @@ func NewAzureAgent(ctx context.Context, conf Config) (*Agent, error) {
 		return nil, errors.Wrap(err)
 	}
 
+	// Start periodic tasks goroutine
+	go wait.Forever(agent.PeriodicTasks, 5*time.Hour)
+
 	return agent, nil
 }
 
@@ -164,7 +168,7 @@ func NewAzureAgentFromClients(
 		vaultsClient:                        vaultsClient,
 		subscriptionToResourceClient:        subscriptionToResourceClient,
 		subscriptionToRoleAssignmentsClient: subscriptionToRoleAssignmentsClient,
-		
+
 		providerResourceTypesCache: expirable.NewLRU[string, map[string]armresources.ProviderResourceType](100, nil, time.Hour),
 	}
 }

--- a/src/shared/azureagent/customroles.go
+++ b/src/shared/azureagent/customroles.go
@@ -20,6 +20,8 @@ const (
 	// maxRoleNameLength rules: 3-512 characters
 	maxRoleNameLength = 200
 
+	AzureCustomRole = "CustomRole"
+
 	OtterizeCustomRoleTag         = "Otterize"
 	OtterizeCustomRoleDescription = "This custom role was created by the Otterize intents-operator's Azure integration. For more details, go to https://otterize.com"
 )
@@ -170,7 +172,7 @@ func (a *Agent) ListCustomRolesForSubscription(ctx context.Context, subscription
 		}
 
 		for _, role := range page.Value {
-			isCustomRole := role.Properties.RoleType != nil && *role.Properties.RoleType == "CustomRole"
+			isCustomRole := role.Properties.RoleType != nil && *role.Properties.RoleType == AzureCustomRole
 			isOtterizeRole := role.Properties.Description != nil && strings.Contains(*role.Properties.Description, OtterizeCustomRoleTag)
 
 			if isCustomRole && isOtterizeRole {

--- a/src/shared/azureagent/customroles.go
+++ b/src/shared/azureagent/customroles.go
@@ -26,7 +26,7 @@ const (
 	OtterizeCustomRoleDescription = "This custom role was created by the Otterize intents-operator's Azure integration. For more details, go to https://otterize.com"
 )
 
-func (a *Agent) getSubscriptionScope(scope string) string {
+func (a *Agent) GetSubscriptionScope(scope string) string {
 	subscriptionId := strings.Split(scope, "/")[2]
 	return fmt.Sprintf("/subscriptions/%s", subscriptionId)
 }
@@ -37,7 +37,7 @@ func (a *Agent) GenerateCustomRoleName(uai armmsi.Identity, scope string) string
 }
 
 func (a *Agent) CreateCustomRole(ctx context.Context, scope string, uai armmsi.Identity, actions []v2alpha1.AzureAction, dataActions []v2alpha1.AzureDataAction) (*armauthorization.RoleDefinition, error) {
-	roleScope := a.getSubscriptionScope(scope)
+	roleScope := a.GetSubscriptionScope(scope)
 
 	formattedActions := lo.Map(actions, func(action v2alpha1.AzureAction, _ int) *string {
 		return to.Ptr(string(action))
@@ -78,7 +78,7 @@ func (a *Agent) UpdateCustomRole(ctx context.Context, scope string, role *armaut
 		return errors.Errorf("role definition is nil or does not have any permissions")
 	}
 
-	roleScope := a.getSubscriptionScope(scope)
+	roleScope := a.GetSubscriptionScope(scope)
 
 	formattedActions := lo.Map(actions, func(action v2alpha1.AzureAction, _ int) *string {
 		return to.Ptr(string(action))
@@ -110,7 +110,7 @@ func (a *Agent) UpdateCustomRole(ctx context.Context, scope string, role *armaut
 }
 
 func (a *Agent) FindCustomRoleByName(ctx context.Context, scope string, name string) (*armauthorization.RoleDefinition, bool) {
-	roleScope := a.getSubscriptionScope(scope)
+	roleScope := a.GetSubscriptionScope(scope)
 	filter := fmt.Sprintf("roleName eq '%s'", name)
 
 	pager := a.roleDefinitionsClient.NewListPager(roleScope, &armauthorization.RoleDefinitionsClientListOptions{
@@ -128,7 +128,7 @@ func (a *Agent) FindCustomRoleByName(ctx context.Context, scope string, name str
 }
 
 func (a *Agent) DeleteCustomRole(ctx context.Context, scope string, roleDefinitionID string) error {
-	roleScope := a.getSubscriptionScope(scope)
+	roleScope := a.GetSubscriptionScope(scope)
 
 	logrus.WithField("id", roleDefinitionID).Debug("Deleting custom role")
 	_, err := a.roleDefinitionsClient.Delete(ctx, roleScope, roleDefinitionID, nil)

--- a/src/shared/azureagent/identities.go
+++ b/src/shared/azureagent/identities.go
@@ -108,7 +108,7 @@ func (a *Agent) DeleteUserAssignedIdentity(ctx context.Context, namespace string
 		return errors.Wrap(err)
 	}
 
-	roleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, identity)
+	roleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, &identity)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/src/shared/azureagent/periodic.go
+++ b/src/shared/azureagent/periodic.go
@@ -45,7 +45,8 @@ func (a *Agent) CleanupCustomRoles(ctx context.Context) error {
 			roleID := *roleAssignment.Properties.RoleDefinitionID
 
 			if _, ok := rolesInUse[roleID]; !ok {
-				// This otterize role assignment is linked to a non-otterize custom role - should not happen
+				// This otterize role assignment is linked to a non-otterize custom role - should not happen in production
+				// If this does happen in testing environments we clean up the role assignment and the custom role it's linked to
 				err := a.DeleteRoleAssignment(ctx, roleAssignment)
 
 				logrus.WithError(err).

--- a/src/shared/azureagent/periodic.go
+++ b/src/shared/azureagent/periodic.go
@@ -1,0 +1,76 @@
+package azureagent
+
+import (
+	"context"
+	"fmt"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+func (a *Agent) PeriodicTasks() {
+	ctx := context.TODO()
+
+	err := a.CleanupCustomRoles(ctx)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to clean up custom roles")
+	}
+}
+
+// CleanupCustomRoles deletes custom roles that got orphaned due to the deletion of its role assignments
+// when deleting a role assignment, the custom role might not get deleted if some error occurs (DeleteRoleAssignment)
+func (a *Agent) CleanupCustomRoles(ctx context.Context) error {
+	// List otterize custom roles across all subscriptions
+	existingCustomRoles, err := a.ListCustomRolesAcrossSubscriptions(ctx)
+	if err != nil {
+		fmt.Println("Error: ", err)
+		return errors.Wrap(err)
+	}
+
+	// Mark all custom roles as not in use
+	rolesInUse := make(map[string]bool)
+	for _, role := range existingCustomRoles {
+		rolesInUse[*role.ID] = false
+	}
+
+	// List otterize role assignments across all subscriptions
+	existingRoleAssignments, err := a.ListRoleAssignmentsAcrossSubscriptions(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	// Mark custom roles that are in use
+	for _, roleAssignment := range existingRoleAssignments {
+		if a.IsCustomRoleAssignment(roleAssignment) {
+			roleID := *roleAssignment.Properties.RoleDefinitionID
+
+			if _, ok := rolesInUse[roleID]; !ok {
+				// This otterize role assignment is linked to a non-otterize custom role - should not happen
+				err := a.DeleteRoleAssignment(ctx, roleAssignment)
+
+				logrus.WithError(err).
+					WithField("role", roleID).
+					WithField("assignment", roleAssignment.Name).
+					Error("Otterize custom role assignment to a non-otterize custom role found")
+				continue
+			}
+
+			rolesInUse[roleID] = true
+		}
+	}
+
+	// Delete custom roles that are not in use
+	for roleID, inUse := range rolesInUse {
+		if !inUse {
+			roleScope := a.getSubscriptionScope(roleID)
+			roleDefinitionID := roleID[strings.LastIndex(roleID, "/")+1:]
+
+			err := a.DeleteCustomRole(ctx, roleScope, roleDefinitionID)
+			if err != nil {
+				return errors.Wrap(err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -905,340 +905,310 @@ type dummyResponse struct {
 // GetDummyError returns dummyResponse.DummyError, and is useful for accessing the field via an interface.
 func (v *dummyResponse) GetDummyError() UserErrorType { return v.DummyError }
 
-// The query or mutation executed by ReportAppliedKubernetesIntents.
-const ReportAppliedKubernetesIntents_Operation = `
-mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
-	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
-}
-`
-
 func ReportAppliedKubernetesIntents(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	namespace *string,
 	intents []*IntentInput,
 	clusterId *string,
 ) (*ReportAppliedKubernetesIntentsResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportAppliedKubernetesIntents",
-		Query:  ReportAppliedKubernetesIntents_Operation,
+		Query: `
+mutation ReportAppliedKubernetesIntents ($namespace: String!, $intents: [IntentInput!]!, $clusterId: String!) {
+	reportAppliedKubernetesIntents(namespace: $namespace, intents: $intents, ossClusterId: $clusterId)
+}
+`,
 		Variables: &__ReportAppliedKubernetesIntentsInput{
 			Namespace: namespace,
 			Intents:   intents,
 			ClusterId: clusterId,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportAppliedKubernetesIntentsResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportAppliedKubernetesIntentsResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by ReportClientIntentEvents.
-const ReportClientIntentEvents_Operation = `
+func ReportClientIntentEvents(
+	ctx context.Context,
+	client graphql.Client,
+	events []ClientIntentEventInput,
+) (*ReportClientIntentEventsResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportClientIntentEvents",
+		Query: `
 mutation ReportClientIntentEvents ($events: [ClientIntentEventInput!]!) {
 	reportClientIntentEvent(events: $events)
 }
-`
-
-func ReportClientIntentEvents(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	events []ClientIntentEventInput,
-) (*ReportClientIntentEventsResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "ReportClientIntentEvents",
-		Query:  ReportClientIntentEvents_Operation,
+`,
 		Variables: &__ReportClientIntentEventsInput{
 			Events: events,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportClientIntentEventsResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportClientIntentEventsResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by ReportClientIntentStatuses.
-const ReportClientIntentStatuses_Operation = `
+func ReportClientIntentStatuses(
+	ctx context.Context,
+	client graphql.Client,
+	statuses []ClientIntentStatusInput,
+) (*ReportClientIntentStatusesResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportClientIntentStatuses",
+		Query: `
 mutation ReportClientIntentStatuses ($statuses: [ClientIntentStatusInput!]!) {
 	reportClientIntentStatus(statuses: $statuses)
 }
-`
-
-func ReportClientIntentStatuses(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	statuses []ClientIntentStatusInput,
-) (*ReportClientIntentStatusesResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "ReportClientIntentStatuses",
-		Query:  ReportClientIntentStatuses_Operation,
+`,
 		Variables: &__ReportClientIntentStatusesInput{
 			Statuses: statuses,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportClientIntentStatusesResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportClientIntentStatusesResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by ReportComponentStatus.
-const ReportComponentStatus_Operation = `
+func ReportComponentStatus(
+	ctx context.Context,
+	client graphql.Client,
+	component ComponentType,
+) (*ReportComponentStatusResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportComponentStatus",
+		Query: `
 mutation ReportComponentStatus ($component: ComponentType!) {
 	reportIntegrationComponentStatus(component: $component)
 }
-`
-
-func ReportComponentStatus(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	component ComponentType,
-) (*ReportComponentStatusResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "ReportComponentStatus",
-		Query:  ReportComponentStatus_Operation,
+`,
 		Variables: &__ReportComponentStatusInput{
 			Component: component,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportComponentStatusResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportComponentStatusResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
-
-// The query or mutation executed by ReportExternallyAccessibleServices.
-const ReportExternallyAccessibleServices_Operation = `
-mutation ReportExternallyAccessibleServices ($namespace: String!, $services: [ExternallyAccessibleServiceInput!]!) {
-	reportExternallyAccessibleServices(namespace: $namespace, services: $services)
-}
-`
 
 func ReportExternallyAccessibleServices(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	namespace string,
 	services []ExternallyAccessibleServiceInput,
 ) (*ReportExternallyAccessibleServicesResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportExternallyAccessibleServices",
-		Query:  ReportExternallyAccessibleServices_Operation,
+		Query: `
+mutation ReportExternallyAccessibleServices ($namespace: String!, $services: [ExternallyAccessibleServiceInput!]!) {
+	reportExternallyAccessibleServices(namespace: $namespace, services: $services)
+}
+`,
 		Variables: &__ReportExternallyAccessibleServicesInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportExternallyAccessibleServicesResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportExternallyAccessibleServicesResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by ReportIntentsOperatorConfiguration.
-const ReportIntentsOperatorConfiguration_Operation = `
+func ReportIntentsOperatorConfiguration(
+	ctx context.Context,
+	client graphql.Client,
+	configuration IntentsOperatorConfigurationInput,
+) (*ReportIntentsOperatorConfigurationResponse, error) {
+	req := &graphql.Request{
+		OpName: "ReportIntentsOperatorConfiguration",
+		Query: `
 mutation ReportIntentsOperatorConfiguration ($configuration: IntentsOperatorConfigurationInput!) {
 	reportIntentsOperatorConfiguration(configuration: $configuration)
 }
-`
-
-func ReportIntentsOperatorConfiguration(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	configuration IntentsOperatorConfigurationInput,
-) (*ReportIntentsOperatorConfigurationResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "ReportIntentsOperatorConfiguration",
-		Query:  ReportIntentsOperatorConfiguration_Operation,
+`,
 		Variables: &__ReportIntentsOperatorConfigurationInput{
 			Configuration: configuration,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportIntentsOperatorConfigurationResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportIntentsOperatorConfigurationResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
-
-// The query or mutation executed by ReportKafkaServerConfig.
-const ReportKafkaServerConfig_Operation = `
-mutation ReportKafkaServerConfig ($namespace: String!, $kafkaServerConfigs: [KafkaServerConfigInput!]!) {
-	reportKafkaServerConfigs(namespace: $namespace, serverConfigs: $kafkaServerConfigs)
-}
-`
 
 func ReportKafkaServerConfig(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	namespace string,
 	kafkaServerConfigs []KafkaServerConfigInput,
 ) (*ReportKafkaServerConfigResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportKafkaServerConfig",
-		Query:  ReportKafkaServerConfig_Operation,
+		Query: `
+mutation ReportKafkaServerConfig ($namespace: String!, $kafkaServerConfigs: [KafkaServerConfigInput!]!) {
+	reportKafkaServerConfigs(namespace: $namespace, serverConfigs: $kafkaServerConfigs)
+}
+`,
 		Variables: &__ReportKafkaServerConfigInput{
 			Namespace:          namespace,
 			KafkaServerConfigs: kafkaServerConfigs,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportKafkaServerConfigResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportKafkaServerConfigResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
-
-// The query or mutation executed by ReportNetworkPolicies.
-const ReportNetworkPolicies_Operation = `
-mutation ReportNetworkPolicies ($namespace: String!, $policies: [NetworkPolicyInput!]!) {
-	reportNetworkPolicies(namespace: $namespace, policies: $policies)
-}
-`
 
 func ReportNetworkPolicies(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	namespace string,
 	policies []NetworkPolicyInput,
 ) (*ReportNetworkPoliciesResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportNetworkPolicies",
-		Query:  ReportNetworkPolicies_Operation,
+		Query: `
+mutation ReportNetworkPolicies ($namespace: String!, $policies: [NetworkPolicyInput!]!) {
+	reportNetworkPolicies(namespace: $namespace, policies: $policies)
+}
+`,
 		Variables: &__ReportNetworkPoliciesInput{
 			Namespace: namespace,
 			Policies:  policies,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportNetworkPoliciesResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportNetworkPoliciesResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
-
-// The query or mutation executed by ReportProtectedServicesSnapshot.
-const ReportProtectedServicesSnapshot_Operation = `
-mutation ReportProtectedServicesSnapshot ($namespace: String!, $services: [ProtectedServiceInput!]!) {
-	reportProtectedServicesSnapshot(namespace: $namespace, services: $services)
-}
-`
 
 func ReportProtectedServicesSnapshot(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	namespace string,
 	services []ProtectedServiceInput,
 ) (*ReportProtectedServicesSnapshotResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportProtectedServicesSnapshot",
-		Query:  ReportProtectedServicesSnapshot_Operation,
+		Query: `
+mutation ReportProtectedServicesSnapshot ($namespace: String!, $services: [ProtectedServiceInput!]!) {
+	reportProtectedServicesSnapshot(namespace: $namespace, services: $services)
+}
+`,
 		Variables: &__ReportProtectedServicesSnapshotInput{
 			Namespace: namespace,
 			Services:  services,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportProtectedServicesSnapshotResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportProtectedServicesSnapshotResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by dummy.
-const dummy_Operation = `
+func dummy(
+	ctx context.Context,
+	client graphql.Client,
+) (*dummyResponse, error) {
+	req := &graphql.Request{
+		OpName: "dummy",
+		Query: `
 query dummy {
 	dummyError
 }
-`
-
-func dummy(
-	ctx_ context.Context,
-	client_ graphql.Client,
-) (*dummyResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "dummy",
-		Query:  dummy_Operation,
+`,
 	}
-	var err_ error
+	var err error
 
-	var data_ dummyResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data dummyResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -585,6 +585,12 @@ input DiscoveredIntentInput {
 	intent: IntentInput!
 }
 
+input EBPFDiagnostics {
+	containerImage: String
+	executable: String
+	programName: String
+}
+
 type EdgeAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
@@ -699,6 +705,8 @@ enum EventType {
 	PROTECTED_SERVICE_APPLIED
 	PROTECTED_SERVICE_DELETED
 	ACTIVE
+	EBPF_ATTACHED
+	EBPF_ATTACH_FAILED
 }
 
 input ExternalTrafficDiscoveredIntentInput {
@@ -1143,6 +1151,7 @@ enum IntegrationState {
 	FAILURE
 	PENDING
 	WARNING
+	DISABLED
 }
 
 type IntegrationStatus {
@@ -1654,6 +1663,7 @@ type Mutation {
 		ignored: Boolean!
 		reason: String
 	): Boolean!
+	createFindingsForOrg: Boolean!
 """Create a new generic integration"""
 	createGenericIntegration(
 		name: String!
@@ -2030,6 +2040,11 @@ type Query {
 		clusterIds: [ID!]
 		featureFlags: InputFeatureFlags
 	): [ClientIntentsFileRepresentation!]!
+""" Get service incoming internet connections """
+	serviceIncomingInternetConnections(
+		targetServiceId: ID!
+		lastSeenAfter: Time!
+	): [String!]!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter
@@ -2360,6 +2375,7 @@ type ServiceAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	protectionStatus: ServerProtectionStatus!
 	protectionStatuses: ServerProtectionStatuses!
 	blockingStatus: ServerBlockingStatus!
@@ -2502,11 +2518,13 @@ enum TelemetryComponentType {
 	CREDENTIALS_OPERATOR
 	NETWORK_MAPPER
 	CLI
+	NODE_AGENT
 }
 
 input TelemetryData {
 	eventType: EventType!
 	count: Int
+	ebpf: EBPFDiagnostics
 }
 
 input TelemetryInput {

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -31,6 +31,21 @@ func (v *Component) GetVersion() string { return v.Version }
 // GetCloudClientId returns Component.CloudClientId, and is useful for accessing the field via an interface.
 func (v *Component) GetCloudClientId() string { return v.CloudClientId }
 
+type EBPFDiagnostics struct {
+	ContainerImage string `json:"containerImage"`
+	Executable     string `json:"executable"`
+	ProgramName    string `json:"programName"`
+}
+
+// GetContainerImage returns EBPFDiagnostics.ContainerImage, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetContainerImage() string { return v.ContainerImage }
+
+// GetExecutable returns EBPFDiagnostics.Executable, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetExecutable() string { return v.Executable }
+
+// GetProgramName returns EBPFDiagnostics.ProgramName, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetProgramName() string { return v.ProgramName }
+
 type Error struct {
 	Message    *string          `json:"message"`
 	ErrorClass *string          `json:"errorClass"`
@@ -85,6 +100,8 @@ const (
 	EventTypeProtectedServiceApplied     EventType = "PROTECTED_SERVICE_APPLIED"
 	EventTypeProtectedServiceDeleted     EventType = "PROTECTED_SERVICE_DELETED"
 	EventTypeActive                      EventType = "ACTIVE"
+	EventTypeEbpfAttached                EventType = "EBPF_ATTACHED"
+	EventTypeEbpfAttachFailed            EventType = "EBPF_ATTACH_FAILED"
 )
 
 type MetadataEntry struct {
@@ -140,11 +157,13 @@ const (
 	TelemetryComponentTypeCredentialsOperator TelemetryComponentType = "CREDENTIALS_OPERATOR"
 	TelemetryComponentTypeNetworkMapper       TelemetryComponentType = "NETWORK_MAPPER"
 	TelemetryComponentTypeCli                 TelemetryComponentType = "CLI"
+	TelemetryComponentTypeNodeAgent           TelemetryComponentType = "NODE_AGENT"
 )
 
 type TelemetryData struct {
-	EventType EventType `json:"eventType"`
-	Count     int       `json:"count"`
+	EventType EventType       `json:"eventType"`
+	Count     int             `json:"count"`
+	Ebpf      EBPFDiagnostics `json:"ebpf"`
 }
 
 // GetEventType returns TelemetryData.EventType, and is useful for accessing the field via an interface.
@@ -152,6 +171,9 @@ func (v *TelemetryData) GetEventType() EventType { return v.EventType }
 
 // GetCount returns TelemetryData.Count, and is useful for accessing the field via an interface.
 func (v *TelemetryData) GetCount() int { return v.Count }
+
+// GetEbpf returns TelemetryData.Ebpf, and is useful for accessing the field via an interface.
+func (v *TelemetryData) GetEbpf() EBPFDiagnostics { return v.Ebpf }
 
 type TelemetryInput struct {
 	Component Component     `json:"component"`
@@ -184,70 +206,64 @@ type __SendTelemetriesInput struct {
 // GetTelemetries returns __SendTelemetriesInput.Telemetries, and is useful for accessing the field via an interface.
 func (v *__SendTelemetriesInput) GetTelemetries() []TelemetryInput { return v.Telemetries }
 
-// The query or mutation executed by ReportErrors.
-const ReportErrors_Operation = `
-mutation ReportErrors ($component: Component!, $errors: [Error!]!) {
-	sendErrors(component: $component, errors: $errors)
-}
-`
-
 func ReportErrors(
-	ctx_ context.Context,
-	client_ graphql.Client,
+	ctx context.Context,
+	client graphql.Client,
 	component *Component,
 	errors []*Error,
 ) (*ReportErrorsResponse, error) {
-	req_ := &graphql.Request{
+	req := &graphql.Request{
 		OpName: "ReportErrors",
-		Query:  ReportErrors_Operation,
+		Query: `
+mutation ReportErrors ($component: Component!, $errors: [Error!]!) {
+	sendErrors(component: $component, errors: $errors)
+}
+`,
 		Variables: &__ReportErrorsInput{
 			Component: component,
 			Errors:    errors,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ ReportErrorsResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data ReportErrorsResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }
 
-// The query or mutation executed by SendTelemetries.
-const SendTelemetries_Operation = `
+func SendTelemetries(
+	ctx context.Context,
+	client graphql.Client,
+	telemetries []TelemetryInput,
+) (*SendTelemetriesResponse, error) {
+	req := &graphql.Request{
+		OpName: "SendTelemetries",
+		Query: `
 mutation SendTelemetries ($telemetries: [TelemetryInput!]!) {
 	sendTelemetries(telemetries: $telemetries)
 }
-`
-
-func SendTelemetries(
-	ctx_ context.Context,
-	client_ graphql.Client,
-	telemetries []TelemetryInput,
-) (*SendTelemetriesResponse, error) {
-	req_ := &graphql.Request{
-		OpName: "SendTelemetries",
-		Query:  SendTelemetries_Operation,
+`,
 		Variables: &__SendTelemetriesInput{
 			Telemetries: telemetries,
 		},
 	}
-	var err_ error
+	var err error
 
-	var data_ SendTelemetriesResponse
-	resp_ := &graphql.Response{Data: &data_}
+	var data SendTelemetriesResponse
+	resp := &graphql.Response{Data: &data}
 
-	err_ = client_.MakeRequest(
-		ctx_,
-		req_,
-		resp_,
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
 	)
 
-	return &data_, err_
+	return &data, err
 }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -399,8 +399,10 @@ type Cluster {
 type ClusterConfiguration {
 	globalDefaultDeny: Boolean!
 	istioGlobalDefaultDeny: Boolean!
+	linkerdGlobalDefaultDeny: Boolean!
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useAWSIAMInAccessGraphStates: Boolean!
 	useGCPIAMInAccessGraphStates: Boolean!
@@ -412,8 +414,10 @@ type ClusterConfiguration {
 input ClusterConfigurationInput {
 	globalDefaultDeny: Boolean!
 	istioGlobalDefaultDeny: Boolean
+	linkerdGlobalDefaultDeny: Boolean
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useAWSIAMInAccessGraphStates: Boolean
 	useGCPIAMInAccessGraphStates: Boolean
@@ -581,9 +585,16 @@ input DiscoveredIntentInput {
 	intent: IntentInput!
 }
 
+input EBPFDiagnostics {
+	containerImage: String
+	executable: String
+	programName: String
+}
+
 type EdgeAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	useKafkaPoliciesInAccessGraphStates: Boolean!
 	verdict: EdgeAccessStatusVerdict!
 	reason: EdgeAccessStatusReason!
@@ -645,6 +656,7 @@ type EdgeAccessStatuses {
 	gcpIam: EdgeAccessStatus!
 	azureIAM: EdgeAccessStatus!
 	database: EdgeAccessStatus!
+	linkerdPolicies: EdgeAccessStatus!
 }
 
 type Environment {
@@ -693,6 +705,8 @@ enum EventType {
 	PROTECTED_SERVICE_APPLIED
 	PROTECTED_SERVICE_DELETED
 	ACTIVE
+	EBPF_ATTACHED
+	EBPF_ATTACH_FAILED
 }
 
 input ExternalTrafficDiscoveredIntentInput {
@@ -1137,6 +1151,7 @@ enum IntegrationState {
 	FAILURE
 	PENDING
 	WARNING
+	DISABLED
 }
 
 type IntegrationStatus {
@@ -1241,6 +1256,7 @@ type IntentsOperatorConfiguration {
 	networkPolicyEnforcementEnabled: Boolean!
 	kafkaACLEnforcementEnabled: Boolean!
 	istioPolicyEnforcementEnabled: Boolean!
+	linkerdPolicyEnforcementEnabled: Boolean!
 	awsIAMPolicyEnforcementEnabled: Boolean!
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
@@ -1256,6 +1272,7 @@ input IntentsOperatorConfigurationInput {
 	networkPolicyEnforcementEnabled: Boolean
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
+	linkerdPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
 	egressNetworkPolicyEnforcementEnabled: Boolean
 	awsIAMPolicyEnforcementEnabled: Boolean
@@ -1646,6 +1663,7 @@ type Mutation {
 		ignored: Boolean!
 		reason: String
 	): Boolean!
+	createFindingsForOrg: Boolean!
 """Create a new generic integration"""
 	createGenericIntegration(
 		name: String!
@@ -2022,6 +2040,11 @@ type Query {
 		clusterIds: [ID!]
 		featureFlags: InputFeatureFlags
 	): [ClientIntentsFileRepresentation!]!
+""" Get service incoming internet connections """
+	serviceIncomingInternetConnections(
+		targetServiceId: ID!
+		lastSeenAfter: Time!
+	): [String!]!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter
@@ -2352,6 +2375,7 @@ type ServiceAccessStatus {
 	useNetworkPoliciesInAccessGraphStates: Boolean!
 	useKafkaACLsInAccessGraphStates: Boolean!
 	useIstioPoliciesInAccessGraphStates: Boolean!
+	useLinkerdPoliciesInAccessGraphStates: Boolean!
 	protectionStatus: ServerProtectionStatus!
 	protectionStatuses: ServerProtectionStatuses!
 	blockingStatus: ServerBlockingStatus!
@@ -2494,11 +2518,13 @@ enum TelemetryComponentType {
 	CREDENTIALS_OPERATOR
 	NETWORK_MAPPER
 	CLI
+	NODE_AGENT
 }
 
 input TelemetryData {
 	eventType: EventType!
 	count: Int
+	ebpf: EBPFDiagnostics
 }
 
 input TelemetryInput {


### PR DESCRIPTION
### Description

Periodically Check and cleanup orphaned resources in azure that could have been left over because of network errors or race conditions. Some resources (such as custom roles and role assignments) must be deleted together and an interrupt in the middle of the deletion transaction might cause orphaned resources.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
