### PR TITLE
When creating an external traffic network policy, now only use a single existing Otterize network policy to determine the pod selector used by the external traffic network policy as all of the different pod selectors are equivalent

### DIFF
--- a/src/operator/controllers/external_traffic/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/external_traffic/external_traffic_network_policy_test.go
@@ -57,9 +57,9 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupSuite() {
 	logrus.Info("Setting up test suite")
 	s.TestEnv = &envtest.Environment{Scheme: clientgoscheme.Scheme}
 	var err error
-	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "..", "config", "crd")}
+	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "config", "crd")}
 	s.TestEnv.WebhookInstallOptions = envtest.WebhookInstallOptions{
-		Paths:            []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		Paths:            []string{filepath.Join("..", "..", "config", "webhook")},
 		LocalServingHost: "localhost",
 	}
 	utilruntime.Must(apiextensionsv1.AddToScheme(s.TestEnv.Scheme))

--- a/src/operator/controllers/external_traffic/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/external_traffic/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -65,9 +65,9 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 	logrus.Info("Setting up test suite")
 	s.TestEnv = &envtest.Environment{Scheme: clientgoscheme.Scheme}
 	var err error
-	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "..", "config", "crd")}
+	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "config", "crd")}
 	s.TestEnv.WebhookInstallOptions = envtest.WebhookInstallOptions{
-		Paths:            []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		Paths:            []string{filepath.Join("..", "..", "config", "webhook")},
 		LocalServingHost: "localhost",
 	}
 	utilruntime.Must(apiextensionsv1.AddToScheme(s.TestEnv.Scheme))

--- a/src/operator/controllers/external_traffic/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/external_traffic/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -1,4 +1,4 @@
-package external_traffic_network_policy
+package external_traffic
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
 	"github.com/otterize/intents-operator/src/operator/controllers"
-	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/networkpolicy"
@@ -25,6 +24,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -33,6 +33,7 @@ import (
 	v1 "k8s.io/api/networking/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -45,16 +46,22 @@ import (
 	"testing"
 )
 
-type ExternalNetworkPolicyReconcilerTestSuite struct {
+const ingressControllerName = "ingress-controller"
+const ingressControllerNamespace = "ingress-nginx"
+const ingressControllerKind = "Deployment"
+const ingressControllerHashedName = "ingress-controller-ingress-nginx-53b476"
+
+type ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
-	IngressReconciler                *external_traffic.IngressReconciler
-	endpointReconciler               external_traffic.EndpointsReconciler
+	IngressReconciler                *IngressReconciler
+	endpointReconciler               EndpointsReconciler
 	EffectivePolicyIntentsReconciler *intents_reconcilers.ServiceEffectivePolicyIntentsReconciler
 	podWatcher                       *pod_reconcilers.PodWatcher
 	defaultDenyReconciler            *protected_service_reconcilers.DefaultDenyReconciler
+	netpolHandler                    *NetworkPolicyHandler
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupSuite() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) SetupSuite() {
 	logrus.Info("Setting up test suite")
 	s.TestEnv = &envtest.Environment{Scheme: clientgoscheme.Scheme}
 	var err error
@@ -81,7 +88,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupSuite() {
 	s.Require().NotNil(s.K8sDirectClient)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) SetupTest() {
 	s.ControllerManagerTestSuiteBase.SetupTest()
 	intentsValidator := webhooks.NewIntentsValidatorV1alpha2(s.Mgr.GetClient())
 	s.Require().NoError((&otterizev1alpha2.ClientIntents{}).SetupWebhookWithManager(s.Mgr, intentsValidator))
@@ -96,7 +103,13 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	testName := s.T().Name()
 	isShadowMode := strings.Contains(testName, "ShadowMode")
 	defaultActive := !isShadowMode
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
+	netpolHandler := NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.IfBlockedByOtterize, []serviceidentity.ServiceIdentity{
+		{
+			Kind:      "Deployment",
+			Namespace: ingressControllerNamespace,
+			Name:      ingressControllerName,
+		},
+	}, false)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), true)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, defaultActive, false, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder(), builders.NewPortNetworkPolicyReconciler(s.Mgr.GetClient())}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
@@ -105,18 +118,20 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
 	s.EffectivePolicyIntentsReconciler.InjectRecorder(recorder)
 
