### PR TITLE
Fix issue in webhook cert persistency where credentials-operator secret name was wrong due to use of configuration

### DIFF
--- a/src/go.sum
+++ b/src/go.sum
@@ -476,8 +476,6 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samber/lo v1.33.0 h1:2aKucr+rQV6gHpY3bpeZu69uYoQOzVhGT3J22Op6Cjk=
-github.com/samber/lo v1.33.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
 github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -526,8 +524,6 @@ github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/suessflorian/gqlfetch v0.6.0 h1:6e+Oe9mWbbjSmJez+6I4tyskQMy6lQlFFQYj64gaCQU=
 github.com/suessflorian/gqlfetch v0.6.0/go.mod h1:Xlz+o2ate8M/Hr237HJpFyJD0l05uh3NAX3zmXVmjxU=
-github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
-github.com/thoas/go-funk v0.9.1/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vektah/gqlparser v1.3.1 h1:8b0IcD3qZKWJQHSzynbDlrtP3IxVydZ2DZepCGofqfU=
 github.com/vektah/gqlparser v1.3.1/go.mod h1:bkVf0FX+Stjg/MHnm8mEyubuaArhNEqfQhF+OTiAL74=

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -363,7 +363,7 @@ func main() {
 
 	if selfSignedCert {
 		logrus.Infoln("Creating self signing certs")
-		secretName := viper.GetString(operatorconfig.WebhookCertSecretNameKey)
+		secretName := "intents-operator-webhook-cert"
 		certBundle, ok, err := webhooks.ReadCertBundleFromSecret(signalHandlerCtx, directClient, secretName, podNamespace)
 		if err != nil {
 			logrus.WithError(err).Warn("unable to read existing certs from secret, generating new ones")

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -68,8 +68,6 @@ const (
 	SeparateNetpolsForIngressAndEgress            = "separate-netpols-for-ingress-and-egress"
 	SeparateNetpolsForIngressAndEgressDefault     = false
 	ExternallyManagedPolicyWorkloadsKey           = "externallyManagedPolicyWorkloads"
-	WebhookCertSecretNameKey                      = "webhook-cert-secret-name"
-	WebhookCertSecretNameDefault                  = "intents-operator-webhook-cert"
 )
 
 func init() {
@@ -94,7 +92,6 @@ func init() {
 	viper.SetDefault(SeparateNetpolsForIngressAndEgress, SeparateNetpolsForIngressAndEgressDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRPeersLimitKey, EnableGroupInternetIPsByCIDRPeersLimitDefault)
-	viper.SetDefault(WebhookCertSecretNameKey, WebhookCertSecretNameDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
### Description
Fix issue in webhook cert persistency using secrets, where the credentials-operator secret name was wrong due to use of configuration. Instead, use fixed secret names.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
