### PR TITLE
Automatically create network policies to allow Prometheus scraping traffic for workloads annotated with `prometheus.io/scrape`

### DIFF
--- a/.github/workflow-helpers/prometheus-test-client-intents.yaml
+++ b/.github/workflow-helpers/prometheus-test-client-intents.yaml
@@ -1,0 +1,11 @@
+apiVersion: k8s.otterize.com/v2beta1
+kind: ClientIntents
+metadata:
+  name: client
+  namespace: otterize-tutorial-npol
+spec:
+  workload:
+    name: client
+  targets:
+    - service:
+        name: simple-server-service

--- a/.github/workflow-helpers/prometheus-test-deployment.yaml
+++ b/.github/workflow-helpers/prometheus-test-deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otterize-tutorial-npol
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-server-deployment
+  namespace: otterize-tutorial-npol
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simple-server
+  template:
+    metadata:
+      labels:
+        app: simple-server
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7000"
+    spec:
+      containers:
+        - name: simple-server
+          image: python:3.9-slim
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh", "-c", "pip install flask requests prometheus_client && python /server.py" ]
+          ports:
+            - containerPort: 8080
+            - containerPort: 7000
+          volumeMounts:
+            - name: server-script
+              mountPath: /server.py
+              subPath: server.py
+      volumes:
+        - name: server-script
+          configMap:
+            name: server-script-configmap
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simple-server-service
+  namespace: otterize-tutorial-npol
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7000"
+spec:
+  selector:
+    app: simple-server
+  ports:
+    - protocol: TCP
+      name: connection
+      port: 80
+      targetPort: 8080
+    - protocol: TCP
+      name: metrics
+      port: 7000
+      targetPort: 7000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  namespace: otterize-tutorial-npol
+spec:
+  selector:
+    matchLabels:
+      app: client
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      containers:
+        - name: client
+          image: alpine/curl
+          command: [ "/bin/sh", "-c", "--" ]
+          args: [ "while true; do echo \"Calling server...\"; if ! timeout 2 curl -si http://simple-server-service:80/?text=client 2>/dev/null; then echo \"curl timed out\"; fi; sleep 2; done" ]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client-other
+  namespace: otterize-tutorial-npol
+spec:
+  selector:
+    matchLabels:
+      app: client-other
+  template:
+    metadata:
+      labels:
+        app: client-other
+    spec:
+      containers:
+        - name: client-other
+          image: alpine/curl
+          command: [ "/bin/sh", "-c", "--" ]
+          args: [ "while true; do echo \"Calling server...\"; if ! timeout 2 curl -si http://simple-server-service:80/?text=client-other 2>/dev/null; then echo \"curl timed out\"; fi; sleep 2; done" ]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: server-script-configmap
+  namespace: otterize-tutorial-npol
+data:
+  server.py: |
+    from flask import Flask, request
+    from prometheus_client import start_http_server, Summary, Counter
+    
+    app = Flask(__name__)
+  
+    REQUEST_TIME = Summary('request_processing_seconds', 'Time spent processing request')
+    REQUEST_COUNT = Counter('server_requests_count', 'Total number of requests made to the server')
+  
+    @app.route('/')
+    @REQUEST_TIME.time()  # Track the time spent on this route
+    def index():
+      REQUEST_COUNT.inc()
+      text = request.args.get('text', 'Hello, world!')
+      return f'You entered: {text}'
+
+    if __name__ == '__main__':
+      # Start Prometheus metrics server on port 7000
+      start_http_server(7000)
+      app.run(host='0.0.0.0', port=8080)
+---

--- a/.github/workflows/netpol-e2e-test.yaml
+++ b/.github/workflows/netpol-e2e-test.yaml
@@ -518,10 +518,138 @@ jobs:
            # should be blocked (using 3 because the log should repeat itself every 3 lines)
           echo "check client other log - should get timed out because it does not have an applied intent"
           wait_for_log $CLI2_POD 10 "curl timed out"
