### PR TITLE
Fix bug where reconciling database intents would fail on pods with empty annotations

### DIFF
--- a/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
+++ b/src/operator/controllers/intents_reconcilers/database/database_reconciler.go
@@ -353,6 +353,9 @@ func (r *DatabaseReconciler) handleDatabaseAnnotationOnPod(ctx context.Context, 
 	}
 
 	updatedPod := pod.DeepCopy()
+	if updatedPod.Annotations == nil {
+		updatedPod.Annotations = make(map[string]string)
+	}
 	updatedPod.Annotations[databaseconfigurator.LatestAccessChangeAnnotation] = time.Now().Format(time.RFC3339)
 	if !intents.DeletionTimestamp.IsZero() {
 		// Clean all databases


### PR DESCRIPTION
### Description
Fix a bug where, when performing reconcile on database intents applied to pods with no annotations, the operator could fail to add otterize annotations to the pod. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
