### PR TITLE
Create warning event if client has internet intent without egress policy

### DIFF
--- a/src/operator/controllers/intents_reconcilers/consts/consts.go
+++ b/src/operator/controllers/intents_reconcilers/consts/consts.go
@@ -29,4 +29,5 @@ const (
 	ReasonCreatedInternetEgressNetworkPolicies                    = "CreatedInternetEgressNetworkPolicies"
 	ReasonIntentToUnresolvedDns                                   = "IntentToUnresolvedDns"
 	ReasonInternetEgressNetworkPolicyCreationWaitingUnresolvedDNS = "InternetEgressNetworkPolicyCreationWaitingUnresolvedDNS"
+	ReasonInternetEgressNetworkPolicyWithEgressPolicyDisabled     = "ReasonInternetEgressNetworkPolicyWithEgressPolicyDisabled"
 )

--- a/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/networkpolicy/reconciler.go
@@ -217,9 +217,21 @@ func (r *Reconciler) recordCreateFailedError(ep effectivepolicy.ServiceEffective
 
 func (r *Reconciler) buildEgressRules(ctx context.Context, ep effectivepolicy.ServiceEffectivePolicy) ([]v1.NetworkPolicyEgressRule, bool, error) {
 	rules := make([]v1.NetworkPolicyEgressRule, 0)
-	if len(ep.Calls) == 0 || len(r.egressRuleBuilders) == 0 {
+
+	if len(ep.Calls) == 0 {
 		return rules, false, nil
 	}
+
+	if len(r.egressRuleBuilders) == 0 {
+		hasInternetIntents := lo.SomeBy(ep.Calls, func(intent effectivepolicy.Call) bool { return intent.Internet != nil })
+		if hasInternetIntents {
+			logrus.Debugf("Client has interner intents but egress network policy is not enabled")
+			ep.ClientIntentsEventRecorder.RecordWarningEventf(consts.ReasonInternetEgressNetworkPolicyWithEgressPolicyDisabled, "ClientIntents refer to the Internet but egress network policy is disabled")
+		}
+
+		return rules, false, nil
+	}
+
 	if !r.EnforcementDefaultState {
 		logrus.Debugf("Enforcement is disabled globally skipping egress network policy creation for service %s in namespace %s", ep.Service.Name, ep.Service.Namespace)
 		ep.ClientIntentsEventRecorder.RecordNormalEventf(consts.ReasonEnforcementDefaultOff, "Enforcement is disabled globally, network policy creation skipped")


### PR DESCRIPTION
### Description
If the egress policy is not enabled, we cannot create a network policy to protect this traffic, as any policy we create referring to the internet can only apply to the client, and thus, it would be an egress policy. 
Now, we will create warning to the ClientIntent to notify of this invalid configuration.

### Testing
Added a unit test that verifies that the warning event is being recorded.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