-	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
+	s.endpointReconciler = NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.endpointReconciler.InjectRecorder(recorder)
 	err := s.endpointReconciler.InitIngressReferencedServicesIndex(s.Mgr)
 	s.Require().NoError(err)
 
-	s.IngressReconciler = external_traffic.NewIngressReconciler(s.Mgr.GetClient(), netpolHandler)
+	s.IngressReconciler = NewIngressReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
+	s.netpolHandler = netpolHandler
+
 	controller := gomock.NewController(s.T())
 	serviceEffectivePolicyReconciler := podreconcilersmocks.NewMockGroupReconciler(controller)
-	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, defaultActive, true, goset.NewSet[string](), &mocks.MockIntentsReconcilerForTestEnv{}, serviceEffectivePolicyReconciler)
+	s.podWatcher = pod_reconcilers.NewPodWatcher(s.Mgr.GetClient(), recorder, []string{}, true, true, goset.NewSet[string](), &mocks.MockIntentsReconcilerForTestEnv{}, serviceEffectivePolicyReconciler)
 	err = s.podWatcher.InitIntentsClientIndices(s.Mgr)
 	s.Require().NoError(err)
 
@@ -124,12 +139,10 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIngress() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForIngress() {
 	serviceName := "test-server-ingress-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
-		Kubernetes: &otterizev2alpha1.KubernetesTarget{
-			Name: serviceName,
-		},
+		Kubernetes: lo.ToPtr(otterizev2alpha1.KubernetesTarget{Name: serviceName}),
 	},
 	})
 	s.Require().NoError(err)
@@ -159,7 +172,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 	s.Require().NoError(err)
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -181,11 +194,27 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 		assert.NoError(err)
 		assert.NotEmpty(np)
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 1)
+	s.Require().Equal([]v1.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+			"intents.otterize.com/owner-kind": ingressControllerKind,
+			"intents.otterize.com/service":    ingressControllerHashedName,
+		}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": ingressControllerNamespace,
+			},
+			},
+		}}, np.Spec.Ingress[0].From)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIngressWithIntentToSVC() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForIngressWithIntentToSVC() {
 	serviceName := "test-server-ingress-test"
-	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{Service: &otterizev2alpha1.ServiceTarget{Name: serviceName}}})
+	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
+		Kubernetes: lo.ToPtr(otterizev2alpha1.KubernetesTarget{Name: serviceName, Kind: serviceidentity.KindService}),
+	},
+	})
 	s.Require().NoError(err)
 	s.AddDeploymentWithService(serviceName, []string{"1.1.1.1"}, map[string]string{"app": "test"}, nil)
 
@@ -212,7 +241,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 	})
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -234,9 +263,22 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 		assert.NoError(err)
 		assert.NotEmpty(np)
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 1)
+	s.Require().Equal([]v1.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+			"intents.otterize.com/owner-kind": ingressControllerKind,
+			"intents.otterize.com/service":    ingressControllerHashedName,
+		}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": ingressControllerNamespace,
+			},
+			},
+		}}, np.Spec.Ingress[0].From)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIngressWithIntentToDeployment() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForIngressWithIntentToDeployment() {
 	serviceName := "test-server-ingress-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName, Kind: "Deployment"},
@@ -268,7 +310,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 	})
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -289,10 +331,24 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForIng
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.NoError(err)
 		assert.NotEmpty(np)
