### PR TITLE
Fix bug where operator config report would report incorrect Istio/Linkerd installation status upon startup

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -329,7 +329,7 @@ func main() {
 		logrus.WithError(err).Error("Failed to initialize Otterize Cloud client")
 	}
 	if connectedToCloud {
-		operator_cloud_client.StartPeriodicCloudReports(signalHandlerCtx, otterizeCloudClient, mgr.GetClient())
+		operator_cloud_client.StartPeriodicCloudReports(signalHandlerCtx, otterizeCloudClient, mgr)
 		intentsEventsSender, err := operator_cloud_client.NewIntentEventsSender(otterizeCloudClient, mgr)
 		if err != nil {
 			logrus.WithError(err).Panic("unable to create intent events sender")

--- a/src/shared/otterizecloud/otterizecloudclient/config.go
+++ b/src/shared/otterizecloud/otterizecloudclient/config.go
@@ -16,7 +16,7 @@ const (
 	ComponentReportIntervalKey          = "component-report-interval"
 	ComponentReportIntervalDefault      = 60
 	OperatorConfigReportIntervalKey     = "operator-config-report-interval"
-	OperatorConfigReportIntervalDefault = 600
+	OperatorConfigReportIntervalDefault = 60
 	IntentEventsReportIntervalKey       = "intent-events-report-interval"
 	IntentEventsReportIntervalDefault   = 60
 	IntentStatusReportIntervalKey       = "intent-status-report-interval"


### PR DESCRIPTION
### Description

The operator could fail to query Linkerd/Istio status because the cache is not yet initialized. This would result in reporting a "true" value, which the cloud would use to calculate the access graph and in turn result in incorrect access statuses.

Fixed the issue where the cache was not initialized by adding a wait, and also no longer assume "true" for installation on failure.