### PR TITLE
Update the CRD storage version from `v1beta1` to `v2alpha1`

### DIFF
--- a/src/operator/api/v1beta1/clientintents_types.go
+++ b/src/operator/api/v1beta1/clientintents_types.go
@@ -332,7 +332,6 @@ type IntentsStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:storageversion
 
 // ClientIntents is the Schema for the intents API
 type ClientIntents struct {

--- a/src/operator/api/v1beta1/kafkaserverconfig_types.go
+++ b/src/operator/api/v1beta1/kafkaserverconfig_types.go
@@ -69,7 +69,6 @@ type KafkaServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:storageversion
 
 // KafkaServerConfig is the Schema for the kafkaserverconfigs API
 type KafkaServerConfig struct {

--- a/src/operator/api/v1beta1/mysqlserverconfig_types.go
+++ b/src/operator/api/v1beta1/mysqlserverconfig_types.go
@@ -18,7 +18,6 @@ type MySQLServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:storageversion
 
 // MySQLServerConfig is the Schema for the mysqlserverconfig API
 type MySQLServerConfig struct {

--- a/src/operator/api/v1beta1/postgresqlserverconfig_types.go
+++ b/src/operator/api/v1beta1/postgresqlserverconfig_types.go
@@ -64,7 +64,6 @@ type PostgreSQLServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:storageversion
 
 // PostgreSQLServerConfig is the Schema for the postgresqlserverconfig API
 type PostgreSQLServerConfig struct {

--- a/src/operator/api/v1beta1/protectedservice_types.go
+++ b/src/operator/api/v1beta1/protectedservice_types.go
@@ -37,7 +37,6 @@ type ProtectedServiceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:storageversion
 
 // ProtectedService is the Schema for the protectedservice API
 type ProtectedService struct {

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -377,6 +377,7 @@ type IntentsStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // ClientIntents is the Schema for the intents API
 type ClientIntents struct {

--- a/src/operator/api/v2alpha1/kafkaserverconfig_types.go
+++ b/src/operator/api/v2alpha1/kafkaserverconfig_types.go
@@ -69,6 +69,7 @@ type KafkaServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // KafkaServerConfig is the Schema for the kafkaserverconfigs API
 type KafkaServerConfig struct {

--- a/src/operator/api/v2alpha1/mysqlserverconfig_types.go
+++ b/src/operator/api/v2alpha1/mysqlserverconfig_types.go
@@ -18,6 +18,7 @@ type MySQLServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // MySQLServerConfig is the Schema for the mysqlserverconfig API
 type MySQLServerConfig struct {

--- a/src/operator/api/v2alpha1/postgresqlserverconfig_types.go
+++ b/src/operator/api/v2alpha1/postgresqlserverconfig_types.go
@@ -71,6 +71,7 @@ type PostgreSQLServerConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // PostgreSQLServerConfig is the Schema for the databaseserverconfig API
 type PostgreSQLServerConfig struct {

--- a/src/operator/api/v2alpha1/protectedservice_types.go
+++ b/src/operator/api/v2alpha1/protectedservice_types.go
@@ -37,6 +37,7 @@ type ProtectedServiceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:storageversion
 
 // ProtectedService is the Schema for the protectedservice API
 type ProtectedService struct {

--- a/src/operator/config/crd/k8s.otterize.com_clientintents.patched
+++ b/src/operator/config/crd/k8s.otterize.com_clientintents.patched
@@ -703,7 +703,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -1034,7 +1034,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_clientintents.yaml
@@ -692,7 +692,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v2alpha1
@@ -1025,7 +1025,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_kafkaserverconfigs.patched
+++ b/src/operator/config/crd/k8s.otterize.com_kafkaserverconfigs.patched
@@ -275,7 +275,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -359,7 +359,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_kafkaserverconfigs.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_kafkaserverconfigs.yaml
@@ -261,7 +261,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v2alpha1
@@ -345,7 +345,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_mysqlserverconfigs.patched
+++ b/src/operator/config/crd/k8s.otterize.com_mysqlserverconfigs.patched
@@ -163,7 +163,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -232,7 +232,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_mysqlserverconfigs.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_mysqlserverconfigs.yaml
@@ -163,7 +163,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v2alpha1
@@ -239,7 +239,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_postgresqlserverconfigs.patched
+++ b/src/operator/config/crd/k8s.otterize.com_postgresqlserverconfigs.patched
@@ -163,7 +163,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -232,7 +232,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_postgresqlserverconfigs.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_postgresqlserverconfigs.yaml
@@ -167,7 +167,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v2alpha1
@@ -245,7 +245,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_protectedservices.patched
+++ b/src/operator/config/crd/k8s.otterize.com_protectedservices.patched
@@ -137,7 +137,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -175,7 +175,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/config/crd/k8s.otterize.com_protectedservices.yaml
+++ b/src/operator/config/crd/k8s.otterize.com_protectedservices.yaml
@@ -123,7 +123,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - name: v2alpha1
@@ -161,7 +161,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v2beta1

--- a/src/operator/controllers/intents_reconcilers/mocks/mock_linkerd.go
+++ b/src/operator/controllers/intents_reconcilers/mocks/mock_linkerd.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
 	v1alpha3 "github.com/otterize/intents-operator/src/operator/api/v1alpha3"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockLinkerdPolicyManager is a mock of LinkerdPolicyManager interface.

--- a/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/clientintents-customresourcedefinition.yaml
@@ -703,7 +703,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -1034,7 +1034,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/otterizecrds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -275,7 +275,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -359,7 +359,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/otterizecrds/mysqlserverconfigs-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/mysqlserverconfigs-customresourcedefinition.yaml
@@ -163,7 +163,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -232,7 +232,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/otterizecrds/postgresqlserverconfigs-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/postgresqlserverconfigs-customresourcedefinition.yaml
@@ -163,7 +163,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -232,7 +232,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/operator/otterizecrds/protectedservices-customresourcedefinition.yaml
+++ b/src/operator/otterizecrds/protectedservices-customresourcedefinition.yaml
@@ -137,7 +137,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - name: v2alpha1
@@ -175,7 +175,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - name: v2beta1

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -284,6 +284,7 @@ type IntentInput struct {
 	Topics               []*KafkaConfigInput       `json:"topics"`
 	Resources            []*HTTPConfigInput        `json:"resources"`
 	DatabaseResources    []*DatabaseConfigInput    `json:"databaseResources"`
+	AwsRole              *string                   `json:"awsRole"`
 	AwsActions           []*string                 `json:"awsActions"`
 	AzureRoles           []*string                 `json:"azureRoles"`
 	AzureActions         []*string                 `json:"azureActions"`
@@ -333,6 +334,9 @@ func (v *IntentInput) GetResources() []*HTTPConfigInput { return v.Resources }
 
 // GetDatabaseResources returns IntentInput.DatabaseResources, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetDatabaseResources() []*DatabaseConfigInput { return v.DatabaseResources }
+
+// GetAwsRole returns IntentInput.AwsRole, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetAwsRole() *string { return v.AwsRole }
 
 // GetAwsActions returns IntentInput.AwsActions, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetAwsActions() []*string { return v.AwsActions }

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -132,6 +132,35 @@ input AWSVisibilitySettingsInput {
 	regions: [String!]!
 }
 
+type AccessApprovalRuleset {
+	id: ID!
+	origin: AccessApprovalRulesetFilter!
+	target: AccessApprovalRulesetFilter!
+	action: AccessApprovalRulesetAction!
+}
+
+enum AccessApprovalRulesetAction {
+	AUTO_APPROVE
+	AUTO_DENY
+	REQUIRE_APPROVAL
+}
+
+type AccessApprovalRulesetFilter {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	environmentIds: IDFilterValue
+}
+
+enum AccessApprovalRulesetFilterValue {
+	ANY
+}
+
+type AccessApprovalRulesetSummary {
+	environment: Environment!
+	count: Int!
+}
+
 type AccessGraph {
 	filter: AccessGraphFilter!
 """Clusters for which there are results"""
@@ -148,6 +177,7 @@ type AccessGraphEdge {
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
 	findings: [CallFinding!]!
+	traffic: TrafficLevel!
 }
 
 """ Access graph filter """
@@ -200,6 +230,39 @@ enum ApiMethod {
 	PUT
 	PATCH
 	DELETE
+}
+
+"""applied intents request"""
+input AppliedIntentsRequestApprovalData {
+"""applied intents request"""
+	approved: Boolean!
+"""applied intents request"""
+	reason: String!
+}
+
+type AppliedIntentsRequestStatus {
+	id: ID!
+"""client"""
+	service: Service!
+	timestamp: Time!
+	status: AppliedIntentsRequestStatusLabel!
+	reason: String
+}
+
+enum AppliedIntentsRequestStatusLabel {
+	PENDING
+	APPROVED
+	DENIED
+}
+
+type AppliedIntentsRequestWithDetails {
+	id: ID!
+	clientService: Service!
+	serverServices: [Service!]!
+	timestamp: Time!
+	status: AppliedIntentsRequestStatusLabel!
+	reason: String
+	clientIntents: ClientIntentsFileRepresentation!
 }
 
 enum AwsIamStep {
@@ -381,6 +444,10 @@ type ClientIntentsRow {
 	text: String!
 	diff: RowDiff
 	calledServerId: ID
+}
+
+type CloudIam {
+	awsRoles: [String!]
 }
 
 type Cluster {
@@ -574,6 +641,11 @@ enum DatabaseVisibilitySource {
 	GCP_PUBSUB
 }
 
+type DefaultIntentsApprovalActionByEnv {
+	environmentId: ID!
+	action: AccessApprovalRulesetAction!
+}
+
 type DetectedCloudServer {
 	cloudProvider: String!
 	cloudService: String!
@@ -588,7 +660,10 @@ input DiscoveredIntentInput {
 input EBPFDiagnostics {
 	containerImage: String
 	executable: String
+	executableHash: String
 	programName: String
+	podName: String
+	podNamespace: String
 }
 
 type EdgeAccessStatus {
@@ -873,11 +948,13 @@ input GitHubRepoInfoInput {
 type GitHubSettings {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPair!]!
+	enableAutoMerge: Boolean!
 }
 
 input GitHubSettingsInput {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPairInput!]!
+	enableAutoMerge: Boolean
 }
 
 type GitLabRepoFilterPair {
@@ -975,6 +1052,40 @@ input IngressControllerConfigInput {
 	kind: String!
 }
 
+"""Ruleset"""
+input InputAccessApprovalRuleset {
+"""Ruleset"""
+	id: ID
+"""Ruleset"""
+	origin: InputAccessApprovalRulesetConfigFilter!
+"""Ruleset"""
+	target: InputAccessApprovalRulesetConfigFilter!
+"""Ruleset"""
+	action: AccessApprovalRulesetAction!
+}
+
+input InputAccessApprovalRulesetConfigFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+}
+
+""" Ruleset filter """
+input InputAccessApprovalRulesetFilter {
+""" Ruleset filter """
+	environmentIds: InputIDFilterValue
+""" Ruleset filter """
+	environmentNames: InputIDFilterValue
+""" Ruleset filter """
+	namespaceIds: InputIDFilterValue
+""" Ruleset filter """
+	clusterIds: InputIDFilterValue
+""" Ruleset filter """
+	serviceIds: InputIDFilterValue
+""" Ruleset filter """
+	actions: InputIDFilterValue
+}
+
 input InputAccessGraphFilter {
 	clusterIds: InputIDFilterValue
 	serviceIds: InputIDFilterValue
@@ -1005,6 +1116,27 @@ input InputAccessLogFilter {
 	accessVerdicts: InputIDFilterValue
 """ Access log filter """
 	accessStatusReasons: InputIDFilterValue
+}
+
+""" Applied intents request filter """
+input InputAppliedIntentsRequestFilter {
+""" Applied intents request filter """
+	requestIds: InputIDFilterValue
+""" Applied intents request filter """
+	clusterIds: InputIDFilterValue
+""" Applied intents request filter """
+	serviceIds: InputIDFilterValue
+""" Applied intents request filter """
+	namespaceIds: InputIDFilterValue
+""" Applied intents request filter """
+	environmentIds: InputIDFilterValue
+""" Applied intents request filter """
+	approvalStatuses: InputIDFilterValue
+}
+
+input InputDefaultIntentsApprovalActionByEnv {
+	environmentId: ID!
+	action: AccessApprovalRulesetAction!
 }
 
 input InputFeatureFlags {
@@ -1080,6 +1212,13 @@ input InputServiceFilter {
 input InputTimeFilterValue {
 	value: Time!
 	operator: TimeFilterOperators!
+}
+
+input InputValidateIDFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
 }
 
 """ Workload/Resource inventory filter """
@@ -1188,6 +1327,7 @@ type Intent {
 	kafkaTopics: [KafkaConfig!]
 	httpResources: [HTTPConfig!]
 	databaseResources: [DatabaseConfig!]
+	awsRole: String
 	awsActions: [String!]
 	azureRoles: [String!]
 	azureActions: [String!]
@@ -1212,6 +1352,7 @@ input IntentInput {
 	topics: [KafkaConfigInput!]
 	resources: [HTTPConfigInput!]
 	databaseResources: [DatabaseConfigInput!]
+	awsRole: String
 	awsActions: [String!]
 	azureRoles: [String!]
 	azureActions: [String!]
@@ -1221,6 +1362,11 @@ input IntentInput {
 	internet: InternetConfigInput
 	status: IntentStatusInput
 	resolutionData: String
+}
+
+input IntentRequestInput {
+	requestId: ID!
+	intent: IntentInput!
 }
 
 type IntentStatus {
@@ -1597,6 +1743,19 @@ input MetadataEntry {
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
+"""applied intents requests"""
+	reportAppliedIntentsRequest(
+		intents: [IntentRequestInput!]!
+	): Boolean!
+	updateIntentsApprovalStatus(
+		id: ID!
+		result: AppliedIntentsRequestApprovalData!
+	): Boolean!
+"""rulesets"""
+	createOrUpdateAccessApprovalRulesets(
+		environmentId: ID!
+		rules: [InputAccessApprovalRuleset!]!
+	): Boolean!
 """Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
 	registerKubernetesPodOwnerCertificateRequest(
 		podOwner: NamespacedPodOwner!
@@ -1871,6 +2030,10 @@ type Mutation {
 	reportServiceMetadata(
 		serviceMeta: ReportServiceMetadataInput!
 	): Boolean!
+"""update multiple service metadata from operator"""
+	reportServicesMetadata(
+		servicesMeta: [ReportServiceMetadataInput!]!
+	): Boolean!
 """Bulk Update services"""
 	addTagsToServices(
 		ids: [ID!]!
@@ -1881,6 +2044,10 @@ type Mutation {
 	): Boolean!
 	sendCLITelemetries(
 		telemetries: [CLITelemetry!]!
+	): Boolean!
+"""Update service"""
+	reportTrafficLevels(
+		trafficLevels: [TrafficLevelInput!]!
 	): Boolean!
 	saveOnboardingFeedback(
 		userEmail: String!
@@ -1976,12 +2143,14 @@ type OrganizationSettings {
 	domains: [String!]
 	enforcedRegulations: [String!]
 	ignoredCloudDomains: [String!]
+	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
 }
 
 input OrganizationSettingsInput {
 	domains: [String!]
 	enforcedRegulations: [String]
 	ignoredCloudDomains: [String!]
+	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 }
 
 input PaginationInput {
@@ -2021,6 +2190,9 @@ type Query {
 	accessGraph(
 		filter: InputAccessGraphFilter
 	): AccessGraph!
+	accessGraphServices(
+		filter: InputAccessGraphFilter
+	): [Service!]!
 	serviceAccessGraph(
 		id: ID!
 	): ServiceAccessGraph!
@@ -2049,6 +2221,19 @@ type Query {
 	accessLog(
 		filter: InputAccessLogFilter
 	): AccessLog!
+"""applied intents requests"""
+	appliedIntentsRequestStatus(
+		filter: InputAppliedIntentsRequestFilter
+	): [AppliedIntentsRequestStatus!]!
+	appliedIntentsRequestWithDetails(
+		id: ID!
+		featureFlags: InputFeatureFlags
+	): AppliedIntentsRequestWithDetails!
+"""rulesets"""
+	accessApprovalRulesetSummary: [AccessApprovalRulesetSummary!]!
+	accessApprovalRulesetList(
+		filter: InputAccessApprovalRulesetFilter
+	): [AccessApprovalRuleset!]!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -2074,6 +2259,10 @@ type Query {
 	oneEnvironment(
 		name: String!
 	): Environment!
+"""Validate existing ID filters and return valid filters"""
+	validateFilters(
+		filter: InputValidateIDFilter!
+	): ValidIDFilter!
 	findings(
 		filter: InputFindingFilter
 		tree: Boolean
@@ -2120,12 +2309,6 @@ type Query {
 	testDatabaseVisibilityConnection(
 		databaseInfo: DatabaseInfoInput!
 	): TestDatabaseConnectionResponse!
-	clientIntentEventsForWorkload(
-		id: ID!
-	): [ClientIntentEvent!]
-	clientIntentStatusForWorkload(
-		id: ID!
-	): ClientIntentStatus
 """List user invites"""
 	invites(
 		email: String
@@ -2345,6 +2528,7 @@ type Service {
 	id: ID!
 	name: String!
 	tags: [String!]
+	cloudIam: CloudIam
 	workloadKind: String
 	aliases: [ServerAlias!]
 	namespace: Namespace
@@ -2421,6 +2605,7 @@ enum ServiceInternalTrafficPolicy {
 
 input ServiceMetadataInput {
 	tags: [String!]
+	awsRoles: [String!]
 }
 
 enum ServiceType {
@@ -2524,6 +2709,7 @@ enum TelemetryComponentType {
 input TelemetryData {
 	eventType: EventType!
 	count: Int
+	error: String
 	ebpf: EBPFDiagnostics
 }
 
@@ -2557,6 +2743,21 @@ type TimeRange {
 input TimeRangeInput {
 	from: Time
 	to: Time
+}
+
+type TrafficLevel {
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
+	lastReportedAt: Time!
+}
+
+input TrafficLevelInput {
+	clientName: String!
+	clientNamespace: String!
+	serverName: String!
+	serverNamespace: String!
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
 }
 
 enum TutorialEvent {
@@ -2623,6 +2824,15 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+""" Used to validate ID based filters """
+type ValidIDFilter {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	regulationIds: IDFilterValue
+	environmentIds: IDFilterValue
 }
 
 type Workload {

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -34,7 +34,10 @@ func (v *Component) GetCloudClientId() string { return v.CloudClientId }
 type EBPFDiagnostics struct {
 	ContainerImage string `json:"containerImage"`
 	Executable     string `json:"executable"`
+	ExecutableHash string `json:"executableHash"`
 	ProgramName    string `json:"programName"`
+	PodName        string `json:"podName"`
+	PodNamespace   string `json:"podNamespace"`
 }
 
 // GetContainerImage returns EBPFDiagnostics.ContainerImage, and is useful for accessing the field via an interface.
@@ -43,8 +46,17 @@ func (v *EBPFDiagnostics) GetContainerImage() string { return v.ContainerImage }
 // GetExecutable returns EBPFDiagnostics.Executable, and is useful for accessing the field via an interface.
 func (v *EBPFDiagnostics) GetExecutable() string { return v.Executable }
 
+// GetExecutableHash returns EBPFDiagnostics.ExecutableHash, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetExecutableHash() string { return v.ExecutableHash }
+
 // GetProgramName returns EBPFDiagnostics.ProgramName, and is useful for accessing the field via an interface.
 func (v *EBPFDiagnostics) GetProgramName() string { return v.ProgramName }
+
+// GetPodName returns EBPFDiagnostics.PodName, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetPodName() string { return v.PodName }
+
+// GetPodNamespace returns EBPFDiagnostics.PodNamespace, and is useful for accessing the field via an interface.
+func (v *EBPFDiagnostics) GetPodNamespace() string { return v.PodNamespace }
 
 type Error struct {
 	Message    *string          `json:"message"`
@@ -163,6 +175,7 @@ const (
 type TelemetryData struct {
 	EventType EventType       `json:"eventType"`
 	Count     int             `json:"count"`
+	Error     string          `json:"error"`
 	Ebpf      EBPFDiagnostics `json:"ebpf"`
 }
 
@@ -171,6 +184,9 @@ func (v *TelemetryData) GetEventType() EventType { return v.EventType }
 
 // GetCount returns TelemetryData.Count, and is useful for accessing the field via an interface.
 func (v *TelemetryData) GetCount() int { return v.Count }
+
+// GetError returns TelemetryData.Error, and is useful for accessing the field via an interface.
+func (v *TelemetryData) GetError() string { return v.Error }
 
 // GetEbpf returns TelemetryData.Ebpf, and is useful for accessing the field via an interface.
 func (v *TelemetryData) GetEbpf() EBPFDiagnostics { return v.Ebpf }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -132,6 +132,35 @@ input AWSVisibilitySettingsInput {
 	regions: [String!]!
 }
 
+type AccessApprovalRuleset {
+	id: ID!
+	origin: AccessApprovalRulesetFilter!
+	target: AccessApprovalRulesetFilter!
+	action: AccessApprovalRulesetAction!
+}
+
+enum AccessApprovalRulesetAction {
+	AUTO_APPROVE
+	AUTO_DENY
+	REQUIRE_APPROVAL
+}
+
+type AccessApprovalRulesetFilter {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	environmentIds: IDFilterValue
+}
+
+enum AccessApprovalRulesetFilterValue {
+	ANY
+}
+
+type AccessApprovalRulesetSummary {
+	environment: Environment!
+	count: Int!
+}
+
 type AccessGraph {
 	filter: AccessGraphFilter!
 """Clusters for which there are results"""
@@ -148,6 +177,7 @@ type AccessGraphEdge {
 	accessStatus: EdgeAccessStatus!
 	accessStatuses: EdgeAccessStatuses!
 	findings: [CallFinding!]!
+	traffic: TrafficLevel!
 }
 
 """ Access graph filter """
@@ -200,6 +230,39 @@ enum ApiMethod {
 	PUT
 	PATCH
 	DELETE
+}
+
+"""applied intents request"""
+input AppliedIntentsRequestApprovalData {
+"""applied intents request"""
+	approved: Boolean!
+"""applied intents request"""
+	reason: String!
+}
+
+type AppliedIntentsRequestStatus {
+	id: ID!
+"""client"""
+	service: Service!
+	timestamp: Time!
+	status: AppliedIntentsRequestStatusLabel!
+	reason: String
+}
+
+enum AppliedIntentsRequestStatusLabel {
+	PENDING
+	APPROVED
+	DENIED
+}
+
+type AppliedIntentsRequestWithDetails {
+	id: ID!
+	clientService: Service!
+	serverServices: [Service!]!
+	timestamp: Time!
+	status: AppliedIntentsRequestStatusLabel!
+	reason: String
+	clientIntents: ClientIntentsFileRepresentation!
 }
 
 enum AwsIamStep {
@@ -381,6 +444,10 @@ type ClientIntentsRow {
 	text: String!
 	diff: RowDiff
 	calledServerId: ID
+}
+
+type CloudIam {
+	awsRoles: [String!]
 }
 
 type Cluster {
@@ -574,6 +641,11 @@ enum DatabaseVisibilitySource {
 	GCP_PUBSUB
 }
 
+type DefaultIntentsApprovalActionByEnv {
+	environmentId: ID!
+	action: AccessApprovalRulesetAction!
+}
+
 type DetectedCloudServer {
 	cloudProvider: String!
 	cloudService: String!
@@ -588,7 +660,10 @@ input DiscoveredIntentInput {
 input EBPFDiagnostics {
 	containerImage: String
 	executable: String
+	executableHash: String
 	programName: String
+	podName: String
+	podNamespace: String
 }
 
 type EdgeAccessStatus {
@@ -873,11 +948,13 @@ input GitHubRepoInfoInput {
 type GitHubSettings {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPair!]!
+	enableAutoMerge: Boolean!
 }
 
 input GitHubSettingsInput {
 	isActive: Boolean!
 	repoFilterPairs: [GitHubRepoFilterPairInput!]!
+	enableAutoMerge: Boolean
 }
 
 type GitLabRepoFilterPair {
@@ -975,6 +1052,40 @@ input IngressControllerConfigInput {
 	kind: String!
 }
 
+"""Ruleset"""
+input InputAccessApprovalRuleset {
+"""Ruleset"""
+	id: ID
+"""Ruleset"""
+	origin: InputAccessApprovalRulesetConfigFilter!
+"""Ruleset"""
+	target: InputAccessApprovalRulesetConfigFilter!
+"""Ruleset"""
+	action: AccessApprovalRulesetAction!
+}
+
+input InputAccessApprovalRulesetConfigFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+}
+
+""" Ruleset filter """
+input InputAccessApprovalRulesetFilter {
+""" Ruleset filter """
+	environmentIds: InputIDFilterValue
+""" Ruleset filter """
+	environmentNames: InputIDFilterValue
+""" Ruleset filter """
+	namespaceIds: InputIDFilterValue
+""" Ruleset filter """
+	clusterIds: InputIDFilterValue
+""" Ruleset filter """
+	serviceIds: InputIDFilterValue
+""" Ruleset filter """
+	actions: InputIDFilterValue
+}
+
 input InputAccessGraphFilter {
 	clusterIds: InputIDFilterValue
 	serviceIds: InputIDFilterValue
@@ -1005,6 +1116,27 @@ input InputAccessLogFilter {
 	accessVerdicts: InputIDFilterValue
 """ Access log filter """
 	accessStatusReasons: InputIDFilterValue
+}
+
+""" Applied intents request filter """
+input InputAppliedIntentsRequestFilter {
+""" Applied intents request filter """
+	requestIds: InputIDFilterValue
+""" Applied intents request filter """
+	clusterIds: InputIDFilterValue
+""" Applied intents request filter """
+	serviceIds: InputIDFilterValue
+""" Applied intents request filter """
+	namespaceIds: InputIDFilterValue
+""" Applied intents request filter """
+	environmentIds: InputIDFilterValue
+""" Applied intents request filter """
+	approvalStatuses: InputIDFilterValue
+}
+
+input InputDefaultIntentsApprovalActionByEnv {
+	environmentId: ID!
+	action: AccessApprovalRulesetAction!
 }
 
 input InputFeatureFlags {
@@ -1080,6 +1212,13 @@ input InputServiceFilter {
 input InputTimeFilterValue {
 	value: Time!
 	operator: TimeFilterOperators!
+}
+
+input InputValidateIDFilter {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
 }
 
 """ Workload/Resource inventory filter """
@@ -1188,6 +1327,7 @@ type Intent {
 	kafkaTopics: [KafkaConfig!]
 	httpResources: [HTTPConfig!]
 	databaseResources: [DatabaseConfig!]
+	awsRole: String
 	awsActions: [String!]
 	azureRoles: [String!]
 	azureActions: [String!]
@@ -1212,6 +1352,7 @@ input IntentInput {
 	topics: [KafkaConfigInput!]
 	resources: [HTTPConfigInput!]
 	databaseResources: [DatabaseConfigInput!]
+	awsRole: String
 	awsActions: [String!]
 	azureRoles: [String!]
 	azureActions: [String!]
@@ -1221,6 +1362,11 @@ input IntentInput {
 	internet: InternetConfigInput
 	status: IntentStatusInput
 	resolutionData: String
+}
+
+input IntentRequestInput {
+	requestId: ID!
+	intent: IntentInput!
 }
 
 type IntentStatus {
@@ -1597,6 +1743,19 @@ input MetadataEntry {
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
+"""applied intents requests"""
+	reportAppliedIntentsRequest(
+		intents: [IntentRequestInput!]!
+	): Boolean!
+	updateIntentsApprovalStatus(
+		id: ID!
+		result: AppliedIntentsRequestApprovalData!
+	): Boolean!
+"""rulesets"""
+	createOrUpdateAccessApprovalRulesets(
+		environmentId: ID!
+		rules: [InputAccessApprovalRuleset!]!
+	): Boolean!
 """Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
 	registerKubernetesPodOwnerCertificateRequest(
 		podOwner: NamespacedPodOwner!
@@ -1871,6 +2030,10 @@ type Mutation {
 	reportServiceMetadata(
 		serviceMeta: ReportServiceMetadataInput!
 	): Boolean!
+"""update multiple service metadata from operator"""
+	reportServicesMetadata(
+		servicesMeta: [ReportServiceMetadataInput!]!
+	): Boolean!
 """Bulk Update services"""
 	addTagsToServices(
 		ids: [ID!]!
@@ -1881,6 +2044,10 @@ type Mutation {
 	): Boolean!
 	sendCLITelemetries(
 		telemetries: [CLITelemetry!]!
+	): Boolean!
+"""Update service"""
+	reportTrafficLevels(
+		trafficLevels: [TrafficLevelInput!]!
 	): Boolean!
 	saveOnboardingFeedback(
 		userEmail: String!
@@ -1976,12 +2143,14 @@ type OrganizationSettings {
 	domains: [String!]
 	enforcedRegulations: [String!]
 	ignoredCloudDomains: [String!]
+	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
 }
 
 input OrganizationSettingsInput {
 	domains: [String!]
 	enforcedRegulations: [String]
 	ignoredCloudDomains: [String!]
+	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 }
 
 input PaginationInput {
@@ -2021,6 +2190,9 @@ type Query {
 	accessGraph(
 		filter: InputAccessGraphFilter
 	): AccessGraph!
+	accessGraphServices(
+		filter: InputAccessGraphFilter
+	): [Service!]!
 	serviceAccessGraph(
 		id: ID!
 	): ServiceAccessGraph!
@@ -2049,6 +2221,19 @@ type Query {
 	accessLog(
 		filter: InputAccessLogFilter
 	): AccessLog!
+"""applied intents requests"""
+	appliedIntentsRequestStatus(
+		filter: InputAppliedIntentsRequestFilter
+	): [AppliedIntentsRequestStatus!]!
+	appliedIntentsRequestWithDetails(
+		id: ID!
+		featureFlags: InputFeatureFlags
+	): AppliedIntentsRequestWithDetails!
+"""rulesets"""
+	accessApprovalRulesetSummary: [AccessApprovalRulesetSummary!]!
+	accessApprovalRulesetList(
+		filter: InputAccessApprovalRulesetFilter
+	): [AccessApprovalRuleset!]!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -2074,6 +2259,10 @@ type Query {
 	oneEnvironment(
 		name: String!
 	): Environment!
+"""Validate existing ID filters and return valid filters"""
+	validateFilters(
+		filter: InputValidateIDFilter!
+	): ValidIDFilter!
 	findings(
 		filter: InputFindingFilter
 		tree: Boolean
@@ -2120,12 +2309,6 @@ type Query {
 	testDatabaseVisibilityConnection(
 		databaseInfo: DatabaseInfoInput!
 	): TestDatabaseConnectionResponse!
-	clientIntentEventsForWorkload(
-		id: ID!
-	): [ClientIntentEvent!]
-	clientIntentStatusForWorkload(
-		id: ID!
-	): ClientIntentStatus
 """List user invites"""
 	invites(
 		email: String
@@ -2345,6 +2528,7 @@ type Service {
 	id: ID!
 	name: String!
 	tags: [String!]
+	cloudIam: CloudIam
 	workloadKind: String
 	aliases: [ServerAlias!]
 	namespace: Namespace
@@ -2421,6 +2605,7 @@ enum ServiceInternalTrafficPolicy {
 
 input ServiceMetadataInput {
 	tags: [String!]
+	awsRoles: [String!]
 }
 
 enum ServiceType {
@@ -2524,6 +2709,7 @@ enum TelemetryComponentType {
 input TelemetryData {
 	eventType: EventType!
 	count: Int
+	error: String
 	ebpf: EBPFDiagnostics
 }
 
@@ -2557,6 +2743,21 @@ type TimeRange {
 input TimeRangeInput {
 	from: Time
 	to: Time
+}
+
+type TrafficLevel {
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
+	lastReportedAt: Time!
+}
+
+input TrafficLevelInput {
+	clientName: String!
+	clientNamespace: String!
+	serverName: String!
+	serverNamespace: String!
+	dataBytesPerSecond: Int!
+	flowsCountPerSecond: Int!
 }
 
 enum TutorialEvent {
@@ -2623,6 +2824,15 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+""" Used to validate ID based filters """
+type ValidIDFilter {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	regulationIds: IDFilterValue
+	environmentIds: IDFilterValue
 }
 
 type Workload {


### PR DESCRIPTION
### Description

Update the CRD storage version from `v1beta1` to `v2alpha1`. 
This change was made by:

1. Moved the "kubebuilder:storageversion" annotations from v1 structs to the v2
2. Ran `make manifests generate copy-manifests-to-helm`



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