+
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 1)
+	s.Require().Equal([]v1.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+			"intents.otterize.com/owner-kind": ingressControllerKind,
+			"intents.otterize.com/service":    ingressControllerHashedName,
+		}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": ingressControllerNamespace,
+			},
+			},
+		}}, np.Spec.Ingress[0].From)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressProtectedService_ShadowMode() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestIngressProtectedService_ShadowMode() {
 	serviceName := "test-server-ingress-test"
 
 	s.AddDeploymentWithService(serviceName, []string{"1.1.1.1"}, map[string]string{"app": "test"}, nil)
@@ -343,7 +399,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressProtectedService_S
 	s.Require().NoError(err)
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -367,7 +423,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressProtectedService_S
 	})
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressWithIntentsProtectedService_ShadowMode() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestIngressWithIntentsProtectedService_ShadowMode() {
 	serviceName := "test-server-ingress-test"
 
 	s.AddDeploymentWithService(serviceName, []string{"1.1.1.1"}, map[string]string{"app": "test"}, nil)
@@ -425,7 +481,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressWithIntentsProtect
 	s.Require().NoError(err)
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -447,9 +503,23 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestIngressWithIntentsProtect
 		assert.NoError(err)
 		assert.NotEmpty(np)
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 1)
+	s.Require().Equal([]v1.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+			"intents.otterize.com/owner-kind": ingressControllerKind,
+			"intents.otterize.com/service":    ingressControllerHashedName,
+		}},
+			NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				"kubernetes.io/metadata.name": ingressControllerNamespace,
+			},
+			},
+		}}, np.Spec.Ingress[0].From)
+
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoadBalancer() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForLoadBalancer() {
 	serviceName := "test-server-load-balancer-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName},
@@ -485,7 +555,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 
 	// make sure the load balancer network policy doesn't exist yet
 	loadBalancerServiceName := serviceName + "-lb"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
@@ -508,10 +578,12 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 		assert.NoError(err)
 		assert.NotEmpty(np)
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 0)
 }
 
-// This one is flaky
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedAndDeletedWhenLastIntentDeleted() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedAndDeletedWhenLastIntentDeleted() {
 	serviceName := "test-server-load-balancer-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName},
@@ -547,7 +619,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 
 	// make sure the load balancer network policy doesn't exist yet
 	loadBalancerServiceName := serviceName + "-lb"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, netpol)
 		assert.True(errors.IsNotFound(err))
@@ -606,7 +678,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 	})
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedAndDoesNotGetDeletedEvenWhenIntentRemovedAsLongAsOneRemains() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForLoadBalancerCreatedAndDoesNotGetDeletedEvenWhenIntentRemovedAsLongAsOneRemains() {
 	serviceName := "test-server-load-balancer-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName},
@@ -659,7 +731,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 
 	// make sure the load balancer network policy doesn't exist yet
 	loadBalancerServiceName := serviceName + "-lb"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -714,9 +786,12 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForLoa
 		assert.NoError(err)
 		assert.Nil(externalNetpol.DeletionTimestamp)
 	})
+
+	s.Require().Len(externalNetpol.Spec.Ingress, 1)
+	s.Require().Len(externalNetpol.Spec.Ingress[0].From, 0)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForNodePort() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyCreateForNodePort() {
 	serviceName := "test-server-node-port-test"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName},
@@ -753,7 +828,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForNod
 
 	// make sure the load balancer network policy doesn't exist yet
 	nodePortServiceName := serviceName + "-np"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
 
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
@@ -775,9 +850,12 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestNetworkPolicyCreateForNod
 		assert.NoError(err)
 		assert.NotEmpty(np)
 	})
+
+	s.Require().Len(np.Spec.Ingress, 1)
+	s.Require().Len(np.Spec.Ingress[0].From, 0)
 }
 
-func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetworkPoliciesDisabled() {
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestEndpointsReconcilerNetworkPoliciesDisabled() {
 	serviceName := "test-endpoints-reconciler-enforcement-disabled"
 	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
 		Kubernetes: &otterizev2alpha1.KubernetesTarget{Name: serviceName},
@@ -813,7 +891,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 
 	// make sure the load balancer network policy doesn't exist yet
 	nodePortServiceName := serviceName + "-np"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
 	s.WaitUntilCondition(func(assert *assert.Assertions) {
 		err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 		assert.True(errors.IsNotFound(err))
@@ -821,8 +899,14 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Off, make([]serviceidentity.ServiceIdentity, 0), false)
-	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
+	netpolHandler := NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Off, []serviceidentity.ServiceIdentity{
+		{
+			Namespace: s.TestNamespace,
+			Name:      ingressControllerName,
+			Kind:      "Deployment",
+		},
+	}, false)
+	endpointReconcilerWithEnforcementDisabled := NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)
 
@@ -842,6 +926,145 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 	s.ExpectNoEvent(recorder)
 }
 
