### PR TITLE
Fix a bug where errors were reported on IAM ClientIntents update or deletion, by detecting that the cloud role was not found, and re-queuing or completing the request

### DIFF
--- a/src/operator/controllers/intents_reconcilers/iam/iam_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/iam/iam_reconciler_test.go
@@ -247,7 +247,7 @@ func (s *IAMIntentsReconcilerTestSuite) TestRoleNotFoundErrorReQueuesEvent() {
 
 	// Throw the sentinel error
 	s.iamAgent.EXPECT().AddRolePolicyFromIntents(gomock.Any(), testNamespace, testClientServiceAccount, testServiceName, []otterizev2alpha1.Target{}, clientPod).Return(
-		errors.Errorf("%w: %s", agentutils.ErrRoleNotFound, "test error"),
+		errors.Errorf("%w: %s", agentutils.ErrCloudIdentityNotFound, "test error"),
 	)
 
 	res, err := s.Reconciler.Reconcile(context.Background(), req)

--- a/src/shared/agentutils/agentutils.go
+++ b/src/shared/agentutils/agentutils.go
@@ -12,7 +12,7 @@ const (
 	truncatedHashLength = 6
 )
 
-var ErrRoleNotFound = errors.NewSentinelError("role not found")
+var ErrCloudIdentityNotFound = errors.NewSentinelError("cloud identity/role not found")
 
 // TruncateHashName truncates the given name to the given max length and appends a hash to it.
 func TruncateHashName(fullName string, maxLen int) string {

--- a/src/shared/awsagent/policies.go
+++ b/src/shared/awsagent/policies.go
@@ -17,15 +17,13 @@ import (
 
 func (a *Agent) AddRolePolicy(ctx context.Context, namespace string, accountName string, intentsServiceName string, statements []StatementEntry) error {
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
-
 	if err != nil {
 		return errors.Wrap(err)
 	}
-
 	if !exists {
 		// Allow sentinel comparison + dynamic error message
 		roleName := a.generateRoleName(namespace, accountName)
-		return errors.Errorf("%w: %s", agentutils.ErrRoleNotFound, roleName)
+		return errors.Errorf("%w: %s", agentutils.ErrCloudIdentityNotFound, roleName)
 	}
 
 	softDeletionStrategyEnabled := HasSoftDeleteStrategyTagSet(role.Tags)
@@ -152,7 +150,6 @@ func (a *Agent) softDeletePolicy(ctx context.Context, policyName string) error {
 	output, err := a.iamClient.GetPolicy(ctx, &iam.GetPolicyInput{
 		PolicyArn: aws.String(a.generatePolicyArn(policyName)),
 	})
-
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -173,13 +170,11 @@ func (a *Agent) SetRolePolicy(ctx context.Context, namespace, accountName string
 	roleName := a.generateRoleName(namespace, accountName)
 
 	exists, role, err := a.GetOtterizeRole(ctx, namespace, accountName)
-
 	if err != nil {
 		return errors.Wrap(err)
 	}
-
 	if !exists {
-		return errors.Errorf("role not found: %s", roleName)
+		return errors.Errorf("%w: %s", agentutils.ErrCloudIdentityNotFound, roleName)
 	}
 
 	policyDoc, _, err := generatePolicyDocument(statements)

--- a/src/shared/awsagent/roles.go
+++ b/src/shared/awsagent/roles.go
@@ -253,7 +253,6 @@ func (a *Agent) CreateOtterizeIAMRole(ctx context.Context, namespaceName string,
 func (a *Agent) DeleteOtterizeIAMRole(ctx context.Context, namespaceName, accountName string) error {
 	logger := logrus.WithField("namespace", namespaceName).WithField("account", accountName)
 	exists, role, err := a.GetOtterizeRole(ctx, namespaceName, accountName)
-
 	if err != nil {
 		return errors.Wrap(err)
 	}


### PR DESCRIPTION
### Description

In cases when service accounts are deleted in parallel with intents (for example if deleting a namespace) - there will be a race condition between the credentials and intents operators. The credentials operator will delete the cloud IAM resource (role/identity) that the intents operator uses. The intents operator in turn will try to query this resource in order to perform its own cleanup and fail on not found. To avoid this we are performing full cleanup of the cloud resource dependencies on deletion (on the credentials operator side) and re-queue/ignore the intents operator event as necessary.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