-  
-  
-  
-  
+
+
+  e2e-test-auto-allow-prometheus-scraping:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
+        with:
+          start-args: "--network-plugin=cni --cni=calico"
+
+      - name: Load images from GitHub Artifacts
+        if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.REGISTRY }}_${{ github.actor }}_intents-operator_${{ github.sha }}.tar
+
+      - name: Load Docker image
+        if: github.repository != 'otterize/intents-operator' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'otterize/intents-operator')
+        run: |-
+          docker image load -i intents-operator.tar
+          minikube image load ${{ env.REGISTRY }}/${{ github.actor }}/intents-operator:${{ github.sha }}
+
+      - name: Login to GCR
+        if: (github.event_name == 'push' && github.repository == 'otterize/intents-operator') || github.event.pull_request.head.repo.full_name == 'otterize/intents-operator'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: _json_key_base64
+          password: ${{ secrets.B64_GCLOUD_SERVICE_ACCOUNT_JSON}}
+
+      - name: Load Docker images from GCR
+        if: (github.event_name == 'push' && github.repository == 'otterize/intents-operator') || github.event.pull_request.head.repo.full_name == 'otterize/intents-operator'
+        run: |-
+          docker pull ${{ env.REGISTRY }}/intents-operator:${{ inputs.operator-tag }}
+          minikube image load ${{ env.REGISTRY }}/intents-operator:${{ inputs.operator-tag }}
+          docker pull ${{ env.REGISTRY }}/intents-operator-webhook-server:${{ inputs.webhook-server-tag }}
+          minikube image load ${{ env.REGISTRY }}/intents-operator-webhook-server:${{ inputs.webhook-server-tag }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Wait for Calico startup
+        run: |-
+          kubectl wait pods -n kube-system -l k8s-app=calico-kube-controllers --for condition=Ready --timeout=90s
+          kubectl wait pods -n kube-system -l k8s-app=calico-node --for condition=Ready --timeout=90s
+          kubectl wait pods -n kube-system -l k8s-app=calico-kube-controllers --for condition=Ready --timeout=90s
+
+      - name: Install Otterize
+        run: |-
+          OPERATOR_FLAGS="--set-string intentsOperator.operator.repository=${{ env.REGISTRY }} --set-string intentsOperator.webhookServer.repository=${{ env.REGISTRY }} --set-string intentsOperator.webhookServer.image=${{ inputs.webhook-server-image }} --set-string intentsOperator.webhookServer.tag=${{ inputs.webhook-server-tag }} --set-string intentsOperator.webhookServer.pullPolicy=Never --set-string intentsOperator.operator.image=${{ inputs.operator-image }} --set-string intentsOperator.operator.tag=${{ inputs.operator-tag }} --set-string intentsOperator.operator.pullPolicy=Never"
+          TELEMETRY_FLAG="--set global.telemetry.enabled=false"
+          EGRESS_FLAG="--set intentsOperator.operator.enableEgressNetworkPolicyCreation=true"
+          THIRD_PARTY_TRAFFIC_FLAG=`echo --set-string intentsOperator.operator.automateThirdPartyNetworkPolicies=ifBlockedByOtterize --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].name=prometheus-server" --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].namespace=prometheus" --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].kind=Deployment"`
+          helm dep up ./helm-charts/otterize-kubernetes
+          helm install otterize ./helm-charts/otterize-kubernetes -n otterize-system --create-namespace $OPERATOR_FLAGS $TELEMETRY_FLAG $EGRESS_FLAG $THIRD_PARTY_TRAFFIC_FLAG
+
+
+      - name: Install Prometheus
+        run: |-
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+          helm install prometheus prometheus-community/prometheus -n prometheus --create-namespace
+
+      - name: Deploy Tutorial services
+        run: |-
+          kubectl apply -f ./.github/workflow-helpers/prometheus-test-deployment.yaml
+
+      - name: Wait for Otterize
+        run: |-
+          kubectl wait pods -n otterize-system -l app=intents-operator --for condition=Ready --timeout=360s
+          kubectl wait pods -n otterize-system -l app=intents-operator-webhook-server --for condition=Ready --timeout=360s
+          # wait for webhook to be ready
+          POD_IP=`kubectl get pod -l app=intents-operator-webhook-server -n otterize-system -o=jsonpath='{.items[0].status.podIP}'`
+          kubectl wait -n otterize-system --for=jsonpath='{.subsets[0].addresses[0].ip}'=$POD_IP endpoints/intents-operator-webhook-service
+          # wait for CRD update
+          kubectl wait --for=jsonpath='{.spec.conversion.webhook.clientConfig.service.namespace}'=otterize-system customresourcedefinitions/clientintents.k8s.otterize.com
+
+
+      - name: Wait for Tutorial services
+        run: |-
+          kubectl wait pods -n otterize-tutorial-npol -l app=client --for condition=Ready --timeout=180s
+          kubectl wait pods -n otterize-tutorial-npol -l app=client-other --for condition=Ready --timeout=180s
+          kubectl wait pods -n otterize-tutorial-npol -l app=simple-server --for condition=Ready --timeout=180s
+
+      - name: Wait for Prometheus
+        run: |-
+          kubectl wait pods -n prometheus -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server --for condition=Ready --timeout=120s
+
+      - name: Before apply intents
+        run: |-
+          CLI1_POD=`kubectl get pod --selector app=client -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`
+          CLI2_POD=`kubectl get pod --selector app=client-other -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`
+          echo Client: $CLI1_POD      client_other: $CLI2_POD
+          source .github/workflows/test-bashrc.sh
+          
+          echo check client log
+          wait_for_log $CLI1_POD 10 "You entered: client"
+          
+          echo check client other log
+          wait_for_log $CLI2_POD 10 "You entered: client-other"
+
+      - name: Apply intents and test connectivity
+        run: |-
+          CLI1_POD=`kubectl get pod --selector app=client -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`
+          CLI2_POD=`kubectl get pod --selector app=client-other -n otterize-tutorial-npol -o json | jq -r ".items[0].metadata.name"`          
+          echo Client: $CLI1_POD      client_other: $CLI2_POD
+          source .github/workflows/test-bashrc.sh
+          
+          echo "Apply intents"
+          apply_intents_and_wait_for_webhook ./.github/workflow-helpers/prometheus-test-client-intents.yaml
+          echo "Intents applied"
+          
+          # should be blocked
+          echo "check client other log - should get timed out because it does not have an applied intent"
+          wait_for_log $CLI2_POD 10 "curl timed out"
+          
+          # should work because there is an applied intent
+          echo "check client log - should work because there is an applied intent"
+          wait_for_log $CLI1_POD 10 "You entered: client"
+
+      - name: Check network policies was created for Prometheus
+        run: |-
+          source .github/workflows/test-bashrc.sh
+          echo "Waiting for network policy to be created"
+          wait_for_netpol metrics-collection-access-to-service-simple-server-deployment 60
+          
   
 
   e2e-test:
@@ -530,6 +658,7 @@ jobs:
       - e2e-test-intents-before-pods
       - e2e-test-intents-after-pods-with-egress
       - e2e-test-intents-with-kind-after-pods-with-egress
+      - e2e-test-auto-allow-prometheus-scraping
     runs-on: ubuntu-latest
     steps:
       - run: |-

--- a/.github/workflows/netpol-e2e-test.yaml
+++ b/.github/workflows/netpol-e2e-test.yaml
@@ -576,7 +576,7 @@ jobs:
           OPERATOR_FLAGS="--set-string intentsOperator.operator.repository=${{ env.REGISTRY }} --set-string intentsOperator.webhookServer.repository=${{ env.REGISTRY }} --set-string intentsOperator.webhookServer.image=${{ inputs.webhook-server-image }} --set-string intentsOperator.webhookServer.tag=${{ inputs.webhook-server-tag }} --set-string intentsOperator.webhookServer.pullPolicy=Never --set-string intentsOperator.operator.image=${{ inputs.operator-image }} --set-string intentsOperator.operator.tag=${{ inputs.operator-tag }} --set-string intentsOperator.operator.pullPolicy=Never"
           TELEMETRY_FLAG="--set global.telemetry.enabled=false"
           EGRESS_FLAG="--set intentsOperator.operator.enableEgressNetworkPolicyCreation=true"
-          THIRD_PARTY_TRAFFIC_FLAG=`echo --set-string intentsOperator.operator.automateThirdPartyNetworkPolicies=ifBlockedByOtterize --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].name=prometheus-server" --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].namespace=prometheus" --set "intentsOperator.operator.metricsScrapingServiceConfigs[0].kind=Deployment"`
+          THIRD_PARTY_TRAFFIC_FLAG=`echo --set-string intentsOperator.operator.automateThirdPartyNetworkPolicies=ifBlockedByOtterize --set "intentsOperator.operator.prometheusServerConfigs[0].name=prometheus-server" --set "intentsOperator.operator.prometheusServerConfigs[0].namespace=prometheus" --set "intentsOperator.operator.prometheusServerConfigs[0].kind=Deployment"`
           helm dep up ./helm-charts/otterize-kubernetes
           helm install otterize ./helm-charts/otterize-kubernetes -n otterize-system --create-namespace $OPERATOR_FLAGS $TELEMETRY_FLAG $EGRESS_FLAG $THIRD_PARTY_TRAFFIC_FLAG
 

--- a/.github/workflows/test-bashrc.sh
+++ b/.github/workflows/test-bashrc.sh
@@ -39,3 +39,23 @@ apply_intents_and_wait_for_webhook() {
         fi;
     done
 }
+
+wait_for_netpol() {
+    NETPOL_NAME=$1
+    DELAY_SECONDS=$2
+    CURRENT_TIME=$(date +%s)
+    END_TIME=$((CURRENT_TIME+DELAY_SECONDS))
+    echo "Waiting for netpol: $NETPOL_NAME"
+    echo "Waiting for $DELAY_SECONDS seconds until $END_TIME starting from $CURRENT_TIME"
+    while [ $CURRENT_TIME -lt $END_TIME ];
+    do
+        OUTPUT=$(kubectl get netpol -n otterize-tutorial-npol | cut -d' ' -f1)
+        grep -qw "$NETPOL_NAME" <(echo $OUTPUT) && return || sleep 1;
+        CURRENT_TIME=$(date +%s)
+    done
+    echo "##############################################"
+    echo "Failed to find netpol"
+    echo "Last output was: $OUTPUT"
+    echo "##############################################"
+    exit 1
+}

--- a/src/operator/controllers/external_traffic/network_policy_test.go
+++ b/src/operator/controllers/external_traffic/network_policy_test.go
@@ -3,7 +3,7 @@ package external_traffic
 import (
 	"context"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/stretchr/testify/suite"
@@ -22,11 +22,11 @@ type NetworkPolicyHandlerTestSuite struct {
 
 func (s *NetworkPolicyHandlerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
+	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleBeforeAccessPolicyRemoval_createWhenNoIntentsEnabled_doNothing() {
-	s.handler.allowExternalTraffic = allowexternaltraffic.Always
+	s.handler.allowExternalTraffic = automate_third_party_network_policy.Always
 
 	serviceName := "testservice"
 	serviceNamespace := "testnamespace"

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/protected_service_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -96,7 +96,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) SetupTest() {
 	testName := s.T().Name()
 	isShadowMode := strings.Contains(testName, "ShadowMode")
 	defaultActive := !isShadowMode
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.IfBlockedByOtterize, make([]serviceidentity.ServiceIdentity, 0), false)
 	s.defaultDenyReconciler = protected_service_reconcilers.NewDefaultDenyReconciler(s.Mgr.GetClient(), true)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, defaultActive, false, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder(), builders.NewPortNetworkPolicyReconciler(s.Mgr.GetClient())}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
@@ -821,7 +821,7 @@ func (s *ExternalNetworkPolicyReconcilerTestSuite) TestEndpointsReconcilerNetwor
 
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, make([]serviceidentity.ServiceIdentity, 0), false)
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Off, make([]serviceidentity.ServiceIdentity, 0), false)
 	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_ingress_controllers_configured_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/controllers/protected_service_reconcilers"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/otterize/intents-operator/src/shared/testbase"
@@ -104,7 +104,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 	testName := s.T().Name()
 	isShadowMode := strings.Contains(testName, "ShadowMode")
 	defaultActive := !isShadowMode
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.IfBlockedByOtterize, []serviceidentity.ServiceIdentity{
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.IfBlockedByOtterize, []serviceidentity.ServiceIdentity{
 		{
 			Kind:      "Deployment",
 			Namespace: ingressControllerNamespace,
@@ -900,7 +900,7 @@ func (s *ExternalNetworkPolicyReconcilerWithIngressControllersConfiguredTestSuit
 
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Off, []serviceidentity.ServiceIdentity{
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Off, []serviceidentity.ServiceIdentity{
 		{
 			Namespace: s.TestNamespace,
 			Name:      ingressControllerName,

--- a/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
+++ b/src/operator/controllers/intents_reconcilers/external_traffic_network_policy/external_traffic_network_policy_with_no_intents_test.go
@@ -19,7 +19,7 @@ import (
 	podreconcilersmocks "github.com/otterize/intents-operator/src/operator/controllers/pod_reconcilers/mocks"
 	"github.com/otterize/intents-operator/src/operator/effectivepolicy"
 	"github.com/otterize/intents-operator/src/operator/webhooks"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
@@ -90,7 +90,7 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) SetupTest() {
 	s.Require().NoError((&otterizev2beta1.ClientIntents{}).SetupWebhookWithManager(s.Mgr, intentsValidator2Beta1))
 
 	recorder := s.Mgr.GetEventRecorderFor("intents-operator")
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, allowexternaltraffic.Always, make([]serviceidentity.ServiceIdentity, 0), false)
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, automate_third_party_network_policy.Always, make([]serviceidentity.ServiceIdentity, 0), false)
 	netpolReconciler := networkpolicy.NewReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, netpolHandler, []string{}, goset.NewSet[string](), true, true, false, []networkpolicy.IngressRuleBuilder{builders.NewIngressNetpolBuilder()}, nil)
 	serviceIdResolver := serviceidresolver.NewResolver(s.Mgr.GetClient())
 	groupReconciler := effectivepolicy.NewGroupReconciler(s.Mgr.GetClient(), s.TestEnv.Scheme, serviceIdResolver, netpolReconciler)
@@ -252,11 +252,11 @@ func (s *ExternalNetworkPolicyReconcilerWithNoIntentsTestSuite) TestEndpointsRec
 	s.AddNodePortService(nodePortServiceName, podIps, podLabels)
 
 	enforcementConfig := enforcement.Config{
-		AllowExternalTraffic:    allowexternaltraffic.Always,
-		EnforcementDefaultState: false,
+		AutomateThirdPartyNetworkPolicies: automate_third_party_network_policy.Always,
+		EnforcementDefaultState:           false,
 	}
-	s.Require().Equal(allowexternaltraffic.IfBlockedByOtterize, enforcementConfig.GetActualExternalTrafficPolicy())
-	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, enforcementConfig.GetActualExternalTrafficPolicy(), make([]serviceidentity.ServiceIdentity, 0), false)
+	s.Require().Equal(automate_third_party_network_policy.IfBlockedByOtterize, enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
+	netpolHandler := external_traffic.NewNetworkPolicyHandler(s.Mgr.GetClient(), s.TestEnv.Scheme, enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), make([]serviceidentity.ServiceIdentity, 0), false)
 	endpointReconcilerWithEnforcementDisabled := external_traffic.NewEndpointsReconciler(s.Mgr.GetClient(), netpolHandler)
 	recorder := record.NewFakeRecorder(10)
 	endpointReconcilerWithEnforcementDisabled.InjectRecorder(recorder)

--- a/src/operator/controllers/metrics_collection_traffic/network_policy_handler.go
+++ b/src/operator/controllers/metrics_collection_traffic/network_policy_handler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/shared/errors"
 	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"github.com/samber/lo"
@@ -59,13 +59,13 @@ type NetworkPolicyHandler struct {
 	client client.Client
 	scheme *runtime.Scheme
 	injectablerecorder.InjectableRecorder
-	allowMetricsCollector allowexternaltraffic.Enum
+	allowMetricsCollector automate_third_party_network_policy.Enum
 }
 
 func NewNetworkPolicyHandler(
 	client client.Client,
 	scheme *runtime.Scheme,
-	allowMetricsCollector allowexternaltraffic.Enum,
+	allowMetricsCollector automate_third_party_network_policy.Enum,
 ) *NetworkPolicyHandler {
 	return &NetworkPolicyHandler{
 		client:                client,
@@ -331,7 +331,7 @@ func (r *NetworkPolicyHandler) buildNetworkPolicyIfNeeded(ctx context.Context, p
 	policyName := r.formatPolicyName(pod.scrapeResourceType, serviceId)
 
 	// If configuration is set to "Always", we want to create the network policy regardless of other network policies
-	if r.allowMetricsCollector == allowexternaltraffic.Always {
+	if r.allowMetricsCollector == automate_third_party_network_policy.Always {
 		netpol, errBuild := r.buildNetpolForPod(ctx, pod, policyName, serviceId, scrapeResourceLabel)
 		if errBuild != nil {
 			return v1.NetworkPolicy{}, false, errors.Wrap(errBuild)
@@ -341,7 +341,7 @@ func (r *NetworkPolicyHandler) buildNetworkPolicyIfNeeded(ctx context.Context, p
 	}
 
 	// If configuration is set to "Off", we want to delete the network policy regardless of other network policies
-	if r.allowMetricsCollector == allowexternaltraffic.Off {
+	if r.allowMetricsCollector == automate_third_party_network_policy.Off {
 		return v1.NetworkPolicy{}, false, nil
 	}
 

--- a/src/operator/controllers/metrics_collection_traffic/network_policy_handler_test.go
+++ b/src/operator/controllers/metrics_collection_traffic/network_policy_handler_test.go
@@ -247,7 +247,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Po
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_MetricsCollectionServerOrderDoesNoHaveAnImpact() {
-	scrapingMetricsServer := []serviceidentity.ServiceIdentity{
+	prometheusServer := []serviceidentity.ServiceIdentity{
 		{
 			Name:      "bbb",
 			Namespace: "default",
@@ -259,7 +259,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Me
 			Kind:      "Deployment",
 		},
 	}
-	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.Always, scrapingMetricsServer)
+	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.Always, prometheusServer)
 	s.handler.InjectRecorder(s.Recorder)
 	s.mockForReturningScrapePodInListNamespace()
 	s.mockForResolvingScrapingPodIdentity()
@@ -302,7 +302,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Me
 	s.ExpectEvent(ReasonCreatingMetricsCollectorPolicy)
 }
 
-func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_NoScrapingMetricsServer_ShouldDoNothing() {
+func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_NoPrometheusServer_ShouldDoNothing() {
 	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.Always, make([]serviceidentity.ServiceIdentity, 0))
 	s.handler.InjectRecorder(s.Recorder)
 	s.mockForReturningScrapePodInListNamespace()

--- a/src/operator/controllers/metrics_collection_traffic/network_policy_handler_test.go
+++ b/src/operator/controllers/metrics_collection_traffic/network_policy_handler_test.go
@@ -3,7 +3,7 @@ package metrics_collection_traffic
 import (
 	"context"
 	"github.com/otterize/intents-operator/src/operator/api/v2alpha1"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
@@ -86,7 +86,7 @@ func TestNetworkPolicyHandlerTestSuite(t *testing.T) {
 
 func (s *NetworkPolicyHandlerTestSuite) SetupTest() {
 	s.MocksSuiteBase.SetupTest()
-	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, allowexternaltraffic.IfBlockedByOtterize)
+	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.IfBlockedByOtterize)
 	s.handler.InjectRecorder(s.Recorder)
 
 	s.podMarkedForScraping = &corev1.Pod{
@@ -163,7 +163,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_ShouldAddPolicy() {
-	s.setHandler(allowexternaltraffic.Always)
+	s.setHandler(automate_third_party_network_policy.Always)
 	s.mockForReturningScrapePodInListNamespace()
 	s.mockForResolvingScrapingPodIdentity()
 	//s.mockOneExistingOtterizeNetworkPolicies() // would not reach here since configuration is always
@@ -178,7 +178,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Sh
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleOff_ShouldDoNothing() {
-	s.setHandler(allowexternaltraffic.Off)
+	s.setHandler(automate_third_party_network_policy.Off)
 	s.mockForReturningScrapePodInListNamespace()
 	s.mockForResolvingScrapingPodIdentity()
 	//s.mockOneExistingOtterizeNetworkPolicies() // would not reach here since configuration is never
@@ -193,7 +193,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleOff_Shoul
 }
 
 func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_PortNotDefinedWithAnnotation_ShouldAddPolicy_UseAllResourcesPort() {
-	s.setHandler(allowexternaltraffic.Always)
+	s.setHandler(automate_third_party_network_policy.Always)
 	s.podMarkedForScraping.Annotations["prometheus.io/port"] = ""
 	s.podMarkedForScraping.Spec.Containers = []corev1.Container{
 		{
@@ -220,7 +220,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Po
 	s.ExpectEvent(ReasonCreatingMetricsCollectorPolicy)
 }
 
-func (s *NetworkPolicyHandlerTestSuite) setHandler(allowMetricsCollector allowexternaltraffic.Enum) {
+func (s *NetworkPolicyHandlerTestSuite) setHandler(allowMetricsCollector automate_third_party_network_policy.Enum) {
 	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, allowMetricsCollector)
 	s.handler.InjectRecorder(s.Recorder)
 }

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -212,7 +212,7 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
 
-	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), enforcementConfig.MetricsScrapingServiceIdentities)
+	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), enforcementConfig.PrometheusServiceIdentities)
 	metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorEndpointsReconciler := metrics_collection_traffic.NewEndpointsReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorServiceReconciler := metrics_collection_traffic.NewServiceReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -212,7 +212,7 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
 
-	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
+	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), enforcementConfig.MetricsScrapingServiceIdentities)
 	metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorEndpointsReconciler := metrics_collection_traffic.NewEndpointsReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorServiceReconciler := metrics_collection_traffic.NewServiceReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -51,7 +51,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/k8sconf"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -213,13 +212,13 @@ func main() {
 
 	kafkaServersStore := kafkaacls.NewServersStore(tlsSource, enforcementConfig.EnableKafkaACL, kafkaacls.NewKafkaIntentsAdmin, enforcementConfig.EnforcementDefaultState)
 
-	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), allowexternaltraffic.Off)
+	metricsCollectorNetpolHandler := metrics_collection_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
 	metricsCollectorPodReconciler := metrics_collection_traffic.NewPodReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorEndpointsReconciler := metrics_collection_traffic.NewEndpointsReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorServiceReconciler := metrics_collection_traffic.NewServiceReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 	metricsCollectorNetworkPolicyReconciler := metrics_collection_traffic.NewNetworkPolicyReconciler(mgr.GetClient(), metricsCollectorNetpolHandler)
 
-	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetActualExternalTrafficPolicy(), operatorconfig.GetIngressControllerServiceIdentities(), viper.GetBool(operatorconfig.IngressControllerALBExemptKey))
+	extNetpolHandler := external_traffic.NewNetworkPolicyHandler(mgr.GetClient(), mgr.GetScheme(), enforcementConfig.GetAutomateThirdPartyNetworkPolicy(), operatorconfig.GetIngressControllerServiceIdentities(), viper.GetBool(operatorconfig.IngressControllerALBExemptKey))
 	endpointReconciler := external_traffic.NewEndpointsReconciler(mgr.GetClient(), extNetpolHandler)
 	ingressRulesBuilder := builders.NewIngressNetpolBuilder()
 

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -71,6 +71,16 @@ func getAutomateThirdPartyNetworkPoliciesConfig() graphqlclient.AutomateThirdPar
 	}
 }
 
+func getMetricsScrapingServiceIdentities() []graphqlclient.MetricsScrapingServerConfigInput {
+	return lo.Map(enforcement.GetConfig().MetricsScrapingServiceIdentities, func(item serviceidentity.ServiceIdentity, _ int) graphqlclient.MetricsScrapingServerConfigInput {
+		return graphqlclient.MetricsScrapingServerConfigInput{
+			Name:      item.Name,
+			Namespace: item.Namespace,
+			Kind:      item.Kind,
+		}
+	})
+}
+
 func getAllowExternalTrafficConfig() graphqlclient.AllowExternalTrafficPolicy {
 	switch enforcement.GetConfig().AutomateThirdPartyNetworkPolicies {
 	case automate_third_party_network_policy.Always:
@@ -130,6 +140,7 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 		EnforcedNamespaces:                    enforcementConfig.EnforcedNamespaces.Items(),
 		AllowExternalTrafficPolicy:            getAllowExternalTrafficConfig(), // The server expect for AllowExternalTrafficPolicy because of backwards compatibility
 		AutomateThirdPartyNetworkPolicies:     getAutomateThirdPartyNetworkPoliciesConfig(),
+		MetricsScrapingServerConfig:           getMetricsScrapingServiceIdentities(),
 	}
 
 	configInput.IngressControllerConfig = lo.Map(ingressConfigIdentities, func(identity serviceidentity.ServiceIdentity, _ int) graphqlclient.IngressControllerConfigInput {

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -71,9 +71,9 @@ func getAutomateThirdPartyNetworkPoliciesConfig() graphqlclient.AutomateThirdPar
 	}
 }
 
-func getMetricsScrapingServiceIdentities() []graphqlclient.MetricsScrapingServerConfigInput {
-	return lo.Map(enforcement.GetConfig().MetricsScrapingServiceIdentities, func(item serviceidentity.ServiceIdentity, _ int) graphqlclient.MetricsScrapingServerConfigInput {
-		return graphqlclient.MetricsScrapingServerConfigInput{
+func getPrometheusServiceIdentities() []graphqlclient.PrometheusServerConfigInput {
+	return lo.Map(enforcement.GetConfig().PrometheusServiceIdentities, func(item serviceidentity.ServiceIdentity, _ int) graphqlclient.PrometheusServerConfigInput {
+		return graphqlclient.PrometheusServerConfigInput{
 			Name:      item.Name,
 			Namespace: item.Namespace,
 			Kind:      item.Kind,
@@ -140,7 +140,7 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 		EnforcedNamespaces:                    enforcementConfig.EnforcedNamespaces.Items(),
 		AllowExternalTrafficPolicy:            getAllowExternalTrafficConfig(), // The server expect for AllowExternalTrafficPolicy because of backwards compatibility
 		AutomateThirdPartyNetworkPolicies:     getAutomateThirdPartyNetworkPoliciesConfig(),
-		MetricsScrapingServerConfig:           getMetricsScrapingServiceIdentities(),
+		PrometheusServerConfigs:               getPrometheusServiceIdentities(),
 	}
 
 	configInput.IngressControllerConfig = lo.Map(ingressConfigIdentities, func(identity serviceidentity.ServiceIdentity, _ int) graphqlclient.IngressControllerConfigInput {

--- a/src/shared/operatorconfig/automate_third_party_network_policy/automate_third_party_network_policy_enum.go
+++ b/src/shared/operatorconfig/automate_third_party_network_policy/automate_third_party_network_policy_enum.go
@@ -1,4 +1,4 @@
-package allowexternaltraffic
+package automate_third_party_network_policy
 
 import (
 	"github.com/otterize/intents-operator/src/shared/errors"
@@ -28,11 +28,11 @@ func (e *Enum) Set(value string) error {
 		return nil
 	}
 
-	return errors.Errorf("invalid value %s for allowExternalTraffic", value)
+	return errors.Errorf("invalid value %s for automateThirdPartyNetworkPolicy", value)
 }
 
 func (e *Enum) Type() string {
-	return "allowExternalTraffic.Enum"
+	return "automateThirdPartyNetworkPolicy.Enum"
 }
 
 func (e *Enum) String() string {

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	EnableLinkerdPolicies                bool
 	EnforcedNamespaces                   *goset.Set[string]
 	AutomateThirdPartyNetworkPolicies    automate_third_party_network_policy.Enum
-	MetricsScrapingServiceIdentities     []serviceidentity.ServiceIdentity
+	PrometheusServiceIdentities          []serviceidentity.ServiceIdentity
 }
 
 func (c Config) GetAutomateThirdPartyNetworkPolicy() automate_third_party_network_policy.Enum {
@@ -68,7 +68,7 @@ const (
 	EnableGCPPolicyDefault                      = false
 	EnableAzurePolicyKey                        = "enable-azure-iam-policy"
 	EnableAzurePolicyDefault                    = false
-	MetricsCollectionServiceConfigKey           = "metricsScrapingService"
+	PrometheusServiceConfigKey                  = "prometheusServerConfigs"
 )
 
 func init() {
@@ -113,7 +113,7 @@ func GetConfig() Config {
 		EnableAzurePolicy:                    viper.GetBool(EnableAzurePolicyKey),
 		EnforcedNamespaces:                   goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
 		AutomateThirdPartyNetworkPolicies:    automate_third_party_network_policy.Enum(viper.GetString(AutomateThirdPartyNetworkPoliciesKey)),
-		MetricsScrapingServiceIdentities:     GetMetricsScrapingServiceIdentities(),
+		PrometheusServiceIdentities:          GetPrometheusServiceIdentities(),
 	}
 }
 
@@ -123,11 +123,11 @@ type ServiceIdentityConfig struct {
 	Kind      string
 }
 
-func GetMetricsScrapingServiceIdentities() []serviceidentity.ServiceIdentity {
+func GetPrometheusServiceIdentities() []serviceidentity.ServiceIdentity {
 	controllers := make([]ServiceIdentityConfig, 0)
-	err := viper.UnmarshalKey(MetricsCollectionServiceConfigKey, &controllers)
+	err := viper.UnmarshalKey(PrometheusServiceConfigKey, &controllers)
 	if err != nil {
-		logrus.WithError(err).Panic("Failed to unmarshal metrics scraping server config")
+		logrus.WithError(err).Panic("Failed to unmarshal Prometheus server config")
 	}
 
 	return lo.Map(controllers, func(controller ServiceIdentityConfig, _ int) serviceidentity.ServiceIdentity {

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -95,8 +95,6 @@ func InitCLIFlags() {
 	pflag.Bool(EnableDatabasePolicy, EnableDatabasePolicyDefault, "Enable the database reconciler")
 	pflag.Bool(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault, "Experimental - enable the generation of egress network policies alongside ingress network policies")
 	pflag.Bool(EnableAWSPolicyKey, EnableAWSPolicyDefault, "Enable the AWS IAM reconciler")
-	automateThirdPartyNetworkPoliciesKeyDefault := AutomateThirdPartyNetworkPoliciesDefault
-	pflag.String(automateThirdPartyNetworkPoliciesKeyDefault, AutomateThirdPartyNetworkPoliciesKey, "Whether to automatically create network policies for third parties traffic, like external traffic and metrics collection traffic")
 }
 
 func GetConfig() Config {

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -2,7 +2,7 @@ package enforcement
 
 import (
 	"github.com/amit7itz/goset"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/allowexternaltraffic"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -19,31 +19,31 @@ type Config struct {
 	EnableAzurePolicy                    bool
 	EnableLinkerdPolicies                bool
 	EnforcedNamespaces                   *goset.Set[string]
-	AllowExternalTraffic                 allowexternaltraffic.Enum
+	AutomateThirdPartyNetworkPolicies    automate_third_party_network_policy.Enum
 }
 
-func (c Config) GetActualExternalTrafficPolicy() allowexternaltraffic.Enum {
+func (c Config) GetAutomateThirdPartyNetworkPolicy() automate_third_party_network_policy.Enum {
 	// rewrite the above code to use a switch statement
-	switch c.AllowExternalTraffic {
-	case allowexternaltraffic.Off:
-		return allowexternaltraffic.Off
-	case allowexternaltraffic.Always:
+	switch c.AutomateThirdPartyNetworkPolicies {
+	case automate_third_party_network_policy.Off:
+		return automate_third_party_network_policy.Off
+	case automate_third_party_network_policy.Always:
 		if !c.EnforcementDefaultState {
-			// We don't want to create network policies for external traffic when enforcement is disabled.
-			// However, if one uses shadow mode we can still block external traffic to his protected services
-			// therefore we should return allowexternaltraffic.IfBlockedByOtterize
-			return allowexternaltraffic.IfBlockedByOtterize
+			// We don't want to create network policies for third parties when enforcement is disabled.
+			// However, if one uses shadow mode we can still block third party traffic to his protected services
+			// therefore we should return automate_third_party_network_policy.IfBlockedByOtterize
+			return automate_third_party_network_policy.IfBlockedByOtterize
 		}
-		return allowexternaltraffic.Always
+		return automate_third_party_network_policy.Always
 	default:
-		return allowexternaltraffic.IfBlockedByOtterize
+		return automate_third_party_network_policy.IfBlockedByOtterize
 	}
 }
 
 const (
-	ActiveEnforcementNamespacesKey              = "active-enforcement-namespaces" // When using the "shadow enforcement" mode, namespaces in this list will be treated as if the enforcement were active
-	AllowExternalTrafficKey                     = "allow-external-traffic"        // Whether to automatically create network policies for external traffic
-	AllowExternalTrafficDefault                 = string(allowexternaltraffic.IfBlockedByOtterize)
+	ActiveEnforcementNamespacesKey              = "active-enforcement-namespaces"         // When using the "shadow enforcement" mode, namespaces in this list will be treated as if the enforcement were active
+	AutomateThirdPartyNetworkPoliciesKey        = "automate-third-party-network-policies" // Whether to automatically create network policies for external traffic & metrics collection traffic
+	AutomateThirdPartyNetworkPoliciesDefault    = string(automate_third_party_network_policy.IfBlockedByOtterize)
 	EnforcementDefaultStateKey                  = "enforcement-default-state" // Sets the default state of the  If true, always enforces. If false, can be overridden using ProtectedService.
 	EnforcementDefaultStateDefault              = true
 	EnableNetworkPolicyKey                      = "enable-network-policy-creation" // Whether to enable Intents network policy creation
@@ -77,7 +77,7 @@ func init() {
 	viper.SetDefault(EnableAWSPolicyKey, EnableAWSPolicyDefault)
 	viper.SetDefault(EnableGCPPolicyKey, EnableGCPPolicyDefault)
 	viper.SetDefault(EnableAzurePolicyKey, EnableAzurePolicyDefault)
-	viper.SetDefault(AllowExternalTrafficKey, AllowExternalTrafficDefault)
+	viper.SetDefault(AutomateThirdPartyNetworkPoliciesKey, AutomateThirdPartyNetworkPoliciesDefault)
 }
 
 func InitCLIFlags() {
@@ -90,8 +90,8 @@ func InitCLIFlags() {
 	pflag.Bool(EnableDatabasePolicy, EnableDatabasePolicyDefault, "Enable the database reconciler")
 	pflag.Bool(EnableEgressNetworkPolicyReconcilersKey, EnableEgressNetworkPolicyReconcilersDefault, "Experimental - enable the generation of egress network policies alongside ingress network policies")
 	pflag.Bool(EnableAWSPolicyKey, EnableAWSPolicyDefault, "Enable the AWS IAM reconciler")
-	allowExternalTrafficDefault := AllowExternalTrafficDefault
-	pflag.String(allowExternalTrafficDefault, AllowExternalTrafficKey, "Whether to automatically create network policies for external traffic")
+	automateThirdPartyNetworkPoliciesKeyDefault := AutomateThirdPartyNetworkPoliciesDefault
+	pflag.String(automateThirdPartyNetworkPoliciesKeyDefault, AutomateThirdPartyNetworkPoliciesKey, "Whether to automatically create network policies for third parties traffic, like external traffic and metrics collection traffic")
 }
 
 func GetConfig() Config {
@@ -107,6 +107,6 @@ func GetConfig() Config {
 		EnableGCPPolicy:                      viper.GetBool(EnableGCPPolicyKey),
 		EnableAzurePolicy:                    viper.GetBool(EnableAzurePolicyKey),
 		EnforcedNamespaces:                   goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
-		AllowExternalTraffic:                 allowexternaltraffic.Enum(viper.GetString(AllowExternalTrafficKey)),
+		AutomateThirdPartyNetworkPolicies:    automate_third_party_network_policy.Enum(viper.GetString(AutomateThirdPartyNetworkPoliciesKey)),
 	}
 }

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -426,6 +426,7 @@ type IntentsOperatorConfigurationInput struct {
 	AllowExternalTrafficPolicy            AllowExternalTrafficPolicy             `json:"allowExternalTrafficPolicy"`
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
+	MetricsScrapingServerConfig           []MetricsScrapingServerConfigInput     `json:"metricsScrapingServerConfig"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -511,6 +512,11 @@ func (v *IntentsOperatorConfigurationInput) GetExternallyManagedPolicyWorkloads(
 // GetAutomateThirdPartyNetworkPolicies returns IntentsOperatorConfigurationInput.AutomateThirdPartyNetworkPolicies, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies() AutomateThirdPartyNetworkPolicy {
 	return v.AutomateThirdPartyNetworkPolicies
+}
+
+// GetMetricsScrapingServerConfig returns IntentsOperatorConfigurationInput.MetricsScrapingServerConfig, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetMetricsScrapingServerConfig() []MetricsScrapingServerConfigInput {
+	return v.MetricsScrapingServerConfig
 }
 
 type InternetConfigInput struct {
@@ -653,6 +659,21 @@ const (
 	KubernetesServiceTypeClusterIp    KubernetesServiceType = "CLUSTER_IP"
 	KubernetesServiceTypeExternalName KubernetesServiceType = "EXTERNAL_NAME"
 )
+
+type MetricsScrapingServerConfigInput struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+}
+
+// GetName returns MetricsScrapingServerConfigInput.Name, and is useful for accessing the field via an interface.
+func (v *MetricsScrapingServerConfigInput) GetName() string { return v.Name }
+
+// GetNamespace returns MetricsScrapingServerConfigInput.Namespace, and is useful for accessing the field via an interface.
+func (v *MetricsScrapingServerConfigInput) GetNamespace() string { return v.Namespace }
+
+// GetKind returns MetricsScrapingServerConfigInput.Kind, and is useful for accessing the field via an interface.
+func (v *MetricsScrapingServerConfigInput) GetKind() string { return v.Kind }
 
 type NetworkPolicyEgressRuleInput struct {
 	To []PeerInput `json:"to"`

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -9,12 +9,21 @@ import (
 	"github.com/Khan/genqlient/graphql"
 )
 
+// This enum should be removed after removing allowExternalTrafficPolicy from IntentsOperatorConfigurationInput, it is here for backward compatibility
 type AllowExternalTrafficPolicy string
 
 const (
 	AllowExternalTrafficPolicyOff                 AllowExternalTrafficPolicy = "OFF"
 	AllowExternalTrafficPolicyAlways              AllowExternalTrafficPolicy = "ALWAYS"
 	AllowExternalTrafficPolicyIfBlockedByOtterize AllowExternalTrafficPolicy = "IF_BLOCKED_BY_OTTERIZE"
+)
+
+type AutomateThirdPartyNetworkPolicy string
+
+const (
+	AutomateThirdPartyNetworkPolicyOff                 AutomateThirdPartyNetworkPolicy = "OFF"
+	AutomateThirdPartyNetworkPolicyAlways              AutomateThirdPartyNetworkPolicy = "ALWAYS"
+	AutomateThirdPartyNetworkPolicyIfBlockedByOtterize AutomateThirdPartyNetworkPolicy = "IF_BLOCKED_BY_OTTERIZE"
 )
 
 type AzureKeyVaultPolicyInput struct {
@@ -416,6 +425,7 @@ type IntentsOperatorConfigurationInput struct {
 	AwsALBLoadBalancerExemptionEnabled    bool                                   `json:"awsALBLoadBalancerExemptionEnabled"`
 	AllowExternalTrafficPolicy            AllowExternalTrafficPolicy             `json:"allowExternalTrafficPolicy"`
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
+	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -496,6 +506,11 @@ func (v *IntentsOperatorConfigurationInput) GetAllowExternalTrafficPolicy() Allo
 // GetExternallyManagedPolicyWorkloads returns IntentsOperatorConfigurationInput.ExternallyManagedPolicyWorkloads, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetExternallyManagedPolicyWorkloads() []ExternallyManagedPolicyWorkloadInput {
 	return v.ExternallyManagedPolicyWorkloads
+}
+
+// GetAutomateThirdPartyNetworkPolicies returns IntentsOperatorConfigurationInput.AutomateThirdPartyNetworkPolicies, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies() AutomateThirdPartyNetworkPolicy {
+	return v.AutomateThirdPartyNetworkPolicies
 }
 
 type InternetConfigInput struct {

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -426,7 +426,7 @@ type IntentsOperatorConfigurationInput struct {
 	AllowExternalTrafficPolicy            AllowExternalTrafficPolicy             `json:"allowExternalTrafficPolicy"`
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
-	MetricsScrapingServerConfig           []MetricsScrapingServerConfigInput     `json:"metricsScrapingServerConfig"`
+	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -514,9 +514,9 @@ func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies
 	return v.AutomateThirdPartyNetworkPolicies
 }
 
-// GetMetricsScrapingServerConfig returns IntentsOperatorConfigurationInput.MetricsScrapingServerConfig, and is useful for accessing the field via an interface.
-func (v *IntentsOperatorConfigurationInput) GetMetricsScrapingServerConfig() []MetricsScrapingServerConfigInput {
-	return v.MetricsScrapingServerConfig
+// GetPrometheusServerConfigs returns IntentsOperatorConfigurationInput.PrometheusServerConfigs, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []PrometheusServerConfigInput {
+	return v.PrometheusServerConfigs
 }
 
 type InternetConfigInput struct {
@@ -660,21 +660,6 @@ const (
 	KubernetesServiceTypeExternalName KubernetesServiceType = "EXTERNAL_NAME"
 )
 
-type MetricsScrapingServerConfigInput struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Kind      string `json:"kind"`
-}
-
-// GetName returns MetricsScrapingServerConfigInput.Name, and is useful for accessing the field via an interface.
-func (v *MetricsScrapingServerConfigInput) GetName() string { return v.Name }
-
-// GetNamespace returns MetricsScrapingServerConfigInput.Namespace, and is useful for accessing the field via an interface.
-func (v *MetricsScrapingServerConfigInput) GetNamespace() string { return v.Namespace }
-
-// GetKind returns MetricsScrapingServerConfigInput.Kind, and is useful for accessing the field via an interface.
-func (v *MetricsScrapingServerConfigInput) GetKind() string { return v.Kind }
-
 type NetworkPolicyEgressRuleInput struct {
 	To []PeerInput `json:"to"`
 }
@@ -720,6 +705,21 @@ type PeerInput struct {
 
 // GetIpBlock returns PeerInput.IpBlock, and is useful for accessing the field via an interface.
 func (v *PeerInput) GetIpBlock() IpBlockInput { return v.IpBlock }
+
+type PrometheusServerConfigInput struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+}
+
+// GetName returns PrometheusServerConfigInput.Name, and is useful for accessing the field via an interface.
+func (v *PrometheusServerConfigInput) GetName() string { return v.Name }
+
+// GetNamespace returns PrometheusServerConfigInput.Namespace, and is useful for accessing the field via an interface.
+func (v *PrometheusServerConfigInput) GetNamespace() string { return v.Namespace }
+
+// GetKind returns PrometheusServerConfigInput.Kind, and is useful for accessing the field via an interface.
+func (v *PrometheusServerConfigInput) GetKind() string { return v.Kind }
 
 type ProtectedServiceInput struct {
 	Name string `json:"name"`

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1483,7 +1483,7 @@ input IntentsOperatorConfigurationInput {
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
-	metricsScrapingServerConfig: [MetricsScrapingServerConfigInput!]
+	prometheusServerConfigs: [PrometheusServerConfigInput!]
 }
 
 type IntentsOperatorState {
@@ -1798,12 +1798,6 @@ type MergedYAMLFile {
 input MetadataEntry {
 	key: String!
 	value: String!
-}
-
-input MetricsScrapingServerConfigInput {
-	name: String!
-	namespace: String!
-	kind: String!
 }
 
 type Mutation {
@@ -2255,6 +2249,12 @@ input PortStatusInput {
 	port: Int!
 	protocol: K8sPortProtocol!
 	error: String
+}
+
+input PrometheusServerConfigInput {
+	name: String!
+	namespace: String!
+	kind: String!
 }
 
 input ProtectedServiceInput {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1483,6 +1483,7 @@ input IntentsOperatorConfigurationInput {
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
+	metricsScrapingServerConfig: [MetricsScrapingServerConfigInput!]
 }
 
 type IntentsOperatorState {
@@ -1797,6 +1798,12 @@ type MergedYAMLFile {
 input MetadataEntry {
 	key: String!
 	value: String!
+}
+
+input MetricsScrapingServerConfigInput {
+	name: String!
+	namespace: String!
+	kind: String!
 }
 
 type Mutation {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -215,6 +215,7 @@ type AccessLogEdge {
 	accessStatus: EdgeAccessStatus!
 }
 
+""" This enum should be removed after removing allowExternalTrafficPolicy from IntentsOperatorConfigurationInput, it is here for backward compatibility """
 enum AllowExternalTrafficPolicy {
 	OFF
 	ALWAYS
@@ -272,6 +273,12 @@ type AppliedIntentsRequestWithDetails {
 	status: AppliedIntentsRequestStatusLabel!
 	reason: String
 	clientIntents: ClientIntentsFileRepresentation!
+}
+
+enum AutomateThirdPartyNetworkPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
 }
 
 enum AwsIamStep {
@@ -722,6 +729,8 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_DEFAULT_DENY_MISSING_EXTERNAL_TRAFFIC_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_MISSING_EXTERNAL_TRAFFIC_POLICY
 	ALLOWED_BY_EXTERNALLY_MANAGED_NETWORK_POLICY
+	ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
+	WOULD_BE_ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
 }
 
 enum EdgeAccessStatusVerdict {
@@ -741,6 +750,11 @@ type EdgeAccessStatuses {
 	azureIAM: EdgeAccessStatus!
 	database: EdgeAccessStatus!
 	linkerdPolicies: EdgeAccessStatus!
+}
+
+enum EligibleForMetricsCollectionReason {
+	POD_ANNOTATIONS
+	SERVICE_ANNOTATIONS
 }
 
 type Environment {
@@ -1468,6 +1482,7 @@ input IntentsOperatorConfigurationInput {
 	awsALBLoadBalancerExemptionEnabled: Boolean
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
+	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 }
 
 type IntentsOperatorState {
@@ -1565,6 +1580,12 @@ enum K8sPortProtocol {
 	TCP
 	UDP
 	SCTP
+}
+
+input K8sResourceEligibleForMetricsCollectionInput {
+	namespace: String!
+	name: String!
+	kind: String!
 }
 
 input K8sResourceIngressInput {
@@ -2030,6 +2051,11 @@ type Mutation {
 	reportK8sIngresses(
 		namespace: String!
 		ingresses: [K8sIngressInput!]!
+	): Boolean!
+	reportK8sResourceEligibleForMetricsCollection(
+		namespace: String!
+		reason: EligibleForMetricsCollectionReason!
+		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!

--- a/src/shared/telemetries/telemetriesgql/generated.go
+++ b/src/shared/telemetries/telemetriesgql/generated.go
@@ -114,6 +114,7 @@ const (
 	EventTypeActive                      EventType = "ACTIVE"
 	EventTypeEbpfAttached                EventType = "EBPF_ATTACHED"
 	EventTypeEbpfAttachFailed            EventType = "EBPF_ATTACH_FAILED"
+	EventTypeEbpfProcessingError         EventType = "EBPF_PROCESSING_ERROR"
 )
 
 type MetadataEntry struct {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -156,6 +156,12 @@ enum AccessApprovalRulesetFilterValue {
 	ANY
 }
 
+type AccessApprovalRulesetResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+}
+
 type AccessApprovalRulesetSummary {
 	environment: Environment!
 	count: Int!
@@ -209,6 +215,7 @@ type AccessLogEdge {
 	accessStatus: EdgeAccessStatus!
 }
 
+""" This enum should be removed after removing allowExternalTrafficPolicy from IntentsOperatorConfigurationInput, it is here for backward compatibility """
 enum AllowExternalTrafficPolicy {
 	OFF
 	ALWAYS
@@ -242,6 +249,8 @@ input AppliedIntentsRequestApprovalData {
 
 type AppliedIntentsRequestStatus {
 	id: ID!
+	resourceId: String!
+	generation: Int!
 """client"""
 	service: Service!
 	timestamp: Time!
@@ -253,6 +262,7 @@ enum AppliedIntentsRequestStatusLabel {
 	PENDING
 	APPROVED
 	DENIED
+	STALE
 }
 
 type AppliedIntentsRequestWithDetails {
@@ -263,6 +273,12 @@ type AppliedIntentsRequestWithDetails {
 	status: AppliedIntentsRequestStatusLabel!
 	reason: String
 	clientIntents: ClientIntentsFileRepresentation!
+}
+
+enum AutomateThirdPartyNetworkPolicy {
+	OFF
+	ALWAYS
+	IF_BLOCKED_BY_OTTERIZE
 }
 
 enum AwsIamStep {
@@ -713,6 +729,8 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_DEFAULT_DENY_MISSING_EXTERNAL_TRAFFIC_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_MISSING_EXTERNAL_TRAFFIC_POLICY
 	ALLOWED_BY_EXTERNALLY_MANAGED_NETWORK_POLICY
+	ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
+	WOULD_BE_ALLOWED_BY_METRICS_COLLECTION_TRAFFIC_NETWORK_POLICY
 }
 
 enum EdgeAccessStatusVerdict {
@@ -732,6 +750,11 @@ type EdgeAccessStatuses {
 	azureIAM: EdgeAccessStatus!
 	database: EdgeAccessStatus!
 	linkerdPolicies: EdgeAccessStatus!
+}
+
+enum EligibleForMetricsCollectionReason {
+	POD_ANNOTATIONS
+	SERVICE_ANNOTATIONS
 }
 
 type Environment {
@@ -782,6 +805,7 @@ enum EventType {
 	ACTIVE
 	EBPF_ATTACHED
 	EBPF_ATTACH_FAILED
+	EBPF_PROCESSING_ERROR
 }
 
 input ExternalTrafficDiscoveredIntentInput {
@@ -817,6 +841,7 @@ type FeatureFlags {
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
+	enableIAMIntentsSuggestions: Boolean
 }
 
 type Finding {
@@ -1055,7 +1080,7 @@ input IngressControllerConfigInput {
 """Ruleset"""
 input InputAccessApprovalRuleset {
 """Ruleset"""
-	id: ID
+	id: ID!
 """Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
@@ -1146,6 +1171,7 @@ input InputFeatureFlags {
 	enableFindingsV2: Boolean
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
+	enableIAMIntentsSuggestions: Boolean
 }
 
 """ Findings filter """
@@ -1207,6 +1233,25 @@ input InputServiceFilter {
 	environmentIds: [ID!]
 """ Service filter """
 	integrationIds: [ID!]
+}
+
+input InputTerraformAwsPolicyInfo {
+	arn: String!
+	address: String!
+}
+
+input InputTerraformAwsRoleInfo {
+	arn: String!
+	address: String!
+	inlinePolicy: String!
+	attachedPolicies: [InputTerraformAwsPolicyInfo!]
+}
+
+input InputTerraformResourceInfo {
+	modulePath: String!
+	gitOriginUrl: String!
+	gitCommitHash: String!
+	awsRoles: [InputTerraformAwsRoleInfo!]
 }
 
 input InputTimeFilterValue {
@@ -1365,8 +1410,13 @@ input IntentInput {
 }
 
 input IntentRequestInput {
-	requestId: ID!
+	resourceGeneration: IntentRequestResourceGeneration!
 	intent: IntentInput!
+}
+
+input IntentRequestResourceGeneration {
+	resourceId: String!
+	generation: Int!
 }
 
 type IntentStatus {
@@ -1430,6 +1480,7 @@ input IntentsOperatorConfigurationInput {
 	awsALBLoadBalancerExemptionEnabled: Boolean
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
+	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 }
 
 type IntentsOperatorState {
@@ -1527,6 +1578,12 @@ enum K8sPortProtocol {
 	TCP
 	UDP
 	SCTP
+}
+
+input K8sResourceEligibleForMetricsCollectionInput {
+	namespace: String!
+	name: String!
+	kind: String!
 }
 
 input K8sResourceIngressInput {
@@ -1751,8 +1808,11 @@ type Mutation {
 		id: ID!
 		result: AppliedIntentsRequestApprovalData!
 	): Boolean!
+	syncPendingRequestStatuses(
+		intentResourceGeneration: [IntentRequestResourceGeneration!]!
+	): [AppliedIntentsRequestStatus!]!
 """rulesets"""
-	createOrUpdateAccessApprovalRulesets(
+	saveAccessApprovalRulesets(
 		environmentId: ID!
 		rules: [InputAccessApprovalRuleset!]!
 	): Boolean!
@@ -1990,6 +2050,11 @@ type Mutation {
 		namespace: String!
 		ingresses: [K8sIngressInput!]!
 	): Boolean!
+	reportK8sResourceEligibleForMetricsCollection(
+		namespace: String!
+		reason: EligibleForMetricsCollectionReason!
+		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
@@ -2045,6 +2110,10 @@ type Mutation {
 	sendCLITelemetries(
 		telemetries: [CLITelemetry!]!
 	): Boolean!
+"""report terraform resources from Otterize CLI"""
+	reportTerraformResources(
+		resourceInfo: InputTerraformResourceInfo!
+	): TerraformResourceInfo!
 """Update service"""
 	reportTrafficLevels(
 		trafficLevels: [TrafficLevelInput!]!
@@ -2233,7 +2302,7 @@ type Query {
 	accessApprovalRulesetSummary: [AccessApprovalRulesetSummary!]!
 	accessApprovalRulesetList(
 		filter: InputAccessApprovalRulesetFilter
-	): [AccessApprovalRuleset!]!
+	): RulesetsWithResources!
 """Get cluster"""
 	cluster(
 		id: ID!
@@ -2383,6 +2452,12 @@ type Query {
 	serviceByIdentity(
 		identity: ServiceIdentityInput!
 	): Service!
+"""get terraform resource by git identity"""
+	terraformResourceByIdentity(
+		modulePath: String!
+		gitOriginUrl: String!
+		gitCommitHash: String!
+	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
 """Get user"""
@@ -2448,6 +2523,11 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+}
+
+type RulesetsWithResources {
+	rulesets: [AccessApprovalRuleset!]!
+	resources: AccessApprovalRulesetResources!
 }
 
 input SelectorKeyValueInput {
@@ -2716,6 +2796,25 @@ input TelemetryData {
 input TelemetryInput {
 	component: Component!
 	data: TelemetryData!
+}
+
+type TerraformAwsPolicyInfo {
+	arn: String!
+	address: String!
+}
+
+type TerraformAwsRoleInfo {
+	arn: String!
+	address: String!
+	inlinePolicy: String!
+	attachedPolicies: [TerraformAwsPolicyInfo!]
+}
+
+type TerraformResourceInfo {
+	modulePath: String!
+	gitOriginUrl: String!
+	gitCommitHash: String!
+	awsRoles: [TerraformAwsRoleInfo!]
 }
 
 type TestDatabaseConnectionResponse {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -1388,9 +1388,11 @@ input IntentInput {
 	clientName: String!
 	clientResolutionData: String
 	clientWorkloadKind: String
+	clientNameResolvedUsingAnnotation: Boolean
 	serverName: String!
 	serverResolutionData: String
 	serverWorkloadKind: String
+	serverNameResolvedUsingAnnotation: Boolean
 	serverAlias: ServerAliasInput
 	serverNamespace: String
 	type: IntentType
@@ -1481,7 +1483,7 @@ input IntentsOperatorConfigurationInput {
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
-	metricsScrapingServerConfig: [MetricsScrapingServerConfigInput!]
+	prometheusServerConfigs: [PrometheusServerConfigInput!]
 }
 
 type IntentsOperatorState {
@@ -1796,12 +1798,6 @@ type MergedYAMLFile {
 input MetadataEntry {
 	key: String!
 	value: String!
-}
-
-input MetricsScrapingServerConfigInput {
-	name: String!
-	namespace: String!
-	kind: String!
 }
 
 type Mutation {
@@ -2253,6 +2249,12 @@ input PortStatusInput {
 	port: Int!
 	protocol: K8sPortProtocol!
 	error: String
+}
+
+input PrometheusServerConfigInput {
+	name: String!
+	namespace: String!
+	kind: String!
 }
 
 input ProtectedServiceInput {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -1481,6 +1481,7 @@ input IntentsOperatorConfigurationInput {
 	allowExternalTrafficPolicy: AllowExternalTrafficPolicy
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
+	metricsScrapingServerConfig: [MetricsScrapingServerConfigInput!]
 }
 
 type IntentsOperatorState {
@@ -1795,6 +1796,12 @@ type MergedYAMLFile {
 input MetadataEntry {
 	key: String!
 	value: String!
+}
+
+input MetricsScrapingServerConfigInput {
+	name: String!
+	namespace: String!
+	kind: String!
 }
 
 type Mutation {


### PR DESCRIPTION
### Description
By setting intentsOperator.operator.automateThirdPartyNetworkPolicies and intentsOperator.operator.metricsScrapingServiceConfigs - Otterize can now automatically enable traffic from Prometheus server to any other workload marked with `prometheus.io/scrape` annotation.

You no longer have to create client-intents from the scraping server to your workloads.

### References
- [Network mapper support](https://github.com/otterize/network-mapper/pull/278)
- [Helm chart support](https://github.com/otterize/helm-charts/pull/295)
- [Documentations](https://github.com/otterize/docs/pull/292)

### Testing
Unit tests & e2e test were added

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