-func TestExternalNetworkPolicyReconcilerTestSuite(t *testing.T) {
-	suite.Run(t, new(ExternalNetworkPolicyReconcilerTestSuite))
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyForAWSALBExemption_enabled() {
+	serviceName := "ingress-service"
+	ingressName := "test-ingress-alb"
+	ingressNamespace := s.TestNamespace
+	s.netpolHandler.SetIngressControllerALBAllowAll(true)
+
+	// Add Ingress with the annotation "alb.ingress.kubernetes.io/scheme": "internet-facing"
+	ingress := s.AddIngressWithAnnotation(ingressName, ingressNamespace, serviceName, map[string]string{
+		"alb.ingress.kubernetes.io/target-type": "ip",
+	})
+
+	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
+		Service: &otterizev2alpha1.ServiceTarget{Name: ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name},
+	},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: intents.Namespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+
+	// Reconcile the ingress
+	res, err := s.IngressReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ingressNamespace, Name: ingressName},
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	// Verify that the network policy allows all ingress traffic
+	np := &v1.NetworkPolicy{}
+	policyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: ingressNamespace, Name: policyName}, np)
+		assert.NoError(err)
+		assert.NotEmpty(np)
+		assert.Len(np.Spec.Ingress, 1)
+		if len(np.Spec.Ingress) == 1 {
+			assert.Len(np.Spec.Ingress[0].From, 0) // Allow all ingress traffic
+		}
+	})
+}
+
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) TestNetworkPolicyForAWSALBExemption_disabled() {
+	serviceName := "ingress-service"
+	ingressName := "test-ingress-alb"
+	ingressNamespace := s.TestNamespace
+	s.netpolHandler.SetIngressControllerALBAllowAll(false)
+
+	// Add Ingress with the annotation "alb.ingress.kubernetes.io/scheme": "internet-facing"
+	ingress := s.AddIngressWithAnnotation(ingressName, ingressNamespace, serviceName, map[string]string{
+		"alb.ingress.kubernetes.io/scheme": "internet-facing",
+	})
+
+	intents, err := s.AddIntents("test-intents", "test-client", "Deployment", []otterizev2alpha1.Target{{
+		Service: &otterizev2alpha1.ServiceTarget{Name: ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name},
+	},
+	})
+	s.Require().NoError(err)
+
+	_, err = s.EffectivePolicyIntentsReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: intents.Namespace,
+			Name:      intents.Name,
+		},
+	})
+
+	s.Require().NoError(err)
+
+	// Reconcile the ingress
+	res, err := s.IngressReconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ingressNamespace, Name: ingressName},
+	})
+	s.Require().NoError(err)
+	s.Require().Empty(res)
+
+	// Verify that the network policy allows all ingress traffic
+	np := &v1.NetworkPolicy{}
+	policyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	s.WaitUntilCondition(func(assert *assert.Assertions) {
+		err := s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: ingressNamespace, Name: policyName}, np)
+		assert.NoError(err)
+		assert.NotEmpty(np)
+		assert.Len(np.Spec.Ingress, 1)
+		if len(np.Spec.Ingress) == 1 {
+			assert.Len(np.Spec.Ingress[0].From, 1) // Only allow traffic from the ingress controller
+		}
+	})
+}
+
+func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite) AddIngressWithAnnotation(name, namespace, serviceName string, annotations map[string]string) *v1.Ingress {
+	ingress := &v1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: v1.IngressSpec{
+			Rules: []v1.IngressRule{
+				{
+					Host: "example.com",
+					IngressRuleValue: v1.IngressRuleValue{
+						HTTP: &v1.HTTPIngressRuleValue{
+							Paths: []v1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: lo.ToPtr(v1.PathTypePrefix),
+									Backend: v1.IngressBackend{
+										Service: &v1.IngressServiceBackend{
+											Name: serviceName,
+											Port: v1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	s.Require().NoError(s.Mgr.GetClient().Create(context.Background(), ingress))
+	s.WaitForObjectToBeCreated(ingress)
+
+	s.AddDeploymentWithService(serviceName, []string{"3.3.3.3"}, map[string]string{"app": "test"}, nil)
+
+	// the ingress reconciler expect the pod watcher labels in order to work
+	_, err := s.podWatcher.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: s.TestNamespace, Name: serviceName + "-0"}})
+	s.Require().NoError(err)
+
+	return ingress
+}
+
+func TestExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite(t *testing.T) {
+	suite.Run(t, new(ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuite))
 }

--- a/src/operator/controllers/external_traffic/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/external_traffic/external_traffic_network_policy_with_no_intents_test.go
@@ -54,9 +54,9 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupSuite() {
 	logrus.Info("Setting up test suite")
 	s.TestEnv = &envtest.Environment{Scheme: clientgoscheme.Scheme}
 	var err error
-	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "..", "config", "crd")}
+	s.TestEnv.CRDDirectoryPaths = []string{filepath.Join("..", "..", "config", "crd")}
 	s.TestEnv.WebhookInstallOptions = envtest.WebhookInstallOptions{
-		Paths:            []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		Paths:            []string{filepath.Join("..", "..", "config", "webhook")},
 		LocalServingHost: "localhost",
 	}
 	utilruntime.Must(apiextensionsv1.AddToScheme(s.TestEnv.Scheme))

--- a/src/operator/controllers/external_traffic/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/external_traffic/external_traffic_network_policy_with_no_intents_test.go
@@ -1,4 +1,4 @@
-package external_traffic_network_policy
+package external_traffic
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
 	"github.com/otterize/intents-operator/src/operator/controllers"
-	"github.com/otterize/intents-operator/src/operator/controllers/external_traffic"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers"
 	mocks "github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/controllers/intents_reconcilers/networkpolicy"
@@ -45,8 +44,8 @@ import (
 
 type ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite struct {
 	testbase.ControllerManagerTestSuiteBase
-	IngressReconciler                *external_traffic.IngressReconciler
-	endpointReconciler               external_traffic.EndpointsReconciler
+	IngressReconciler                *IngressReconciler
+	endpointReconciler               EndpointsReconciler
 	EffectivePolicyIntentsReconciler *intents_reconcilers.ServiceEffectivePolicyIntentsReconciler
 	podWatcher                       *pod_reconcilers.PodWatcher
 }
@@ -90,7 +89,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.Require().NoError((&otterizev2beta1.ClientIntents{}).SetupWebhookWithManager(s.Mgr, intentsValidator2Beta1))
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Always, make([]serviceidentity.ServiceIdentity, 0), false)
+	netpolHandler := NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Always, make([]serviceidentity.ServiceIdentity, 0), false)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, true, false, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, serviceIdResolver, netpolReconciler)
@@ -98,12 +97,12 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.Require().NoError((&controllers.IntentsReconciler{}).InitIntentsServerIndices(s.Mgr))
 	s.EffectivePolicyIntentsReconciler.InjectRecorder(recorder)
 
-	s.endpointReconciler = external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
+	s.endpointReconciler = NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.endpointReconciler.InjectRecorder(recorder)
 	err := s.endpointReconciler.InitIngressReferencedServicesIndex(s.Mgr)
 	s.Require().NoError(err)
 
-	s.IngressReconciler = external_traffic.NewIngressReconciler(s.Mgr.GetClient(), netpolHandler)
+	s.IngressReconciler = NewIngressReconciler(s.Mgr.GetClient(), netpolHandler)
 	s.IngressReconciler.InjectRecorder(recorder)
 	s.Require().NoError(err)
 
@@ -130,7 +129,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 	s.Require().NoError(err)
 
 	// make sure the ingress network policy doesn't exist yet
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, serviceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, serviceName)
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 	s.Require().True(errors.IsNotFound(err))
 
