### PR TITLE
Added support for reusing the webhook TLS certificate across different deployments to prevent cases where operator takes too long to start up

### DIFF
--- a/src/operator/config/rbac/manifests-patched.yaml
+++ b/src/operator/config/rbac/manifests-patched.yaml
@@ -56,6 +56,17 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - intents-operator-webhook-cert
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/src/operator/config/rbac/role.yaml
+++ b/src/operator/config/rbac/role.yaml
@@ -56,6 +56,17 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - intents-operator-webhook-cert
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:


### PR DESCRIPTION
### Description
Before this PR, the intents operator would recreate its webhook TLS certificate upon startup. During rollout, this meant that the old and new instances of the operator would "fight" to keep their certificate the one that is configured on the cluster. This would resolve itself after a short while, as the old instance went down. However, it resulted in many errors in the log, and in rare cases, a startup time of over 200 seconds and multiple restarts until the operator was finally healthy.

This PR makes the operator reuse the certificate, so both the old and new instances will use the same one. Importantly, this means that the new operator can start WATCHing resources immediately. Before, if the new operator switched the webhook certificate, it could not watch ClientIntents, since ClientIntents had a webhook set up on them, and this would break the webhook temporarily. This was the root cause for startup taking some time: the operator had to retry watching until it was set up as the webhook, and it's a race condition with retries, so in rare situations it could take a long time. This prevents this situation altogether and also, the operator is now only Ready only once it was able to sync its cache, indicating that reconciliation will immediately be functional.

### References
https://github.com/otterize/helm-charts/pull/282
