### PR TITLE
Fix intents-operator sending STARTED telemetry with 0-count, which is inconsistent with other operators

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -552,7 +552,7 @@ func main() {
 	}
 
 	logrus.Info("starting manager")
-	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeStarted, 0)
+	telemetrysender.SendIntentOperator(telemetriesgql.EventTypeStarted, 1)
 	telemetrysender.IntentsOperatorRunActiveReporter(signalHandlerCtx)
 
 	if err := mgr.Start(signalHandlerCtx); err != nil {


### PR DESCRIPTION
### Description
Fix STARTED telemetry sent by the intents-operator, to be sent with `count=1` (rather than 0), making it consistent with other OSS components. 



### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
