### PR TITLE
Remove overly verbose event ReasonEnforcementGloballyDisabled in allowexternaltraffic.Off mode & improve event messages

### DIFF
--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -34,7 +34,6 @@ const (
 	ReasonRemovingExternalTrafficPolicyFailed = "RemovingExternalTrafficPolicyFailed"
 	ReasonRemovedExternalTrafficPolicy        = "RemovedExternalTrafficPolicy"
 	OtterizeExternalNetworkPolicyNameTemplate = "external-access-to-%s"
-	successMsgNetpolCreate                    = "Created external traffic network policy. service '%s' refers to pods protected by network policy '%s'"
 )
 
 type NetworkPolicyHandler struct {
@@ -540,7 +539,8 @@ func (r *NetworkPolicyHandler) handleNetpolsForOtterizeService(ctx context.Conte
 	}
 
 	for _, netpol := range netpolList {
-		successMsg := fmt.Sprintf(successMsgNetpolCreate, endpoints.GetName(), netpol.GetName())
+		successMsg := fmt.Sprintf("Created external traffic network policy. service '%s' refers to pods protected by network policy '%s'",
+			endpoints.GetName(), netpol.GetName())
 		err = r.createOrUpdateNetworkPolicy(ctx, endpoints, svc, otterizeServiceName, netpol.Spec.PodSelector, ingressList, successMsg)
 
 		if err != nil {

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -839,12 +839,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
 	})
-	select {
-	case event := <-recorder.Events:
-		s.Require().Contains(event, external_traffic.ReasonEnforcementGloballyDisabled)
-	default:
-		s.Fail("event not raised")
-	}
+	s.ExpectNoEvent(recorder)
 }
 
 func TestExternalNetworkPolicyReconcilerTestSuite(t *testing.T) {

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -924,12 +924,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
 	})
-	select {
-	case event := <-recorder.Events:
-		s.Require().Contains(event, external_traffic.ReasonEnforcementGloballyDisabled)
-	default:
-		s.Fail("event not raised")
-	}
+	s.ExpectNoEvent(recorder)
 }
 
 func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyForAWSALBExemption_enabled() {

--- a/src/shared/testbase/mocks_tests_suite_base.go
+++ b/src/shared/testbase/mocks_tests_suite_base.go
@@ -2,7 +2,6 @@ package testbase
 
 import (
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
-	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"k8s.io/client-go/tools/record"
 	"strings"
@@ -14,7 +13,7 @@ const (
 )
 
 type MocksSuiteBase struct {
-	suite.Suite
+	TestSuiteBase
 	Controller *gomock.Controller
 	Recorder   *record.FakeRecorder
 	Client     *mocks.MockClient
@@ -61,14 +60,5 @@ func (s *MocksSuiteBase) ExpectEventsOrderAndCountDontMatter(expectedEventReason
 		case <-time.After(100 * time.Millisecond):
 			return
 		}
-	}
-}
-
-func (s *MocksSuiteBase) ExpectNoEvent(eventRecorder *record.FakeRecorder) {
-	select {
-	case event := <-eventRecorder.Events:
-		s.Fail("Unexpected event found", event)
-	default:
-		// Amazing, no events left behind!
 	}
 }

--- a/src/shared/testbase/testsuitebase.go
+++ b/src/shared/testbase/testsuitebase.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	_ "os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,8 +40,21 @@ const waitForCreationInterval = 20 * time.Millisecond
 const waitForCreationTimeout = 10 * time.Second
 const waitForDeletionTSTimeout = 3 * time.Second
 
-type ControllerManagerTestSuiteBase struct {
+type TestSuiteBase struct {
 	suite.Suite
+}
+
+func (s *TestSuiteBase) ExpectNoEvent(eventRecorder *record.FakeRecorder) {
+	select {
+	case event := <-eventRecorder.Events:
+		s.Fail("Unexpected event found", event)
+	default:
+		// Amazing, no events left behind!
+	}
+}
+
+type ControllerManagerTestSuiteBase struct {
+	TestSuiteBase
 	TestEnv          *envtest.Environment
 	RestConfig       *rest.Config
 	TestNamespace    string


### PR DESCRIPTION
### Description

This PR removes an overly verbose event with reason ReasonEnforcementGloballyDisabled, reported when external traffic policy support is disabled. 
The PR also fixes the formatting of the events (to start with capital case, to meed conventions).

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
