### PR TITLE
Resolve an issue where the AllowExternalTraffic configuration was not set to its default value

### DIFF
--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -43,7 +43,7 @@ func (c Config) GetActualExternalTrafficPolicy() allowexternaltraffic.Enum {
 const (
 	ActiveEnforcementNamespacesKey              = "active-enforcement-namespaces" // When using the "shadow enforcement" mode, namespaces in this list will be treated as if the enforcement were active
 	AllowExternalTrafficKey                     = "allow-external-traffic"        // Whether to automatically create network policies for external traffic
-	AllowExternalTrafficDefault                 = allowexternaltraffic.IfBlockedByOtterize
+	AllowExternalTrafficDefault                 = string(allowexternaltraffic.IfBlockedByOtterize)
 	EnforcementDefaultStateKey                  = "enforcement-default-state" // Sets the default state of the  If true, always enforces. If false, can be overridden using ProtectedService.
 	EnforcementDefaultStateDefault              = true
 	EnableNetworkPolicyKey                      = "enable-network-policy-creation" // Whether to enable Intents network policy creation
@@ -91,7 +91,7 @@ func InitCLIFlags() {
 	pflag.Bool(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault, "Experimental - enable the generation of egress network policies alongside ingress network policies")
 	pflag.Bool(EnableAWSPolicyKey, EnableAWSPolicyDefault, "Enable the AWS IAM reconciler")
 	allowExternalTrafficDefault := AllowExternalTrafficDefault
-	pflag.Var(&allowExternalTrafficDefault, AllowExternalTrafficKey, "Whether to automatically create network policies for external traffic")
+	pflag.String(allowExternalTrafficDefault, AllowExternalTrafficKey, "Whether to automatically create network policies for external traffic")
 }
 
 func GetConfig() Config {


### PR DESCRIPTION
### Description
Fixing setting the initial value of `AllowExternalTraffic` configuration when there is no value in the helm file.

Technical details:
When creating the configuration, we are fetching this value using `viper.GetString()`, which expect a string value (rather than enum), so we must set it as string as well.

### Testing
Tested locally by running the intents operator and making sure that it reports values to Otterize cloud..

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