@@ -169,7 +168,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the load balancer network policy doesn't exist yet
 	loadBalancerServiceName := serviceName + "-lb"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 	s.Require().True(errors.IsNotFound(err))
 
@@ -207,7 +206,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the load balancer network policy doesn't exist yet
 	nodePortServiceName := serviceName + "-np"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 	s.Require().True(errors.IsNotFound(err))
 
@@ -245,7 +244,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 
 	// make sure the load balancer network policy doesn't exist yet
 	nodePortServiceName := serviceName + "-np"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, nodePortServiceName)
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, np)
 	s.Require().True(errors.IsNotFound(err))
 
@@ -255,9 +254,10 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 		AutomateThirdPartyNetworkPolicies: automate_third_party_network_policy.Always,
 		EnforcementDefaultState:           false,
 	}
+
 	s.Require().Equal(automate_third_party_network_policy.IfBlockedByOtterize, enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), make([]serviceidentity.ServiceIdentity, 0), false)
-	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
+	netpolHandler := NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), make([]serviceidentity.ServiceIdentity, 0), false)
+	endpointReconcilerWithEnforcementDisabled := NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)
 
@@ -309,7 +309,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestNetworkPolic
 
 	// make sure the load balancer network policy doesn't exist yet
 	loadBalancerServiceName := serviceName + "-lb"
