### PR TITLE
Refactor Persist/Read cert from secret functions so they can be reused by the credentials-operator to persist/read its certs

### DIFF
--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -363,7 +363,8 @@ func main() {
 
 	if selfSignedCert {
 		logrus.Infoln("Creating self signing certs")
-		certBundle, ok, err := webhooks.ReadCertBundleFromSecret(signalHandlerCtx, directClient, podNamespace)
+		secretName := viper.GetString(operatorconfig.WebhookCertSecretNameKey)
+		certBundle, ok, err := webhooks.ReadCertBundleFromSecret(signalHandlerCtx, directClient, secretName, podNamespace)
 		if err != nil {
 			logrus.WithError(err).Warn("unable to read existing certs from secret, generating new ones")
 		}
@@ -379,7 +380,7 @@ func main() {
 				logrus.WithError(err).Panic("unable to create self signed certs for webhook")
 			}
 
-			err = webhooks.PersistCertBundleToSecret(signalHandlerCtx, directClient, podNamespace, certBundleNew)
+			err = webhooks.PersistCertBundleToSecret(signalHandlerCtx, directClient, secretName, podNamespace, certBundleNew)
 			if err != nil {
 				logrus.WithError(err).Panic("unable to persist certs to secret")
 			}

--- a/src/operator/webhooks/certs.go
+++ b/src/operator/webhooks/certs.go
@@ -33,11 +33,10 @@ import (
 )
 
 const (
-	Year                  = 365 * 24 * time.Hour
-	CertDirPath           = "/tmp/k8s-webhook-server/serving-certs"
-	CertFilename          = "tls.crt"
-	PrivateKeyFilename    = "tls.key"
-	WebhookCertSecretName = "intents-operator-webhook-cert"
+	Year               = 365 * 24 * time.Hour
+	CertDirPath        = "/tmp/k8s-webhook-server/serving-certs"
+	CertFilename       = "tls.crt"
+	PrivateKeyFilename = "tls.key"
 )
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update,resourceNames={intents-operator-webhook-cert}
@@ -133,9 +132,9 @@ func GenerateSelfSignedCertificate(hostname string, namespace string) (Certifica
 	}, nil
 }
 
-func ReadCertBundleFromSecret(ctx context.Context, client client.Client, operatorNamespace string) (CertificateBundle, bool, error) {
+func ReadCertBundleFromSecret(ctx context.Context, client client.Client, secretName string, operatorNamespace string) (CertificateBundle, bool, error) {
 	var secret v1.Secret
-	err := client.Get(ctx, types.NamespacedName{Name: "intents-operator-webhook-cert", Namespace: operatorNamespace}, &secret)
+	err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: operatorNamespace}, &secret)
 	if err != nil {
 		return CertificateBundle{}, false, errors.Wrap(err)
 	}
@@ -173,9 +172,9 @@ func ReadCertBundleFromSecret(ctx context.Context, client client.Client, operato
 	}, true, nil
 }
 
-func PersistCertBundleToSecret(ctx context.Context, client client.Client, operatorNamespace string, bundle CertificateBundle) error {
+func PersistCertBundleToSecret(ctx context.Context, client client.Client, secretName string, operatorNamespace string, bundle CertificateBundle) error {
 	var secret v1.Secret
-	err := client.Get(ctx, types.NamespacedName{Name: WebhookCertSecretName, Namespace: operatorNamespace}, &secret)
+	err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: operatorNamespace}, &secret)
 	if err != nil {
 		// secret must exist as it is created as part of Helm chart
 		return errors.Wrap(err)

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -68,6 +68,8 @@ const (
 	SeparateNetpolsForIngressAndEgress            = "separate-netpols-for-ingress-and-egress"
 	SeparateNetpolsForIngressAndEgressDefault     = false
 	ExternallyManagedPolicyWorkloadsKey           = "externallyManagedPolicyWorkloads"
+	WebhookCertSecretNameKey                      = "webhook-cert-secret-name"
+	WebhookCertSecretNameDefault                  = "intents-operator-webhook-cert"
 )
 
 func init() {
@@ -92,6 +94,7 @@ func init() {
 	viper.SetDefault(SeparateNetpolsForIngressAndEgress, SeparateNetpolsForIngressAndEgressDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRPeersLimitKey, EnableGroupInternetIPsByCIDRPeersLimitDefault)
+	viper.SetDefault(WebhookCertSecretNameKey, WebhookCertSecretNameDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
### Description

Refactor Persist/Read cert from secret functions so they will get the secret name as an argument to reuse them in the credentials-operator


### References

https://github.com/otterize/intents-operator/pull/560

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
