### PR TITLE
Fix bug where reporting applied intents to the cloud could fail when using istio, due to a missing SharedServiceAccount annotation

### DIFF
--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -572,13 +572,13 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 
 	status.IstioStatus.ServiceAccountName = toPtrOrNil(serviceAccountName)
 	isSharedValue, ok := clientIntents.Annotations[OtterizeSharedServiceAccountAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation shared service account for client intents %s", clientIntents.Name)
-	}
-
-	isShared, err := strconv.ParseBool(isSharedValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+	isShared := false
+	if ok {
+		parsedIsShared, err := strconv.ParseBool(isSharedValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+		}
+		isShared = parsedIsShared
 	}
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 

--- a/src/operator/api/v1beta1/clientintents_types.go
+++ b/src/operator/api/v1beta1/clientintents_types.go
@@ -575,13 +575,13 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 
 	status.IstioStatus.ServiceAccountName = toPtrOrNil(serviceAccountName)
 	isSharedValue, ok := clientIntents.Annotations[OtterizeSharedServiceAccountAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation shared service account for client intents %s", clientIntents.Name)
-	}
-
-	isShared, err := strconv.ParseBool(isSharedValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+	isShared := false
+	if ok {
+		parsedIsShared, err := strconv.ParseBool(isSharedValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+		}
+		isShared = parsedIsShared
 	}
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -688,13 +688,13 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Target
 
 	status.IstioStatus.ServiceAccountName = toPtrOrNil(serviceAccountName)
 	isSharedValue, ok := clientIntents.Annotations[OtterizeSharedServiceAccountAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation shared service account for client intents %s", clientIntents.Name)
-	}
-
-	isShared, err := strconv.ParseBool(isSharedValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+	isShared := false
+	if ok {
+		parsedIsShared, err := strconv.ParseBool(isSharedValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+		}
+		isShared = parsedIsShared
 	}
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 

--- a/src/operator/api/v2beta1/clientintents_types.go
+++ b/src/operator/api/v2beta1/clientintents_types.go
@@ -688,13 +688,13 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Target
 
 	status.IstioStatus.ServiceAccountName = toPtrOrNil(serviceAccountName)
 	isSharedValue, ok := clientIntents.Annotations[OtterizeSharedServiceAccountAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation shared service account for client intents %s", clientIntents.Name)
-	}
-
-	isShared, err := strconv.ParseBool(isSharedValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+	isShared := false
+	if ok {
+		parsedIsShared, err := strconv.ParseBool(isSharedValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse shared service account annotation for client intents %s", clientIntents.Name)
+		}
+		isShared = parsedIsShared
 	}
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 


### PR DESCRIPTION


### Description

In some cases `SharedServiceAccount` annotation is not present on the clientIntent, and it should not fail the cloud report



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