-	externalNetworkPolicyName := fmt.Sprintf(external_traffic.OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
+	externalNetworkPolicyName := fmt.Sprintf(OtterizeExternalNetworkPolicyNameTemplate, loadBalancerServiceName)
 	err = s.Mgr.GetClient().Get(context.Background(), types.NamespacedName{Namespace: s.TestNamespace, Name: externalNetworkPolicyName}, netpol)
 	s.Require().True(errors.IsNotFound(err))
 

--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -423,6 +423,8 @@ func (r *NetworkPolicyHandler) handleEndpointsWithIngressList(ctx context.Contex
 		netpolsAffectingThisWorkload = append(netpolsAffectingThisWorkload, netpolList.Items...)
 
 		// Sort netpolsAffectingThisWorkload by name so that we always use the same netpol when running Find below
+		// This is important because we relay on the order of the netpols to determine whether it already exists, does not
+		// exist or need an update
 		slices.SortStableFunc(netpolsAffectingThisWorkload, func(i, j v1.NetworkPolicy) bool {
 			return i.Name < j.Name
 		})

--- a/src/operator/controllers/external_traffic/network_policy.go
+++ b/src/operator/controllers/external_traffic/network_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -393,35 +394,40 @@ func (r *NetworkPolicyHandler) handleEndpointsWithIngressList(ctx context.Contex
 		if !ok {
 			continue
 		}
-		netpolSlice := make([]v1.NetworkPolicy, 0)
+		netpolsAffectingThisWorkload := make([]v1.NetworkPolicy, 0)
 
 		serviceId, err := serviceidresolver.NewResolver(r.client).ResolvePodToServiceIdentity(ctx, pod)
 		if err != nil {
 			return errors.Wrap(err)
 		}
 		netpolList := &v1.NetworkPolicyList{}
-		// Get netpolSlice which was created by intents targeting this pod by its owner with "kind"
+		// Get netpolsAffectingThisWorkload which was created by intents targeting this pod by its owner with "kind"
 		err = r.client.List(ctx, netpolList, client.MatchingLabels{v2alpha1.OtterizeNetworkPolicy: serviceId.GetFormattedOtterizeIdentityWithKind()})
 		if err != nil {
 			return errors.Wrap(err)
 		}
-		netpolSlice = append(netpolSlice, netpolList.Items...)
-		// Get netpolSlice which was created by intents targeting this pod by its owner without "kind"
+		netpolsAffectingThisWorkload = append(netpolsAffectingThisWorkload, netpolList.Items...)
+		// Get netpolsAffectingThisWorkload which was created by intents targeting this pod by its owner without "kind"
 		err = r.client.List(ctx, netpolList, client.MatchingLabels{v2alpha1.OtterizeNetworkPolicy: serviceId.GetFormattedOtterizeIdentityWithoutKind()})
 		if err != nil {
 			return errors.Wrap(err)
 		}
-		netpolSlice = append(netpolSlice, netpolList.Items...)
+		netpolsAffectingThisWorkload = append(netpolsAffectingThisWorkload, netpolList.Items...)
 
-		// Get netpolSlice which was created by intents targeting this pod by its service
+		// Get netpolsAffectingThisWorkload which was created by intents targeting this pod by its service
 		err = r.client.List(ctx, netpolList, client.MatchingLabels{v2alpha1.OtterizeNetworkPolicy: (&serviceidentity.ServiceIdentity{Name: endpoints.Name, Namespace: endpoints.Namespace, Kind: serviceidentity.KindService}).GetFormattedOtterizeIdentityWithKind()})
 		if err != nil {
 			return errors.Wrap(err)
 		}
 
-		netpolSlice = append(netpolSlice, netpolList.Items...)
+		netpolsAffectingThisWorkload = append(netpolsAffectingThisWorkload, netpolList.Items...)
 
-		hasIngressRules := lo.SomeBy(netpolSlice, func(netpol v1.NetworkPolicy) bool {
+		// Sort netpolsAffectingThisWorkload by name so that we always use the same netpol when running Find below
+		slices.SortStableFunc(netpolsAffectingThisWorkload, func(i, j v1.NetworkPolicy) bool {
+			return i.Name < j.Name
+		})
+
+		ingressNetpol, hasIngressRules := lo.Find(netpolsAffectingThisWorkload, func(netpol v1.NetworkPolicy) bool {
 			return lo.Contains(netpol.Spec.PolicyTypes, v1.PolicyTypeIngress)
 		})
 
@@ -442,7 +448,7 @@ func (r *NetworkPolicyHandler) handleEndpointsWithIngressList(ctx context.Contex
 		}
 
 		foundOtterizeNetpolsAffectingPods = true
-		err = r.handleNetpolsForOtterizeService(ctx, endpoints, serverLabel, ingressList, netpolSlice)
+		err = r.handleNetpolsForOtterizeService(ctx, endpoints, serverLabel, ingressList, ingressNetpol.Spec.PodSelector)
 		if err != nil {
 			return errors.Wrap(err)
 		}
@@ -522,7 +528,7 @@ func (r *NetworkPolicyHandler) handlePolicyDelete(ctx context.Context, policyNam
 	return nil
 }
 
-func (r *NetworkPolicyHandler) handleNetpolsForOtterizeService(ctx context.Context, endpoints *corev1.Endpoints, otterizeServiceName string, ingressList *v1.IngressList, netpolList []v1.NetworkPolicy) error {
+func (r *NetworkPolicyHandler) handleNetpolsForOtterizeService(ctx context.Context, endpoints *corev1.Endpoints, otterizeServiceName string, ingressList *v1.IngressList, affectedPodSelector metav1.LabelSelector) error {
 	svc := &corev1.Service{}
 	err := r.client.Get(ctx, types.NamespacedName{Name: endpoints.Name, Namespace: endpoints.Namespace}, svc)
 	if err != nil {
@@ -538,14 +544,10 @@ func (r *NetworkPolicyHandler) handleNetpolsForOtterizeService(ctx context.Conte
 		return nil
 	}
 
-	for _, netpol := range netpolList {
-		successMsg := fmt.Sprintf("Created external traffic network policy. service '%s' refers to pods protected by network policy '%s'",
-			endpoints.GetName(), netpol.GetName())
-		err = r.createOrUpdateNetworkPolicy(ctx, endpoints, svc, otterizeServiceName, netpol.Spec.PodSelector, ingressList, successMsg)
+	err = r.createOrUpdateNetworkPolicy(ctx, endpoints, svc, otterizeServiceName, affectedPodSelector, ingressList, fmt.Sprintf("Created external traffic network policy. Service '%s' is affected by Otterize network policies", endpoints.GetName()))
 
-		if err != nil {
-			return errors.Wrap(err)
-		}
+	if err != nil {
+		return errors.Wrap(err)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

This PR does not have any behavioral affect on the intents-operator. 
Before this change, when we had to create an external traffic network policy, we used to create one and modify it many times based on existing network policies selectors.
No we only choose one selector from one existing network policy, and create the network policy only once, thus reducing the number of operations we perform in the cluster.
It also makes the code more clear and easy to understand.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
