### PR TITLE
Fix bug where reporting applied intents to the cloud could fail when using istio, due to a missing MissingSidecarAnnotation annotation

### DIFF
--- a/src/operator/api/v1alpha2/intents_types.go
+++ b/src/operator/api/v1alpha2/intents_types.go
@@ -368,15 +368,16 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation missing sidecar for client intents %s", clientIntents.Name)
-	}
-
-	clientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+	clientMissingSidecar := false
+	if ok {
+		parsedClientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+		}
+		clientMissingSidecar = parsedClientMissingSidecar
 	}
 	status.IstioStatus.IsClientMissingSidecar = lo.ToPtr(clientMissingSidecar)
+
 	isServerMissingSidecar, err := clientIntents.IsServerMissingSidecar(intent)
 	if err != nil {
 		return nil, false, errors.Wrap(err)

--- a/src/operator/api/v1alpha3/clientintents_types.go
+++ b/src/operator/api/v1alpha3/clientintents_types.go
@@ -583,15 +583,16 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation missing sidecar for client intents %s", clientIntents.Name)
-	}
-
-	clientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+	clientMissingSidecar := false
+	if ok {
+		parsedClientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+		}
+		clientMissingSidecar = parsedClientMissingSidecar
 	}
 	status.IstioStatus.IsClientMissingSidecar = lo.ToPtr(clientMissingSidecar)
+
 	isServerMissingSidecar, err := clientIntents.IsServerMissingSidecar(intent)
 	if err != nil {
 		return nil, false, errors.Wrap(err)

--- a/src/operator/api/v1beta1/clientintents_types.go
+++ b/src/operator/api/v1beta1/clientintents_types.go
@@ -585,15 +585,16 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Intent
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation missing sidecar for client intents %s", clientIntents.Name)
-	}
-
-	clientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+	clientMissingSidecar := false
+	if ok {
+		parsedClientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+		}
+		clientMissingSidecar = parsedClientMissingSidecar
 	}
 	status.IstioStatus.IsClientMissingSidecar = lo.ToPtr(clientMissingSidecar)
+
 	isServerMissingSidecar, err := clientIntents.IsServerMissingSidecar(intent)
 	if err != nil {
 		return nil, false, errors.Wrap(err)

--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -702,15 +702,16 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Target
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation missing sidecar for client intents %s", clientIntents.Name)
-	}
-
-	clientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+	clientMissingSidecar := false
+	if ok {
+		parsedClientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+		}
+		clientMissingSidecar = parsedClientMissingSidecar
 	}
 	status.IstioStatus.IsClientMissingSidecar = lo.ToPtr(clientMissingSidecar)
+
 	isServerMissingSidecar, err := clientIntents.IsServerMissingSidecar(intent)
 	if err != nil {
 		return nil, false, errors.Wrap(err)

--- a/src/operator/api/v2beta1/clientintents_types.go
+++ b/src/operator/api/v2beta1/clientintents_types.go
@@ -699,15 +699,16 @@ func clientIntentsStatusToCloudFormat(clientIntents ClientIntents, intent Target
 	status.IstioStatus.IsServiceAccountShared = lo.ToPtr(isShared)
 
 	clientMissingSidecarValue, ok := clientIntents.Annotations[OtterizeMissingSidecarAnnotation]
-	if !ok {
-		return nil, false, errors.Errorf("missing annotation missing sidecar for client intents %s", clientIntents.Name)
-	}
-
-	clientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
-	if err != nil {
-		return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+	clientMissingSidecar := false
+	if ok {
+		parsedClientMissingSidecar, err := strconv.ParseBool(clientMissingSidecarValue)
+		if err != nil {
+			return nil, false, errors.Errorf("failed to parse missing sidecar annotation for client intents %s", clientIntents.Name)
+		}
+		clientMissingSidecar = parsedClientMissingSidecar
 	}
 	status.IstioStatus.IsClientMissingSidecar = lo.ToPtr(clientMissingSidecar)
+
 	isServerMissingSidecar, err := clientIntents.IsServerMissingSidecar(intent)
 	if err != nil {
 		return nil, false, errors.Wrap(err)

--- a/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
+++ b/src/operator/controllers/intents_reconcilers/cloud_reconciler_test.go
@@ -649,7 +649,29 @@ func (s *CloudReconcilerTestSuite) TestIntentStatusFormattingError_MissingSideca
 		},
 	}
 
-	s.expectReconcilerError(clientIntents)
+	expectedIntent := graphqlclient.IntentInput{
+		ClientName:      lo.ToPtr(clientName),
+		ServerName:      lo.ToPtr(server),
+		Namespace:       lo.ToPtr(testNamespace),
+		ServerNamespace: lo.ToPtr(testNamespace),
+		Type:            lo.ToPtr(graphqlclient.IntentTypeHttp),
+		Resources: []*graphqlclient.HTTPConfigInput{
+			{
+				Path:    lo.ToPtr("/login"),
+				Methods: []*graphqlclient.HTTPMethod{lo.ToPtr(graphqlclient.HTTPMethodGet), lo.ToPtr(graphqlclient.HTTPMethodPost)},
+			},
+		},
+		Status: &graphqlclient.IntentStatusInput{
+			IstioStatus: &graphqlclient.IstioStatusInput{
+				ServiceAccountName:     lo.ToPtr(serviceAccountName),
+				IsServiceAccountShared: lo.ToPtr(false),
+				IsClientMissingSidecar: lo.ToPtr(false),
+				IsServerMissingSidecar: lo.ToPtr(false),
+			},
+		},
+	}
+
+	s.assertReportedIntents(clientIntents, []graphqlclient.IntentInput{expectedIntent})
 }
 
 func (s *CloudReconcilerTestSuite) TestIntentStatusFormattingError_BadFormatSharedSA() {


### PR DESCRIPTION
### Description
This PR fixes a bug where, when the `MissingSidecarAnnotation` is for whatever reason missing on the ClientIntents, reporting the ClientIntent to Otterize cloud would fail. 


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
