### PR TITLE
Fix bug where the workload identity resolution algorithm could fail if an owner ref uses a wrong apiVersion or kind

### DIFF
--- a/src/shared/serviceidresolver/podownerresolver/podownerresolver.go
+++ b/src/shared/serviceidresolver/podownerresolver/podownerresolver.go
@@ -156,6 +156,12 @@ func GetOwnerObject(ctx context.Context, k8sClient client.Client, pod *corev1.Po
 				)
 				ownerObj.SetName(owner.Name)
 				return ownerObj, nil
+			} else if errors.Is(err, &meta.NoKindMatchError{}) {
+				log.WithError(err).WithFields(logrus.Fields{"owner": owner.Name, "ownerKind": obj.GetObjectKind().GroupVersionKind()}).Warning(
+					"resolving owner failed due to owner kind not found, will use current owner name as service identifier",
+				)
+				ownerObj.SetName(owner.Name)
+				return ownerObj, nil
 			}
 			return nil, errors.Errorf("error querying owner reference: %w", err)
 		}


### PR DESCRIPTION
### Description

In some cases, the object's owner reference may be incorrect or not included in the schema. We don't want to fail in those situations; it is sufficient to halt owner resolution and report the error. 



### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
