### PR TITLE
Add support for intents in strict mode

### DIFF
--- a/src/operator/webhooks/clientintents_webhook_v2alpha1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2alpha1.go
@@ -68,7 +68,7 @@ func (v *IntentsValidatorV2alpha1) ValidateCreate(ctx context.Context, obj runti
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.EnableStrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -101,7 +101,7 @@ func (v *IntentsValidatorV2alpha1) ValidateUpdate(ctx context.Context, oldObj, n
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.EnableStrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}

--- a/src/operator/webhooks/clientintents_webhook_v2alpha1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2alpha1.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/spf13/viper"
 	"golang.org/x/net/idna"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +67,7 @@ func (v *IntentsValidatorV2alpha1) ValidateCreate(ctx context.Context, obj runti
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.StrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -100,7 +100,7 @@ func (v *IntentsValidatorV2alpha1) ValidateUpdate(ctx context.Context, oldObj, n
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.StrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}

--- a/src/operator/webhooks/clientintents_webhook_v2alpha1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2alpha1.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	"github.com/otterize/intents-operator/src/shared/errors"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
 	"github.com/spf13/viper"
 	"golang.org/x/net/idna"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +67,7 @@ func (v *IntentsValidatorV2alpha1) ValidateCreate(ctx context.Context, obj runti
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -100,7 +100,7 @@ func (v *IntentsValidatorV2alpha1) ValidateUpdate(ctx context.Context, oldObj, n
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}

--- a/src/operator/webhooks/clientintents_webhook_v2beta1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2beta1.go
@@ -68,7 +68,7 @@ func (v *IntentsValidatorV2beta1) ValidateCreate(ctx context.Context, obj runtim
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.EnableStrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -101,7 +101,7 @@ func (v *IntentsValidatorV2beta1) ValidateUpdate(ctx context.Context, oldObj, ne
 		return nil, errors.Wrap(err)
 	}
 
-	if viper.GetBool(enforcement.StrictModeIntentsKey) {
+	if viper.GetBool(enforcement.EnableStrictModeIntentsKey) {
 		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
 			allErrs = append(allErrs, err)
 		}

--- a/src/operator/webhooks/clientintents_webhook_v2beta1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2beta1.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
 	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/spf13/viper"
 	"golang.org/x/net/idna"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,6 +66,13 @@ func (v *IntentsValidatorV2beta1) ValidateCreate(ctx context.Context, obj runtim
 	if err := v.List(ctx, intentsList, &client.ListOptions{Namespace: intentsObj.Namespace}); err != nil {
 		return nil, errors.Wrap(err)
 	}
+
+	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
+		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
 	if err := v.validateNoDuplicateClients(intentsObj, intentsList); err != nil {
 		allErrs = append(allErrs, err)
 	}
@@ -90,6 +99,13 @@ func (v *IntentsValidatorV2beta1) ValidateUpdate(ctx context.Context, oldObj, ne
 	if err := v.List(ctx, intentsList, &client.ListOptions{Namespace: intentsObj.Namespace}); err != nil {
 		return nil, errors.Wrap(err)
 	}
+
+	if viper.GetBool(operatorconfig.StrictModeIntentsKey) {
+		if err := v.enforceIntentsAbideStrictMode(intentsObj); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
 	if err := v.validateNoDuplicateClients(intentsObj, intentsList); err != nil {
 		allErrs = append(allErrs, err)
 	}
@@ -460,6 +476,25 @@ func (v *IntentsValidatorV2beta1) validateInternetTarget(internetTarget *otteriz
 				Detail:   "should be value IP address or CIDR",
 				BadValue: ip,
 			}
+		}
+	}
+	return nil
+}
+
+func (v *IntentsValidatorV2beta1) enforceIntentsAbideStrictMode(intents *otterizev2beta1.ClientIntents) *field.Error {
+	for _, target := range intents.GetTargetList() {
+		intentType := target.GetIntentType()
+		switch intentType {
+		case otterizev2beta1.IntentTypeInternet:
+			if hasWildcardDomain(target.Internet.Domains) {
+				return &field.Error{
+					Type:   field.ErrorTypeForbidden,
+					Field:  "domains",
+					Detail: fmt.Sprintf("invalid target format. type %s must not contain wildcard domains while in strict mode", intentType),
+				}
+			}
+		default:
+			continue
 		}
 	}
 	return nil

--- a/src/operator/webhooks/clientintents_webhook_v2beta1.go
+++ b/src/operator/webhooks/clientintents_webhook_v2beta1.go
@@ -493,6 +493,13 @@ func (v *IntentsValidatorV2beta1) enforceIntentsAbideStrictMode(intents *otteriz
 					Detail: fmt.Sprintf("invalid target format. type %s must not contain wildcard domains while in strict mode", intentType),
 				}
 			}
+			if len(target.Internet.Ports) == 0 {
+				return &field.Error{
+					Type:   field.ErrorTypeForbidden,
+					Field:  "ports",
+					Detail: fmt.Sprintf("invalid target format. type %s must contain ports while in strict mode", intentType),
+				}
+			}
 		case otterizev2beta1.IntentTypeHTTP:
 			if nonServiceTarget(target) {
 				return &field.Error{

--- a/src/operator/webhooks/strict_mode_helpers.go
+++ b/src/operator/webhooks/strict_mode_helpers.go
@@ -1,8 +1,6 @@
 package webhooks
 
 import (
-	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
-	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
 	"strings"
 )
 
@@ -13,13 +11,5 @@ func hasWildcardDomain(fqdns []string) bool {
 			return true
 		}
 	}
-	return false
-}
-
-func nonServiceTarget(target otterizev2beta1.Target) bool {
-	if target.Service == nil && (target.Kubernetes == nil || target.Kubernetes.Kind != serviceidentity.KindService) {
-		return true
-	}
-
 	return false
 }

--- a/src/operator/webhooks/strict_mode_helpers.go
+++ b/src/operator/webhooks/strict_mode_helpers.go
@@ -1,0 +1,13 @@
+package webhooks
+
+import "strings"
+
+// hasWildcardDomain checks if a list of FQDNs contains one with a '*' character.
+func hasWildcardDomain(fqdns []string) bool {
+	for _, fqdn := range fqdns {
+		if strings.Contains(fqdn, "*") {
+			return true
+		}
+	}
+	return false
+}

--- a/src/operator/webhooks/strict_mode_helpers.go
+++ b/src/operator/webhooks/strict_mode_helpers.go
@@ -1,6 +1,10 @@
 package webhooks
 
-import "strings"
+import (
+	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
+	"github.com/otterize/intents-operator/src/shared/serviceidresolver/serviceidentity"
+	"strings"
+)
 
 // hasWildcardDomain checks if a list of FQDNs contains one with a '*' character.
 func hasWildcardDomain(fqdns []string) bool {
@@ -9,5 +13,13 @@ func hasWildcardDomain(fqdns []string) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func nonServiceTarget(target otterizev2beta1.Target) bool {
+	if target.Service == nil && (target.Kubernetes == nil || target.Kubernetes.Kind != serviceidentity.KindService) {
+		return true
+	}
+
 	return false
 }

--- a/src/operator/webhooks/webhook_suite_test.go
+++ b/src/operator/webhooks/webhook_suite_test.go
@@ -774,7 +774,7 @@ func (s *ConversionWebhookTestSuite) TestConversionWebhookInternetIntents() {
 }
 
 func (s *ValidationWebhookTestSuite) TestStrictModeNonKubernetesServiceRejected() {
-	viper.Set(enforcement.StrictModeIntentsKey, true)
+	viper.Set(enforcement.EnableStrictModeIntentsKey, true)
 	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Kubernetes: &otterizev2beta1.KubernetesTarget{
@@ -788,7 +788,7 @@ func (s *ValidationWebhookTestSuite) TestStrictModeNonKubernetesServiceRejected(
 }
 
 func (s *ValidationWebhookTestSuite) TestStrictModeWildcardDNSRejected() {
-	viper.Set(enforcement.StrictModeIntentsKey, true)
+	viper.Set(enforcement.EnableStrictModeIntentsKey, true)
 	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Internet: &otterizev2beta1.Internet{
@@ -801,7 +801,7 @@ func (s *ValidationWebhookTestSuite) TestStrictModeWildcardDNSRejected() {
 }
 
 func (s *ValidationWebhookTestSuite) TestStrictModeDNSWithoutPortRejected() {
-	viper.Set(enforcement.StrictModeIntentsKey, true)
+	viper.Set(enforcement.EnableStrictModeIntentsKey, true)
 	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Internet: &otterizev2beta1.Internet{

--- a/src/operator/webhooks/webhook_suite_test.go
+++ b/src/operator/webhooks/webhook_suite_test.go
@@ -775,7 +775,7 @@ func (s *ConversionWebhookTestSuite) TestConversionWebhookInternetIntents() {
 
 func (s *ValidationWebhookTestSuite) TestStrictModeNonKubernetesServiceRejected() {
 	viper.Set(enforcement.StrictModeIntentsKey, true)
-	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Kubernetes: &otterizev2beta1.KubernetesTarget{
 				Name: "deny-me",
@@ -789,7 +789,7 @@ func (s *ValidationWebhookTestSuite) TestStrictModeNonKubernetesServiceRejected(
 
 func (s *ValidationWebhookTestSuite) TestStrictModeWildcardDNSRejected() {
 	viper.Set(enforcement.StrictModeIntentsKey, true)
-	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Internet: &otterizev2beta1.Internet{
 				Domains: []string{"*.example.com"},
@@ -802,7 +802,7 @@ func (s *ValidationWebhookTestSuite) TestStrictModeWildcardDNSRejected() {
 
 func (s *ValidationWebhookTestSuite) TestStrictModeDNSWithoutPortRejected() {
 	viper.Set(enforcement.StrictModeIntentsKey, true)
-	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", s.TestNamespace, []otterizev2beta1.Target{
 		{
 			Internet: &otterizev2beta1.Internet{
 				Domains: []string{"api.example.com"},

--- a/src/operator/webhooks/webhook_suite_test.go
+++ b/src/operator/webhooks/webhook_suite_test.go
@@ -24,8 +24,10 @@ import (
 	otterizev1beta1 "github.com/otterize/intents-operator/src/operator/api/v1beta1"
 	otterizev2alpha1 "github.com/otterize/intents-operator/src/operator/api/v2alpha1"
 	otterizev2beta1 "github.com/otterize/intents-operator/src/operator/api/v2beta1"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/testbase"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	istiosecurityscheme "istio.io/client-go/pkg/apis/security/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -769,6 +771,47 @@ func (s *ConversionWebhookTestSuite) TestConversionWebhookInternetIntents() {
 		s.Require().Equal(v1alpha3Intents.GetCallsList()[i].Internet.Ports, anotherV1alpha3Intents.GetCallsList()[i].Internet.Ports)
 		s.Require().Equal(v1alpha3Intents.GetCallsList()[i].Internet.Domains, anotherV1alpha3Intents.GetCallsList()[i].Internet.Domains)
 	}
+}
+
+func (s *ValidationWebhookTestSuite) TestStrictModeNonKubernetesServiceRejected() {
+	viper.Set(enforcement.StrictModeIntentsKey, true)
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+		{
+			Kubernetes: &otterizev2beta1.KubernetesTarget{
+				Name: "deny-me",
+				Kind: "ReplicaSet",
+			},
+		},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "Target must be a Kubernetes service while in strict mode")
+}
+
+func (s *ValidationWebhookTestSuite) TestStrictModeWildcardDNSRejected() {
+	viper.Set(enforcement.StrictModeIntentsKey, true)
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+		{
+			Internet: &otterizev2beta1.Internet{
+				Domains: []string{"*.example.com"},
+			},
+		},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "must not contain wildcard domains while in strict mode")
+}
+
+func (s *ValidationWebhookTestSuite) TestStrictModeDNSWithoutPortRejected() {
+	viper.Set(enforcement.StrictModeIntentsKey, true)
+	_, err := s.AddIntentsInNamespaceV2beta1("test-intents", "test-client", "test-namespace", []otterizev2beta1.Target{
+		{
+			Internet: &otterizev2beta1.Internet{
+				Domains: []string{"api.example.com"},
+				// Ports is not set
+			},
+		},
+	})
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "must contain ports while in strict mode")
 }
 
 func TestValidationWebhookTestSuite(t *testing.T) {

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -138,7 +138,6 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 		LinkerdPolicyEnforcementEnabled:       enforcementConfig.EnableLinkerdPolicies && isLinkerdInstalled,
 		ProtectedServicesEnabled:              enforcementConfig.EnableNetworkPolicy, // in this version, protected services are enabled if network policy creation is enabled, regardless of enforcement default state
 		EnforcedNamespaces:                    enforcementConfig.EnforcedNamespaces.Items(),
-		StrictModeEnabled:                     enforcementConfig.StrictModeEnabled,
 		AllowExternalTrafficPolicy:            getAllowExternalTrafficConfig(), // The server expect for AllowExternalTrafficPolicy because of backwards compatibility
 		AutomateThirdPartyNetworkPolicies:     getAutomateThirdPartyNetworkPoliciesConfig(),
 		PrometheusServerConfigs:               getPrometheusServiceIdentities(),

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -139,6 +139,7 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 		ProtectedServicesEnabled:              enforcementConfig.EnableNetworkPolicy, // in this version, protected services are enabled if network policy creation is enabled, regardless of enforcement default state
 		EnforcedNamespaces:                    enforcementConfig.EnforcedNamespaces.Items(),
 		StrictModeEnabled:                     enforcementConfig.StrictModeEnabled,
+		ExcludedStrictModeNamespaces:          enforcementConfig.ExcludedStrictModeNamespaces.Items(),
 		AllowExternalTrafficPolicy:            getAllowExternalTrafficConfig(), // The server expect for AllowExternalTrafficPolicy because of backwards compatibility
 		AutomateThirdPartyNetworkPolicies:     getAutomateThirdPartyNetworkPoliciesConfig(),
 		PrometheusServerConfigs:               getPrometheusServiceIdentities(),

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -138,6 +138,7 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 		LinkerdPolicyEnforcementEnabled:       enforcementConfig.EnableLinkerdPolicies && isLinkerdInstalled,
 		ProtectedServicesEnabled:              enforcementConfig.EnableNetworkPolicy, // in this version, protected services are enabled if network policy creation is enabled, regardless of enforcement default state
 		EnforcedNamespaces:                    enforcementConfig.EnforcedNamespaces.Items(),
+		StrictModeEnabled:                     enforcementConfig.StrictModeEnabled,
 		AllowExternalTrafficPolicy:            getAllowExternalTrafficConfig(), // The server expect for AllowExternalTrafficPolicy because of backwards compatibility
 		AutomateThirdPartyNetworkPolicies:     getAutomateThirdPartyNetworkPoliciesConfig(),
 		PrometheusServerConfigs:               getPrometheusServiceIdentities(),

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	EnableGCPPolicy                      bool
 	EnableAzurePolicy                    bool
 	EnableLinkerdPolicies                bool
+	StrictModeEnabled                    bool
 	EnforcedNamespaces                   *goset.Set[string]
 	AutomateThirdPartyNetworkPolicies    automate_third_party_network_policy.Enum
 	PrometheusServiceIdentities          []serviceidentity.ServiceIdentity
@@ -69,6 +70,8 @@ const (
 	EnableAzurePolicyKey                        = "enable-azure-iam-policy"
 	EnableAzurePolicyDefault                    = false
 	PrometheusServiceConfigKey                  = "prometheusServerConfigs"
+	StrictModeIntentsKey                        = "strict-mode-intents"
+	StrictModeIntentsDefault                    = false
 )
 
 func init() {
@@ -83,6 +86,7 @@ func init() {
 	viper.SetDefault(EnableGCPPolicyKey, EnableGCPPolicyDefault)
 	viper.SetDefault(EnableAzurePolicyKey, EnableAzurePolicyDefault)
 	viper.SetDefault(AutomateThirdPartyNetworkPoliciesKey, AutomateThirdPartyNetworkPoliciesDefault)
+	viper.SetDefault(StrictModeIntentsKey, StrictModeIntentsDefault)
 }
 
 func InitCLIFlags() {
@@ -109,6 +113,7 @@ func GetConfig() Config {
 		EnableAWSPolicy:                      viper.GetBool(EnableAWSPolicyKey),
 		EnableGCPPolicy:                      viper.GetBool(EnableGCPPolicyKey),
 		EnableAzurePolicy:                    viper.GetBool(EnableAzurePolicyKey),
+		StrictModeEnabled:                    viper.GetBool(StrictModeIntentsKey),
 		EnforcedNamespaces:                   goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
 		AutomateThirdPartyNetworkPolicies:    automate_third_party_network_policy.Enum(viper.GetString(AutomateThirdPartyNetworkPoliciesKey)),
 		PrometheusServiceIdentities:          GetPrometheusServiceIdentities(),

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -71,8 +71,8 @@ const (
 	EnableAzurePolicyKey                        = "enable-azure-iam-policy"
 	EnableAzurePolicyDefault                    = false
 	PrometheusServiceConfigKey                  = "prometheusServerConfigs"
-	StrictModeIntentsKey                        = "strict-mode-intents"
-	StrictModeIntentsDefault                    = false
+	EnableStrictModeIntentsKey                  = "enable-strict-mode-intents" // Whether to enable strict mode intents
+	EnableStrictModeIntentsDefault              = false
 	ExcludedStrictModeNamespacesKey             = "excluded-strict-mode-namespaces"
 )
 
@@ -88,7 +88,7 @@ func init() {
 	viper.SetDefault(EnableGCPPolicyKey, EnableGCPPolicyDefault)
 	viper.SetDefault(EnableAzurePolicyKey, EnableAzurePolicyDefault)
 	viper.SetDefault(AutomateThirdPartyNetworkPoliciesKey, AutomateThirdPartyNetworkPoliciesDefault)
-	viper.SetDefault(StrictModeIntentsKey, StrictModeIntentsDefault)
+	viper.SetDefault(EnableStrictModeIntentsKey, EnableStrictModeIntentsDefault)
 }
 
 func InitCLIFlags() {
@@ -97,7 +97,7 @@ func InitCLIFlags() {
 	pflag.Bool(EnableKafkaACLKey, EnableKafkaACLDefault, "Whether to disable Intents Kafka ACL creation")
 	pflag.StringSlice(ActiveEnforcementNamespacesKey, nil, "While using the shadow enforcement mode, namespaces in this list will be treated as if the enforcement were active.")
 	pflag.StringSlice(ExcludedStrictModeNamespacesKey, nil, "Namespaces to exclude from strict mode intents when it is enabled.")
-	pflag.Bool(StrictModeIntentsKey, StrictModeIntentsDefault, "Whether to enable strict mode intents")
+	pflag.Bool(EnableStrictModeIntentsKey, EnableStrictModeIntentsDefault, "Whether to enable strict mode intents")
 	pflag.Bool(EnableIstioPolicyKey, EnableIstioPolicyDefault, "Whether to enable Istio authorization policy creation")
 	pflag.Bool(EnableLinkerdPolicyKey, EnableLinkerdPolicyDefault, "Experimental - enable Linkerd policy creation")
 	pflag.Bool(EnableDatabasePolicy, EnableDatabasePolicyDefault, "Enable the database reconciler")
@@ -117,7 +117,7 @@ func GetConfig() Config {
 		EnableAWSPolicy:                      viper.GetBool(EnableAWSPolicyKey),
 		EnableGCPPolicy:                      viper.GetBool(EnableGCPPolicyKey),
 		EnableAzurePolicy:                    viper.GetBool(EnableAzurePolicyKey),
-		StrictModeEnabled:                    viper.GetBool(StrictModeIntentsKey),
+		StrictModeEnabled:                    viper.GetBool(EnableStrictModeIntentsKey),
 		EnforcedNamespaces:                   goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
 		ExcludedStrictModeNamespaces:         goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
 		AutomateThirdPartyNetworkPolicies:    automate_third_party_network_policy.Enum(viper.GetString(AutomateThirdPartyNetworkPoliciesKey)),

--- a/src/shared/operatorconfig/enforcement/config.go
+++ b/src/shared/operatorconfig/enforcement/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	EnableLinkerdPolicies                bool
 	StrictModeEnabled                    bool
 	EnforcedNamespaces                   *goset.Set[string]
+	ExcludedStrictModeNamespaces         *goset.Set[string]
 	AutomateThirdPartyNetworkPolicies    automate_third_party_network_policy.Enum
 	PrometheusServiceIdentities          []serviceidentity.ServiceIdentity
 }
@@ -72,6 +73,7 @@ const (
 	PrometheusServiceConfigKey                  = "prometheusServerConfigs"
 	StrictModeIntentsKey                        = "strict-mode-intents"
 	StrictModeIntentsDefault                    = false
+	ExcludedStrictModeNamespacesKey             = "excluded-strict-mode-namespaces"
 )
 
 func init() {
@@ -94,6 +96,8 @@ func InitCLIFlags() {
 	pflag.Bool(EnableNetworkPolicyKey, EnableNetworkPolicyDefault, "Whether to enable Intents network policy creation")
 	pflag.Bool(EnableKafkaACLKey, EnableKafkaACLDefault, "Whether to disable Intents Kafka ACL creation")
 	pflag.StringSlice(ActiveEnforcementNamespacesKey, nil, "While using the shadow enforcement mode, namespaces in this list will be treated as if the enforcement were active.")
+	pflag.StringSlice(ExcludedStrictModeNamespacesKey, nil, "Namespaces to exclude from strict mode intents when it is enabled.")
+	pflag.Bool(StrictModeIntentsKey, StrictModeIntentsDefault, "Whether to enable strict mode intents")
 	pflag.Bool(EnableIstioPolicyKey, EnableIstioPolicyDefault, "Whether to enable Istio authorization policy creation")
 	pflag.Bool(EnableLinkerdPolicyKey, EnableLinkerdPolicyDefault, "Experimental - enable Linkerd policy creation")
 	pflag.Bool(EnableDatabasePolicy, EnableDatabasePolicyDefault, "Enable the database reconciler")
@@ -115,6 +119,7 @@ func GetConfig() Config {
 		EnableAzurePolicy:                    viper.GetBool(EnableAzurePolicyKey),
 		StrictModeEnabled:                    viper.GetBool(StrictModeIntentsKey),
 		EnforcedNamespaces:                   goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
+		ExcludedStrictModeNamespaces:         goset.FromSlice(viper.GetStringSlice(ActiveEnforcementNamespacesKey)),
 		AutomateThirdPartyNetworkPolicies:    automate_third_party_network_policy.Enum(viper.GetString(AutomateThirdPartyNetworkPoliciesKey)),
 		PrometheusServiceIdentities:          GetPrometheusServiceIdentities(),
 	}

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -449,7 +449,6 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
-	excludedStrictModeNamespaces          interface{}
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -447,7 +447,6 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
-	StrictModeEnabled                     bool                                   `json:"strictModeEnabled"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -539,9 +538,6 @@ func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies
 func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []PrometheusServerConfigInput {
 	return v.PrometheusServerConfigs
 }
-
-// GetStrictModeEnabled returns IntentsOperatorConfigurationInput.StrictModeEnabled, and is useful for accessing the field via an interface.
-func (v *IntentsOperatorConfigurationInput) GetStrictModeEnabled() bool { return v.StrictModeEnabled }
 
 type InternetConfigInput struct {
 	Domains          []*string       `json:"domains"`

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -440,6 +440,8 @@ type IntentsOperatorConfigurationInput struct {
 	GcpIAMPolicyEnforcementEnabled        bool                                   `json:"gcpIAMPolicyEnforcementEnabled"`
 	AzureIAMPolicyEnforcementEnabled      bool                                   `json:"azureIAMPolicyEnforcementEnabled"`
 	DatabaseEnforcementEnabled            bool                                   `json:"databaseEnforcementEnabled"`
+	StrictModeEnabled                     bool                                   `json:"strictModeEnabled"`
+	ExcludedStrictModeNamespaces          []string                               `json:"excludedStrictModeNamespaces"`
 	EnforcedNamespaces                    []string                               `json:"enforcedNamespaces"`
 	IngressControllerConfig               []IngressControllerConfigInput         `json:"ingressControllerConfig"`
 	AwsALBLoadBalancerExemptionEnabled    bool                                   `json:"awsALBLoadBalancerExemptionEnabled"`
@@ -447,7 +449,7 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
-	StrictModeEnabled                     bool                                   `json:"strictModeEnabled"`
+	excludedStrictModeNamespaces          interface{}
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -505,6 +507,14 @@ func (v *IntentsOperatorConfigurationInput) GetDatabaseEnforcementEnabled() bool
 	return v.DatabaseEnforcementEnabled
 }
 
+// GetStrictModeEnabled returns IntentsOperatorConfigurationInput.StrictModeEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetStrictModeEnabled() bool { return v.StrictModeEnabled }
+
+// GetExcludedStrictModeNamespaces returns IntentsOperatorConfigurationInput.ExcludedStrictModeNamespaces, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetExcludedStrictModeNamespaces() []string {
+	return v.ExcludedStrictModeNamespaces
+}
+
 // GetEnforcedNamespaces returns IntentsOperatorConfigurationInput.EnforcedNamespaces, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetEnforcedNamespaces() []string {
 	return v.EnforcedNamespaces
@@ -539,9 +549,6 @@ func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies
 func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []PrometheusServerConfigInput {
 	return v.PrometheusServerConfigs
 }
-
-// GetStrictModeEnabled returns IntentsOperatorConfigurationInput.StrictModeEnabled, and is useful for accessing the field via an interface.
-func (v *IntentsOperatorConfigurationInput) GetStrictModeEnabled() bool { return v.StrictModeEnabled }
 
 type InternetConfigInput struct {
 	Domains          []*string       `json:"domains"`

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -157,6 +157,21 @@ const (
 	ComponentTypeNetworkMapper       ComponentType = "NETWORK_MAPPER"
 )
 
+type ConnectionsCount struct {
+	Current *int `json:"current"`
+	Removed *int `json:"removed"`
+	Added   *int `json:"added"`
+}
+
+// GetCurrent returns ConnectionsCount.Current, and is useful for accessing the field via an interface.
+func (v *ConnectionsCount) GetCurrent() *int { return v.Current }
+
+// GetRemoved returns ConnectionsCount.Removed, and is useful for accessing the field via an interface.
+func (v *ConnectionsCount) GetRemoved() *int { return v.Removed }
+
+// GetAdded returns ConnectionsCount.Added, and is useful for accessing the field via an interface.
+func (v *ConnectionsCount) GetAdded() *int { return v.Added }
+
 type DNSIPPairInput struct {
 	DnsName *string   `json:"dnsName"`
 	Ips     []*string `json:"ips"`
@@ -305,6 +320,7 @@ type IntentInput struct {
 	Internet                          *InternetConfigInput      `json:"internet"`
 	Status                            *IntentStatusInput        `json:"status"`
 	ResolutionData                    *string                   `json:"resolutionData"`
+	ConnectionsCount                  *ConnectionsCount         `json:"connectionsCount"`
 }
 
 // GetNamespace returns IntentInput.Namespace, and is useful for accessing the field via an interface.
@@ -388,6 +404,9 @@ func (v *IntentInput) GetStatus() *IntentStatusInput { return v.Status }
 // GetResolutionData returns IntentInput.ResolutionData, and is useful for accessing the field via an interface.
 func (v *IntentInput) GetResolutionData() *string { return v.ResolutionData }
 
+// GetConnectionsCount returns IntentInput.ConnectionsCount, and is useful for accessing the field via an interface.
+func (v *IntentInput) GetConnectionsCount() *ConnectionsCount { return v.ConnectionsCount }
+
 type IntentStatusInput struct {
 	IstioStatus *IstioStatusInput `json:"istioStatus"`
 }
@@ -398,14 +417,15 @@ func (v *IntentStatusInput) GetIstioStatus() *IstioStatusInput { return v.IstioS
 type IntentType string
 
 const (
-	IntentTypeHttp     IntentType = "HTTP"
-	IntentTypeKafka    IntentType = "KAFKA"
-	IntentTypeDatabase IntentType = "DATABASE"
-	IntentTypeAws      IntentType = "AWS"
-	IntentTypeGcp      IntentType = "GCP"
-	IntentTypeAzure    IntentType = "AZURE"
-	IntentTypeS3       IntentType = "S3"
-	IntentTypeInternet IntentType = "INTERNET"
+	IntentTypeKubernetes IntentType = "KUBERNETES"
+	IntentTypeHttp       IntentType = "HTTP"
+	IntentTypeKafka      IntentType = "KAFKA"
+	IntentTypeDatabase   IntentType = "DATABASE"
+	IntentTypeAws        IntentType = "AWS"
+	IntentTypeGcp        IntentType = "GCP"
+	IntentTypeAzure      IntentType = "AZURE"
+	IntentTypeS3         IntentType = "S3"
+	IntentTypeInternet   IntentType = "INTERNET"
 )
 
 type IntentsOperatorConfigurationInput struct {
@@ -427,6 +447,7 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
+	StrictModeEnabled                     bool                                   `json:"strictModeEnabled"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -519,6 +540,9 @@ func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []Prome
 	return v.PrometheusServerConfigs
 }
 
+// GetStrictModeEnabled returns IntentsOperatorConfigurationInput.StrictModeEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetStrictModeEnabled() bool { return v.StrictModeEnabled }
+
 type InternetConfigInput struct {
 	Domains          []*string       `json:"domains"`
 	DiscoveredTarget *DNSIPPairInput `json:"discoveredTarget"`
@@ -537,17 +561,6 @@ func (v *InternetConfigInput) GetIps() []*string { return v.Ips }
 
 // GetPorts returns InternetConfigInput.Ports, and is useful for accessing the field via an interface.
 func (v *InternetConfigInput) GetPorts() []*int { return v.Ports }
-
-type IpBlockInput struct {
-	Cidr   string   `json:"cidr"`
-	Except []string `json:"except"`
-}
-
-// GetCidr returns IpBlockInput.Cidr, and is useful for accessing the field via an interface.
-func (v *IpBlockInput) GetCidr() string { return v.Cidr }
-
-// GetExcept returns IpBlockInput.Except, and is useful for accessing the field via an interface.
-func (v *IpBlockInput) GetExcept() []string { return v.Except }
 
 type IstioStatusInput struct {
 	ServiceAccountName     *string `json:"serviceAccountName"`
@@ -660,51 +673,16 @@ const (
 	KubernetesServiceTypeExternalName KubernetesServiceType = "EXTERNAL_NAME"
 )
 
-type NetworkPolicyEgressRuleInput struct {
-	To []PeerInput `json:"to"`
-}
-
-// GetTo returns NetworkPolicyEgressRuleInput.To, and is useful for accessing the field via an interface.
-func (v *NetworkPolicyEgressRuleInput) GetTo() []PeerInput { return v.To }
-
 type NetworkPolicyInput struct {
-	Namespace                    string                 `json:"namespace"`
-	Name                         string                 `json:"name"`
-	ServerName                   string                 `json:"serverName"`
-	ExternalNetworkTrafficPolicy bool                   `json:"externalNetworkTrafficPolicy"`
-	Spec                         NetworkPolicySpecInput `json:"spec"`
+	Name string `json:"name"`
+	Yaml string `json:"yaml"`
 }
-
-// GetNamespace returns NetworkPolicyInput.Namespace, and is useful for accessing the field via an interface.
-func (v *NetworkPolicyInput) GetNamespace() string { return v.Namespace }
 
 // GetName returns NetworkPolicyInput.Name, and is useful for accessing the field via an interface.
 func (v *NetworkPolicyInput) GetName() string { return v.Name }
 
-// GetServerName returns NetworkPolicyInput.ServerName, and is useful for accessing the field via an interface.
-func (v *NetworkPolicyInput) GetServerName() string { return v.ServerName }
-
-// GetExternalNetworkTrafficPolicy returns NetworkPolicyInput.ExternalNetworkTrafficPolicy, and is useful for accessing the field via an interface.
-func (v *NetworkPolicyInput) GetExternalNetworkTrafficPolicy() bool {
-	return v.ExternalNetworkTrafficPolicy
-}
-
-// GetSpec returns NetworkPolicyInput.Spec, and is useful for accessing the field via an interface.
-func (v *NetworkPolicyInput) GetSpec() NetworkPolicySpecInput { return v.Spec }
-
-type NetworkPolicySpecInput struct {
-	Egress []NetworkPolicyEgressRuleInput `json:"egress"`
-}
-
-// GetEgress returns NetworkPolicySpecInput.Egress, and is useful for accessing the field via an interface.
-func (v *NetworkPolicySpecInput) GetEgress() []NetworkPolicyEgressRuleInput { return v.Egress }
-
-type PeerInput struct {
-	IpBlock IpBlockInput `json:"ipBlock"`
-}
-
-// GetIpBlock returns PeerInput.IpBlock, and is useful for accessing the field via an interface.
-func (v *PeerInput) GetIpBlock() IpBlockInput { return v.IpBlock }
+// GetYaml returns NetworkPolicyInput.Yaml, and is useful for accessing the field via an interface.
+func (v *NetworkPolicyInput) GetYaml() string { return v.Yaml }
 
 type PrometheusServerConfigInput struct {
 	Name      string `json:"name"`
@@ -841,6 +819,7 @@ const (
 	UserErrorTypeConflict            UserErrorType = "CONFLICT"
 	UserErrorTypeBadUserInput        UserErrorType = "BAD_USER_INPUT"
 	UserErrorTypeAppliedIntentsError UserErrorType = "APPLIED_INTENTS_ERROR"
+	UserErrorTypeTimeout             UserErrorType = "TIMEOUT"
 )
 
 // __ReportAppliedKubernetesIntentsInput is used internally by genqlient
@@ -1185,7 +1164,7 @@ func ReportNetworkPolicies(
 		OpName: "ReportNetworkPolicies",
 		Query: `
 mutation ReportNetworkPolicies ($namespace: String!, $policies: [NetworkPolicyInput!]!) {
-	reportNetworkPolicies(namespace: $namespace, policies: $policies)
+	reportNetworkPolicies(namespace: $namespace, networkPolicies: $policies)
 }
 `,
 		Variables: &__ReportNetworkPoliciesInput{

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -447,6 +447,7 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
+	StrictModeEnabled                     bool                                   `json:"strictModeEnabled"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -538,6 +539,9 @@ func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies
 func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []PrometheusServerConfigInput {
 	return v.PrometheusServerConfigs
 }
+
+// GetStrictModeEnabled returns IntentsOperatorConfigurationInput.StrictModeEnabled, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetStrictModeEnabled() bool { return v.StrictModeEnabled }
 
 type InternetConfigInput struct {
 	Domains          []*string       `json:"domains"`

--- a/src/shared/otterizecloud/graphqlclient/genqlient.graphql
+++ b/src/shared/otterizecloud/graphqlclient/genqlient.graphql
@@ -8,7 +8,7 @@ mutation ReportAppliedKubernetesIntents($namespace: String!,$intents: [IntentInp
 }
 
 mutation ReportNetworkPolicies($namespace: String!, $policies: [NetworkPolicyInput!]!) {
-    reportNetworkPolicies(namespace: $namespace, policies: $policies)
+    reportNetworkPolicies(namespace: $namespace, networkPolicies: $policies)
 }
 
 mutation ReportIntentsOperatorConfiguration($configuration: IntentsOperatorConfigurationInput!) {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -7,14 +7,17 @@ directive @constraint(
 	example: String!
 ) on ENUM_VALUE
 
-"""The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer."""
+"""Directs the executor to defer this fragment when the `if` argument is true or undefined."""
 directive @defer(
+"""Deferred when true or undefined."""
 	if: Boolean
+"""Unique name"""
 	label: String
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
+"""Marks an element of a GraphQL schema as no longer supported."""
 directive @deprecated(
+"""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."""
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
@@ -27,14 +30,29 @@ directive @httpError(
 	statusCode: Int!
 ) on ENUM_VALUE
 
-"""The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
+"""Directs the executor to include this field or fragment only when the `if` argument is true."""
 directive @include(
+"""Included when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"""@noRole indicates that the specified query / mutation / subscription can be executed regardless of the user's roles.
+This practically means that the query will not allow accessing any org-specific data."""
+directive @noRole on FIELD_DEFINITION
+
 """@noauth indicates that the specified query / mutation / subscription can be executed anonymously without
+user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION.
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
 directive @noauth on FIELD_DEFINITION
+
+"""Indicates exactly one field must be supplied and this field must not be `null`."""
+directive @oneOf on INPUT_OBJECT
+
+"""@requiresRole indicates that the specified query / mutation / subscription requires any of the provided roles to be executed.
+Users without any of the specified roles will not be able to execute the query / mutation / subscription."""
+directive @requiresRole(
+	roles: [AuthRole!]!
+) on FIELD_DEFINITION
 
 directive @restApiField(
 	action: ApiFieldAction
@@ -46,13 +64,15 @@ directive @restApiRoute(
 	tags: [String!]!
 ) on FIELD_DEFINITION
 
-"""The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
+"""Directs the executor to skip this field or fragment when the `if` argument is true."""
 directive @skip(
+"""Skipped when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @specifiedBy built-in directive is used within the type system definition language to provide a scalar specification URL for specifying the behavior of custom scalar types."""
+"""Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
+"""The URL that specifies the behavior of this scalar."""
 	url: String!
 ) on SCALAR
 
@@ -195,6 +215,7 @@ type AccessGraphFilter {
 	lastSeen: TimeFilterValue
 	featureFlags: FeatureFlags
 	includeOnlyClientsMatchingFilter: Boolean
+	hits: NumericFilterValue
 }
 
 type AccessLog {
@@ -273,6 +294,11 @@ type AppliedIntentsRequestWithDetails {
 	status: AppliedIntentsRequestStatusLabel!
 	reason: String
 	clientIntents: ClientIntentsFileRepresentation!
+}
+
+enum AuthRole {
+	ADMIN
+	VIEWER
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -552,6 +578,12 @@ enum ComponentType {
 	NETWORK_MAPPER
 }
 
+input ConnectionsCount {
+	current: Int!
+	removed: Int!
+	added: Int!
+}
+
 type CreateGitHubIntegrationResponse {
 	integration: Integration!
 	nextURL: String!
@@ -560,6 +592,10 @@ type CreateGitHubIntegrationResponse {
 type CreateGitLabIntegrationResponse {
 	integration: Integration!
 	nextURL: String!
+}
+
+type CreateSIEMIntegrationResponse {
+	integration: Integration!
 }
 
 type CreateSlackIntegrationResponse {
@@ -699,6 +735,8 @@ enum EdgeAccessStatusReason {
 	ALLOWED_BY_APPLIED_INTENTS_KAFKA_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_DATABASE_OVERLY_PERMISSIVE
 	ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
+	ALLOWED_BY_INTERNET_EGRESS_NETWORK_POLICY
+	ALLOWED_BY_INTERNET_INGRESS_NETWORK_POLICY
 	WOULD_BE_ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_RESOURCE_MISMATCH
@@ -710,6 +748,8 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_APPLIED_INTENTS_DATABASE_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_DATABASE_RESOURCE_MISMATCH
 	BLOCKED_BY_DATABASE_ENFORCEMENT_CONFIG_MISSING_APPLIED_INTENTS
+	BLOCKED_BY_INTERNET_EGRESS_NETWORK_POLICY
+	BLOCKED_BY_INTERNET_INGRESS_NETWORK_POLICY
 	BLOCKED_BY_DEFAULT_DENY
 	SHARED_SERVICE_ACCOUNT
 	CLIENT_ISTIO_SIDECAR_MISSING
@@ -817,6 +857,8 @@ input ExternalTrafficIntentInput {
 	namespace: String!
 	clientName: String!
 	target: DNSIPPairInput!
+	connectionsCount: ConnectionsCount
+	ttl: Time
 }
 
 input ExternallyAccessibleServiceInput {
@@ -1056,6 +1098,12 @@ enum IPFamily {
 	UNKNOWN
 }
 
+"""IP filters"""
+type IPFilterValue {
+	cidr: String!
+	exclude: [String!]
+}
+
 input IncomingInternetSourceInput {
 	ip: String!
 }
@@ -1119,6 +1167,7 @@ input InputAccessGraphFilter {
 	lastSeen: InputTimeFilterValue
 	featureFlags: InputFeatureFlags
 	includeOnlyClientsMatchingFilter: Boolean
+	hits: InputNumericFilterValue
 }
 
 """ Access log filter """
@@ -1210,6 +1259,34 @@ input InputIntegrationAccessGraphFilter {
 	namespaceFilterType: IDFilterOperators
 	serviceIds: [ID!]
 	serviceFilterType: IDFilterOperators
+	targets: [IntentType!]
+}
+
+""" Network policies filter """
+input InputNetworkPolicyFilter {
+""" Network policies filter """
+	search: String
+""" Network policies filter """
+	clusterIds: InputIDFilterValue
+""" Network policies filter """
+	namespaceIds: InputIDFilterValue
+""" Network policies filter """
+	environmentIds: InputIDFilterValue
+""" Network policies filter """
+	networkPolicyIds: InputIDFilterValue
+""" Network policies filter """
+	policyKinds: InputIDFilterValue
+""" Network policies filter """
+	since: InputTimeFilterValue
+}
+
+input InputNetworkPolicyHitsFilter {
+	since: InputTimeFilterValue
+}
+
+input InputNumericFilterValue {
+	value: Int!
+	operator: NumericFilterOperators!
 }
 
 input InputResourceInventoryFilter {
@@ -1303,6 +1380,7 @@ type Integration {
 	gitLabSettings: GitLabSettings
 	slackSettings: SlackSettings
 	awsVisibilitySettings: AWSVisibilitySettings
+	siemSettings: SIEMSettings
 	organizationId: String!
 	status: IntegrationStatus
 }
@@ -1317,6 +1395,7 @@ type IntegrationAccessGraphFilter {
 	serviceIds: [ID!]
 	serviceFilterType: IDFilterOperators
 	lastSeenAfter: Time
+	targets: [IntentType!]
 }
 
 type IntegrationComponents {
@@ -1361,6 +1440,7 @@ enum IntegrationType {
 	AZURE
 	SLACK
 	AWS_VISIBILITY
+	SIEM
 }
 
 type Intent {
@@ -1409,6 +1489,7 @@ input IntentInput {
 	internet: InternetConfigInput
 	status: IntentStatusInput
 	resolutionData: String
+	connectionsCount: ConnectionsCount
 }
 
 input IntentRequestInput {
@@ -1433,6 +1514,7 @@ input IntentStatusInput {
 }
 
 enum IntentType {
+	KUBERNETES
 	HTTP
 	KAFKA
 	DATABASE
@@ -1463,6 +1545,7 @@ type IntentsOperatorConfiguration {
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
+	strictModeEnabled: Boolean!
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1484,6 +1567,7 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
+	strictModeEnabled: Boolean
 }
 
 type IntentsOperatorState {
@@ -1510,6 +1594,7 @@ type Invite {
 	id: ID!
 	email: String!
 	organization: Organization!
+	organizationMembership: OrganizationMembership!
 	inviter: User!
 	created: Time!
 	acceptedAt: Time
@@ -1519,11 +1604,6 @@ type Invite {
 enum InviteStatus {
 	PENDING
 	ACCEPTED
-}
-
-input IpBlockInput {
-	cidr: String!
-	except: [String!]
 }
 
 enum IpFamilyPolicy {
@@ -1776,12 +1856,18 @@ type Me {
 	user: User!
 """The organizations to which the current logged-in user belongs."""
 	organizations: [Organization!]!
+"""The organizations to which the current logged-in user belongs."""
+	userOrganizations: [UserOrganizationAssociation!]!
 """Organizations to which the current logged-in user may join."""
 	invites: [Invite!]!
 """The organization under which the current user request acts.
 This is selected by the X-Otterize-Organization header,
 or, for users with a single organization, this is that single selected organization."""
 	selectedOrganization: Organization!
+"""The organization under which the current user request acts.
+This is selected by the X-Otterize-Organization header,
+or, for users with a single organization, this is that single selected organization."""
+	selectedUserOrganization: UserOrganizationAssociation!
 }
 
 type MeMutation {
@@ -1930,6 +2016,17 @@ type Mutation {
 		name: String!
 		slackSettings: SlackSettingsInput!
 	): CreateSlackIntegrationResponse
+"""Create a new SIEM integration"""
+	createSIEMIntegration(
+		name: String!
+		siemSettings: SIEMSettingsInput!
+	): CreateSIEMIntegrationResponse
+"""Update SIEM integration"""
+	updateSIEMIntegration(
+		id: ID!
+		name: String!
+		siemSettings: SIEMSettingsInput!
+	): Integration
 """Update a Slack integration"""
 	updateSlackIntegration(
 		id: ID!
@@ -2019,10 +2116,6 @@ type Mutation {
 		intents: [IntentInput!]!
 		ossClusterId: String
 	): Boolean!
-	reportNetworkPolicies(
-		namespace: String!
-		policies: [NetworkPolicyInput!]!
-	): Boolean!
 	reportExternallyAccessibleServices(
 		namespace: String!
 		services: [ExternallyAccessibleServiceInput!]!
@@ -2036,6 +2129,7 @@ type Mutation {
 """Create user invite"""
 	createInvite(
 		email: String!
+		organizationMembership: OrganizationMembershipInput
 	): Invite!
 """Delete user invite"""
 	deleteInvite(
@@ -2069,6 +2163,15 @@ type Mutation {
 		id: ID!
 		environmentId: ID
 	): Namespace!
+	reportNamespaceLabels(
+		name: String!
+		labels: [LabelInput!]
+	): Boolean!
+	reportNetworkPolicies(
+		namespace: String
+		networkPolicies: [NetworkPolicyInput!]
+	): Boolean!
+	computeNetworkPoliciesForOrg: Boolean!
 """Create a new organization"""
 	createOrganization(
 		name: String
@@ -2079,6 +2182,9 @@ type Mutation {
 		name: String
 		imageURL: String
 		settings: OrganizationSettingsInput
+	): Organization!
+	updateDomainsDefaultRole(
+		defaultRole: AuthRole!
 	): Organization!
 """Remove user from organization"""
 	removeUserFromOrganization(
@@ -2124,6 +2230,9 @@ type Mutation {
 	saveOnboardingFeedback(
 		userEmail: String!
 		feedback: String!
+	): Boolean!
+	saveOrgMemberships(
+		memberships: [UserOrgMembershipInput!]!
 	): Boolean!
 	createOrActivateTutorial(
 		tutorialName: TutorialName!
@@ -2186,20 +2295,65 @@ enum NetworkPoliciesStep {
 	COMPLETED
 }
 
-input NetworkPolicyEgressRuleInput {
-	to: [PeerInput!]!
+type NetworkPolicy {
+	id: ID!
+	name: String!
+	kind: NetworkPolicyKind!
+	cluster: Cluster!
+	namespace: Namespace
+	environment: Environment!
+	hits: Int!
+	allowedHits: Int!
+	blockedHits: Int!
+	workloads: [NetworkPolicyWorkload!]!
+	workloadsAffected: Int!
+	spec: String!
+	lastUsed: Time
+	metadata: NetworkPolicyMetadata
 }
 
 input NetworkPolicyInput {
-	namespace: String!
 	name: String!
-	serverName: String!
-	externalNetworkTrafficPolicy: Boolean!
-	spec: NetworkPolicySpecInput
+	yaml: String!
 }
 
-input NetworkPolicySpecInput {
-	egress: [NetworkPolicyEgressRuleInput!]
+enum NetworkPolicyKind {
+	NETWORK_POLICY
+	NETWORK_POLICY_MANAGED_BY_OTTERIZE
+	CILIUM_NETWORK_POLICY
+	CILIUM_CLUSTER_WIDE_NETWORK_POLICY
+}
+
+type NetworkPolicyMetadata {
+	isEgress: Boolean!
+	isIngress: Boolean!
+	hasIpBlocks: Boolean!
+}
+
+enum NetworkPolicyScope {
+	PRIMARY
+	EGRESS
+	INGRESS
+}
+
+type NetworkPolicyWorkload {
+	scope: NetworkPolicyScope!
+	service: Service!
+}
+
+"""Numeric filters"""
+enum NumericFilterOperators {
+	EQUAL
+	NOT_EQUAL
+	GREATER_THAN
+	GREATER_THAN_OR_EQUAL
+	LESS_THAN
+	LESS_THAN_OR_EQUAL
+}
+
+type NumericFilterValue {
+	value: Int!
+	operator: NumericFilterOperators!
 }
 
 type Organization {
@@ -2211,11 +2365,45 @@ type Organization {
 	created: Time!
 }
 
+type OrganizationMembership {
+	role: AuthRole!
+	restrictions: OrganizationMembershipRestrictions
+	restrictionResources: OrganizationMembershipRestrictionResources
+}
+
+input OrganizationMembershipInput {
+	role: AuthRole!
+	restrictions: OrganizationMembershipRestrictionsInput
+}
+
+type OrganizationMembershipRestrictionResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+	environments: [Environment!]!
+}
+
+type OrganizationMembershipRestrictions {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	environmentIds: IDFilterValue
+}
+
+input OrganizationMembershipRestrictionsInput {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+}
+
 type OrganizationSettings {
 	domains: [String!]
 	enforcedRegulations: [String!]
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
+	ignoreInternetIntents: Boolean
+	domainsDefaultRole: AuthRole!
 }
 
 input OrganizationSettingsInput {
@@ -2223,6 +2411,7 @@ input OrganizationSettingsInput {
 	enforcedRegulations: [String]
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
+	ignoreInternetIntents: Boolean
 }
 
 input PaginationInput {
@@ -2239,10 +2428,6 @@ enum PathType {
 	IMPLEMENTATION_SPECIFIC
 	PREFIX
 	EXACT
-}
-
-input PeerInput {
-	ipBlock: IpBlockInput!
 }
 
 input PortStatusInput {
@@ -2295,6 +2480,16 @@ type Query {
 		targetServiceId: ID!
 		lastSeenAfter: Time!
 	): [String!]!
+	edgeNetworkPolicies(
+		clientServiceId: ID!
+		serverServiceId: ID!
+	): [NetworkPolicy!]!
+""" Get edge connections count """
+	edgeConnectionsCount(
+		clientId: ID!
+		serverId: ID!
+		lastSeenAfter: Time!
+	): Int!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter
@@ -2420,6 +2615,13 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
+	networkPolicy(
+		id: ID!
+		filter: InputNetworkPolicyHitsFilter
+	): NetworkPolicy
+	networkPolicies(
+		filter: InputNetworkPolicyFilter
+	): [NetworkPolicy!]!
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2469,6 +2671,9 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
+"""List users with restriction resources"""
+	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
+	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
 		id: ID!
@@ -2508,6 +2713,9 @@ enum RegulationCode {
 	ZERO_TRUST_EGRESS_ACCESS_COVERED
 	ZERO_TRUST_EXTERNAL_INGRESS_TAGGED
 	ZERO_TRUST_ALL_INTRA_CLUSTER_ACCESS_COVERED
+	THREAT_INTELLIGENCE
+"""Detect known IOCs (IPs, domain names) against ingress and egress Internet traffic"""
+	THREAT_INTELLIGENCE_KNOWN_IOCS
 }
 
 enum RegulationStandard {
@@ -2515,6 +2723,7 @@ enum RegulationStandard {
 	PII
 	HIPAA
 	ZERO_TRUST
+	THREAT_INTELLIGENCE
 }
 
 input ReportServiceMetadataInput {
@@ -2537,6 +2746,44 @@ enum RowDiff {
 type RulesetsWithResources {
 	rulesets: [AccessApprovalRuleset!]!
 	resources: AccessApprovalRulesetResources!
+}
+
+type SIEMIntegrationTrigger {
+	isActive: Boolean!
+}
+
+input SIEMIntegrationTriggerInput {
+	isActive: Boolean!
+}
+
+type SIEMSettings {
+	isActive: Boolean!
+	syslogHostname: String!
+	syslogPort: Int!
+	syslogFacility: Int!
+	tlsConfiguration: TLSConfiguration
+	serviceTriggers: [SIEMTrigger!]!
+	findingTriggers: [SIEMTrigger!]!
+	integrationTriggers: SIEMIntegrationTrigger!
+}
+
+input SIEMSettingsInput {
+	isActive: Boolean!
+	syslogHostname: String!
+	syslogPort: Int!
+	syslogFacility: Int!
+	tlsConfiguration: TLSConfigurationInput
+	serviceTriggers: [SIEMTriggerInput!]!
+	findingTriggers: [SIEMTriggerInput!]!
+	integrationTriggers: SIEMIntegrationTriggerInput!
+}
+
+type SIEMTrigger {
+	filter: IntegrationAccessGraphFilter!
+}
+
+input SIEMTriggerInput {
+	filter: InputIntegrationAccessGraphFilter!
 }
 
 input SelectorKeyValueInput {
@@ -2622,6 +2869,7 @@ type Service {
 	aliases: [ServerAlias!]
 	namespace: Namespace
 	environment: Environment!
+	networkPolicies: [NetworkPolicy!]
 """If service is Kafka, its KafkaServerConfig."""
 	kafkaServerConfig: KafkaServerConfig
 	certificateInformation: CertificateInformation
@@ -2685,6 +2933,7 @@ input ServiceIdentityInput {
 	name: String!
 	namespace: String!
 	kind: String!
+	nameResolvedUsingAnnotation: Boolean
 }
 
 enum ServiceInternalTrafficPolicy {
@@ -2695,6 +2944,9 @@ enum ServiceInternalTrafficPolicy {
 input ServiceMetadataInput {
 	tags: [String!]
 	awsRoles: [String!]
+	labels: [LabelInput!]
+	podIps: [String!]
+	serviceIps: [String!]
 }
 
 enum ServiceType {
@@ -2786,6 +3038,17 @@ type StatusSummary {
 
 """The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
 scalar String
+
+type TLSConfiguration {
+	caCertificate: String
+	certificate: String!
+}
+
+input TLSConfigurationInput {
+	caCertificate: String
+	certificate: String!
+	key: String!
+}
 
 enum TelemetryComponentType {
 	INTENTS_OPERATOR
@@ -2920,6 +3183,18 @@ enum UserErrorType {
 	CONFLICT
 	BAD_USER_INPUT
 	APPLIED_INTENTS_ERROR
+	TIMEOUT
+}
+
+input UserOrgMembershipInput {
+	userId: ID!
+	membership: OrganizationMembershipInput!
+}
+
+type UserOrganizationAssociation {
+	org: Organization!
+	user: User!
+	membership: OrganizationMembership!
 }
 
 type UserTutorial {
@@ -2932,6 +3207,11 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+type UsersWithRestrictionResources {
+	orgUsers: [UserOrganizationAssociation!]!
+	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1541,11 +1541,12 @@ type IntentsOperatorConfiguration {
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
 	databaseEnforcementEnabled: Boolean!
+	strictModeEnabled: Boolean!
 	protectedServicesEnabled: Boolean!
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
-	strictModeEnabled: Boolean!
+	excludedStrictModeNamespaces: [String!]
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1560,6 +1561,8 @@ input IntentsOperatorConfigurationInput {
 	gcpIAMPolicyEnforcementEnabled: Boolean
 	azureIAMPolicyEnforcementEnabled: Boolean
 	databaseEnforcementEnabled: Boolean
+	strictModeEnabled: Boolean
+	excludedStrictModeNamespaces: [String!]
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
@@ -1567,7 +1570,6 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
-	strictModeEnabled: Boolean
 }
 
 type IntentsOperatorState {
@@ -1599,6 +1601,11 @@ type Invite {
 	created: Time!
 	acceptedAt: Time
 	status: InviteStatus!
+}
+
+input InviteOrgMembershipInput {
+	inviteId: ID!
+	membership: OrganizationMembershipInput!
 }
 
 enum InviteStatus {
@@ -1868,6 +1875,7 @@ or, for users with a single organization, this is that single selected organizat
 This is selected by the X-Otterize-Organization header,
 or, for users with a single organization, this is that single selected organization."""
 	selectedUserOrganization: UserOrganizationAssociation!
+	selectedOrganizationRestrictionResources: OrganizationMembershipRestrictionResources
 }
 
 type MeMutation {
@@ -2139,6 +2147,9 @@ type Mutation {
 	acceptInvite(
 		id: ID!
 	): Invite!
+	saveInviteOrgMemberships(
+		memberships: [InviteOrgMembershipInput!]!
+	): Boolean!
 	reportK8sServices(
 		namespace: String!
 		services: [K8sServiceInput!]!
@@ -2366,6 +2377,7 @@ type Organization {
 }
 
 type OrganizationMembership {
+	organizationId: ID!
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictions
 	restrictionResources: OrganizationMembershipRestrictionResources
@@ -2404,6 +2416,7 @@ type OrganizationSettings {
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
 	ignoreInternetIntents: Boolean
 	domainsDefaultRole: AuthRole!
+	defaultInviteMembership: OrganizationMembership!
 }
 
 input OrganizationSettingsInput {
@@ -2412,6 +2425,7 @@ input OrganizationSettingsInput {
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 	ignoreInternetIntents: Boolean
+	defaultInviteMembership: OrganizationMembershipInput
 }
 
 input PaginationInput {
@@ -2671,8 +2685,6 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
-"""List users with restriction resources"""
-	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
 	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
@@ -3041,13 +3053,13 @@ scalar String
 
 type TLSConfiguration {
 	caCertificate: String
-	certificate: String!
+	certificate: String
 }
 
 input TLSConfigurationInput {
 	caCertificate: String
-	certificate: String!
-	key: String!
+	certificate: String
+	key: String
 }
 
 enum TelemetryComponentType {
@@ -3207,11 +3219,6 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
-}
-
-type UsersWithRestrictionResources {
-	orgUsers: [UserOrganizationAssociation!]!
-	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1545,7 +1545,6 @@ type IntentsOperatorConfiguration {
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
-	strictModeEnabled: Boolean!
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1567,7 +1566,6 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
-	strictModeEnabled: Boolean
 }
 
 type IntentsOperatorState {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -1545,6 +1545,7 @@ type IntentsOperatorConfiguration {
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
+	strictModeEnabled: Boolean!
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1566,6 +1567,7 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
+	strictModeEnabled: Boolean
 }
 
 type IntentsOperatorState {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -154,6 +154,7 @@ input AWSVisibilitySettingsInput {
 
 type AccessApprovalRuleset {
 	id: ID!
+	order: Int!
 	origin: AccessApprovalRulesetFilter!
 	target: AccessApprovalRulesetFilter!
 	action: AccessApprovalRulesetAction!
@@ -299,6 +300,11 @@ type AppliedIntentsRequestWithDetails {
 enum AuthRole {
 	ADMIN
 	VIEWER
+}
+
+type AutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -884,6 +890,7 @@ type FeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 type Finding {
@@ -1004,12 +1011,14 @@ type GitHubRepoInfo {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 input GitHubRepoInfoInput {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitHubSettings {
@@ -1044,6 +1053,7 @@ input GitLabRepoInfoInput {
 	projectPath: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitLabSettings {
@@ -1117,6 +1127,7 @@ input IncomingTrafficIntentInput {
 	serverName: String!
 	namespace: String!
 	source: IncomingInternetSourceInput!
+	connectionsCount: ConnectionsCount
 }
 
 input IngressControllerConfigInput {
@@ -1129,6 +1140,8 @@ input IngressControllerConfigInput {
 input InputAccessApprovalRuleset {
 """Ruleset"""
 	id: ID!
+"""Ruleset"""
+	order: Int!
 """Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
@@ -1208,6 +1221,11 @@ input InputAppliedIntentsRequestFilter {
 	approvalStatuses: InputIDFilterValue
 }
 
+input InputAutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
+}
+
 input InputDefaultIntentsApprovalActionByEnv {
 	environmentId: ID!
 	action: AccessApprovalRulesetAction!
@@ -1221,6 +1239,7 @@ input InputFeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 """ Findings filter """
@@ -1289,6 +1308,11 @@ input InputNumericFilterValue {
 	operator: NumericFilterOperators!
 }
 
+input InputOffsetPagination {
+	page: Int
+	size: Int
+}
+
 input InputResourceInventoryFilter {
 	serviceIds: InputIDFilterValue
 	environmentIds: InputIDFilterValue
@@ -1312,15 +1336,21 @@ input InputServiceFilter {
 	integrationIds: [ID!]
 }
 
+input InputTerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 input InputTerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 input InputTerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [InputTerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [InputTerraformAwsPolicyInfo!]
 }
 
@@ -2291,6 +2321,11 @@ type NetworkMapperComponent {
 	status: ComponentStatus!
 }
 
+type NetworkPoliciesPage {
+	data: [NetworkPolicy!]!
+	meta: PaginationMeta
+}
+
 enum NetworkPoliciesStep {
 """Connect cluster"""
 	CREATE_CLUSTER
@@ -2417,6 +2452,7 @@ type OrganizationSettings {
 	ignoreInternetIntents: Boolean
 	domainsDefaultRole: AuthRole!
 	defaultInviteMembership: OrganizationMembership!
+	autoApproveMoreRestrictiveIntentsByEnv: [AutoApproveMoreRestrictiveIntentsByEnv!]!
 }
 
 input OrganizationSettingsInput {
@@ -2426,6 +2462,7 @@ input OrganizationSettingsInput {
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 	ignoreInternetIntents: Boolean
 	defaultInviteMembership: OrganizationMembershipInput
+	autoApproveMoreRestrictiveIntentsByEnv: [InputAutoApproveMoreRestrictiveIntentsByEnv!]
 }
 
 input PaginationInput {
@@ -2635,7 +2672,8 @@ type Query {
 	): NetworkPolicy
 	networkPolicies(
 		filter: InputNetworkPolicyFilter
-	): [NetworkPolicy!]!
+		pagination: InputOffsetPagination
+	): NetworkPoliciesPage
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2753,6 +2791,7 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+	STRICT_MODE_WARNING
 }
 
 type RulesetsWithResources {
@@ -2975,6 +3014,7 @@ enum ServiceType {
 	KUBERNETES_LOAD_BALANCER
 	AWS_VISIBILITY_EKS
 	DETECTED_CLOUD_SERVER
+	CONTROL_PLANE
 }
 
 type ServicesResponse {
@@ -3082,21 +3122,28 @@ input TelemetryInput {
 	data: TelemetryData!
 }
 
+type TerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 type TerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 type TerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [TerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [TerraformAwsPolicyInfo!]
 }
 
 type TerraformResourceInfo {
 	modulePath: String!
-	gitOriginUrl: String!
+	gitPlatform: String!
+	gitOrigin: String!
 	gitCommitHash: String!
 	awsRoles: [TerraformAwsRoleInfo!]
 }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -7,14 +7,17 @@ directive @constraint(
 	example: String!
 ) on ENUM_VALUE
 
-"""The @defer directive may be specified on a fragment spread to imply de-prioritization, that causes the fragment to be omitted in the initial response, and delivered as a subsequent response afterward. A query with @defer directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred delivered in a subsequent response. @include and @skip take precedence over @defer."""
+"""Directs the executor to defer this fragment when the `if` argument is true or undefined."""
 directive @defer(
+"""Deferred when true or undefined."""
 	if: Boolean
+"""Unique name"""
 	label: String
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
+"""Marks an element of a GraphQL schema as no longer supported."""
 directive @deprecated(
+"""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."""
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
@@ -27,14 +30,29 @@ directive @httpError(
 	statusCode: Int!
 ) on ENUM_VALUE
 
-"""The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
+"""Directs the executor to include this field or fragment only when the `if` argument is true."""
 directive @include(
+"""Included when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+"""@noRole indicates that the specified query / mutation / subscription can be executed regardless of the user's roles.
+This practically means that the query will not allow accessing any org-specific data."""
+directive @noRole on FIELD_DEFINITION
+
 """@noauth indicates that the specified query / mutation / subscription can be executed anonymously without
+user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION.
 user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
 directive @noauth on FIELD_DEFINITION
+
+"""Indicates exactly one field must be supplied and this field must not be `null`."""
+directive @oneOf on INPUT_OBJECT
+
+"""@requiresRole indicates that the specified query / mutation / subscription requires any of the provided roles to be executed.
+Users without any of the specified roles will not be able to execute the query / mutation / subscription."""
+directive @requiresRole(
+	roles: [AuthRole!]!
+) on FIELD_DEFINITION
 
 directive @restApiField(
 	action: ApiFieldAction
@@ -46,13 +64,15 @@ directive @restApiRoute(
 	tags: [String!]!
 ) on FIELD_DEFINITION
 
-"""The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
+"""Directs the executor to skip this field or fragment when the `if` argument is true."""
 directive @skip(
+"""Skipped when true."""
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-"""The @specifiedBy built-in directive is used within the type system definition language to provide a scalar specification URL for specifying the behavior of custom scalar types."""
+"""Exposes a URL that specifies the behavior of this scalar."""
 directive @specifiedBy(
+"""The URL that specifies the behavior of this scalar."""
 	url: String!
 ) on SCALAR
 
@@ -195,6 +215,7 @@ type AccessGraphFilter {
 	lastSeen: TimeFilterValue
 	featureFlags: FeatureFlags
 	includeOnlyClientsMatchingFilter: Boolean
+	hits: NumericFilterValue
 }
 
 type AccessLog {
@@ -273,6 +294,11 @@ type AppliedIntentsRequestWithDetails {
 	status: AppliedIntentsRequestStatusLabel!
 	reason: String
 	clientIntents: ClientIntentsFileRepresentation!
+}
+
+enum AuthRole {
+	ADMIN
+	VIEWER
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -552,6 +578,12 @@ enum ComponentType {
 	NETWORK_MAPPER
 }
 
+input ConnectionsCount {
+	current: Int!
+	removed: Int!
+	added: Int!
+}
+
 type CreateGitHubIntegrationResponse {
 	integration: Integration!
 	nextURL: String!
@@ -560,6 +592,10 @@ type CreateGitHubIntegrationResponse {
 type CreateGitLabIntegrationResponse {
 	integration: Integration!
 	nextURL: String!
+}
+
+type CreateSIEMIntegrationResponse {
+	integration: Integration!
 }
 
 type CreateSlackIntegrationResponse {
@@ -699,6 +735,8 @@ enum EdgeAccessStatusReason {
 	ALLOWED_BY_APPLIED_INTENTS_KAFKA_OVERLY_PERMISSIVE
 	ALLOWED_BY_APPLIED_INTENTS_DATABASE_OVERLY_PERMISSIVE
 	ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
+	ALLOWED_BY_INTERNET_EGRESS_NETWORK_POLICY
+	ALLOWED_BY_INTERNET_INGRESS_NETWORK_POLICY
 	WOULD_BE_ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
 	BLOCKED_BY_APPLIED_INTENTS_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_RESOURCE_MISMATCH
@@ -710,6 +748,8 @@ enum EdgeAccessStatusReason {
 	BLOCKED_BY_APPLIED_INTENTS_DATABASE_UNDER_PERMISSIVE
 	BLOCKED_BY_APPLIED_INTENTS_DATABASE_RESOURCE_MISMATCH
 	BLOCKED_BY_DATABASE_ENFORCEMENT_CONFIG_MISSING_APPLIED_INTENTS
+	BLOCKED_BY_INTERNET_EGRESS_NETWORK_POLICY
+	BLOCKED_BY_INTERNET_INGRESS_NETWORK_POLICY
 	BLOCKED_BY_DEFAULT_DENY
 	SHARED_SERVICE_ACCOUNT
 	CLIENT_ISTIO_SIDECAR_MISSING
@@ -817,6 +857,8 @@ input ExternalTrafficIntentInput {
 	namespace: String!
 	clientName: String!
 	target: DNSIPPairInput!
+	connectionsCount: ConnectionsCount
+	ttl: Time
 }
 
 input ExternallyAccessibleServiceInput {
@@ -1056,6 +1098,12 @@ enum IPFamily {
 	UNKNOWN
 }
 
+"""IP filters"""
+type IPFilterValue {
+	cidr: String!
+	exclude: [String!]
+}
+
 input IncomingInternetSourceInput {
 	ip: String!
 }
@@ -1119,6 +1167,7 @@ input InputAccessGraphFilter {
 	lastSeen: InputTimeFilterValue
 	featureFlags: InputFeatureFlags
 	includeOnlyClientsMatchingFilter: Boolean
+	hits: InputNumericFilterValue
 }
 
 """ Access log filter """
@@ -1210,6 +1259,34 @@ input InputIntegrationAccessGraphFilter {
 	namespaceFilterType: IDFilterOperators
 	serviceIds: [ID!]
 	serviceFilterType: IDFilterOperators
+	targets: [IntentType!]
+}
+
+""" Network policies filter """
+input InputNetworkPolicyFilter {
+""" Network policies filter """
+	search: String
+""" Network policies filter """
+	clusterIds: InputIDFilterValue
+""" Network policies filter """
+	namespaceIds: InputIDFilterValue
+""" Network policies filter """
+	environmentIds: InputIDFilterValue
+""" Network policies filter """
+	networkPolicyIds: InputIDFilterValue
+""" Network policies filter """
+	policyKinds: InputIDFilterValue
+""" Network policies filter """
+	since: InputTimeFilterValue
+}
+
+input InputNetworkPolicyHitsFilter {
+	since: InputTimeFilterValue
+}
+
+input InputNumericFilterValue {
+	value: Int!
+	operator: NumericFilterOperators!
 }
 
 input InputResourceInventoryFilter {
@@ -1303,6 +1380,7 @@ type Integration {
 	gitLabSettings: GitLabSettings
 	slackSettings: SlackSettings
 	awsVisibilitySettings: AWSVisibilitySettings
+	siemSettings: SIEMSettings
 	organizationId: String!
 	status: IntegrationStatus
 }
@@ -1317,6 +1395,7 @@ type IntegrationAccessGraphFilter {
 	serviceIds: [ID!]
 	serviceFilterType: IDFilterOperators
 	lastSeenAfter: Time
+	targets: [IntentType!]
 }
 
 type IntegrationComponents {
@@ -1361,6 +1440,7 @@ enum IntegrationType {
 	AZURE
 	SLACK
 	AWS_VISIBILITY
+	SIEM
 }
 
 type Intent {
@@ -1409,6 +1489,7 @@ input IntentInput {
 	internet: InternetConfigInput
 	status: IntentStatusInput
 	resolutionData: String
+	connectionsCount: ConnectionsCount
 }
 
 input IntentRequestInput {
@@ -1433,6 +1514,7 @@ input IntentStatusInput {
 }
 
 enum IntentType {
+	KUBERNETES
 	HTTP
 	KAFKA
 	DATABASE
@@ -1510,20 +1592,21 @@ type Invite {
 	id: ID!
 	email: String!
 	organization: Organization!
+	organizationMembership: OrganizationMembership!
 	inviter: User!
 	created: Time!
 	acceptedAt: Time
 	status: InviteStatus!
 }
 
+input InviteOrgMembershipInput {
+	inviteId: ID!
+	membership: OrganizationMembershipInput!
+}
+
 enum InviteStatus {
 	PENDING
 	ACCEPTED
-}
-
-input IpBlockInput {
-	cidr: String!
-	except: [String!]
 }
 
 enum IpFamilyPolicy {
@@ -1776,12 +1859,19 @@ type Me {
 	user: User!
 """The organizations to which the current logged-in user belongs."""
 	organizations: [Organization!]!
+"""The organizations to which the current logged-in user belongs."""
+	userOrganizations: [UserOrganizationAssociation!]!
 """Organizations to which the current logged-in user may join."""
 	invites: [Invite!]!
 """The organization under which the current user request acts.
 This is selected by the X-Otterize-Organization header,
 or, for users with a single organization, this is that single selected organization."""
 	selectedOrganization: Organization!
+"""The organization under which the current user request acts.
+This is selected by the X-Otterize-Organization header,
+or, for users with a single organization, this is that single selected organization."""
+	selectedUserOrganization: UserOrganizationAssociation!
+	selectedOrganizationRestrictionResources: OrganizationMembershipRestrictionResources
 }
 
 type MeMutation {
@@ -1930,6 +2020,17 @@ type Mutation {
 		name: String!
 		slackSettings: SlackSettingsInput!
 	): CreateSlackIntegrationResponse
+"""Create a new SIEM integration"""
+	createSIEMIntegration(
+		name: String!
+		siemSettings: SIEMSettingsInput!
+	): CreateSIEMIntegrationResponse
+"""Update SIEM integration"""
+	updateSIEMIntegration(
+		id: ID!
+		name: String!
+		siemSettings: SIEMSettingsInput!
+	): Integration
 """Update a Slack integration"""
 	updateSlackIntegration(
 		id: ID!
@@ -2019,10 +2120,6 @@ type Mutation {
 		intents: [IntentInput!]!
 		ossClusterId: String
 	): Boolean!
-	reportNetworkPolicies(
-		namespace: String!
-		policies: [NetworkPolicyInput!]!
-	): Boolean!
 	reportExternallyAccessibleServices(
 		namespace: String!
 		services: [ExternallyAccessibleServiceInput!]!
@@ -2036,6 +2133,7 @@ type Mutation {
 """Create user invite"""
 	createInvite(
 		email: String!
+		organizationMembership: OrganizationMembershipInput
 	): Invite!
 """Delete user invite"""
 	deleteInvite(
@@ -2045,6 +2143,9 @@ type Mutation {
 	acceptInvite(
 		id: ID!
 	): Invite!
+	saveInviteOrgMemberships(
+		memberships: [InviteOrgMembershipInput!]!
+	): Boolean!
 	reportK8sServices(
 		namespace: String!
 		services: [K8sServiceInput!]!
@@ -2069,6 +2170,15 @@ type Mutation {
 		id: ID!
 		environmentId: ID
 	): Namespace!
+	reportNamespaceLabels(
+		name: String!
+		labels: [LabelInput!]
+	): Boolean!
+	reportNetworkPolicies(
+		namespace: String
+		networkPolicies: [NetworkPolicyInput!]
+	): Boolean!
+	computeNetworkPoliciesForOrg: Boolean!
 """Create a new organization"""
 	createOrganization(
 		name: String
@@ -2079,6 +2189,9 @@ type Mutation {
 		name: String
 		imageURL: String
 		settings: OrganizationSettingsInput
+	): Organization!
+	updateDomainsDefaultRole(
+		defaultRole: AuthRole!
 	): Organization!
 """Remove user from organization"""
 	removeUserFromOrganization(
@@ -2124,6 +2237,9 @@ type Mutation {
 	saveOnboardingFeedback(
 		userEmail: String!
 		feedback: String!
+	): Boolean!
+	saveOrgMemberships(
+		memberships: [UserOrgMembershipInput!]!
 	): Boolean!
 	createOrActivateTutorial(
 		tutorialName: TutorialName!
@@ -2186,20 +2302,65 @@ enum NetworkPoliciesStep {
 	COMPLETED
 }
 
-input NetworkPolicyEgressRuleInput {
-	to: [PeerInput!]!
+type NetworkPolicy {
+	id: ID!
+	name: String!
+	kind: NetworkPolicyKind!
+	cluster: Cluster!
+	namespace: Namespace
+	environment: Environment!
+	hits: Int!
+	allowedHits: Int!
+	blockedHits: Int!
+	workloads: [NetworkPolicyWorkload!]!
+	workloadsAffected: Int!
+	spec: String!
+	lastUsed: Time
+	metadata: NetworkPolicyMetadata
 }
 
 input NetworkPolicyInput {
-	namespace: String!
 	name: String!
-	serverName: String!
-	externalNetworkTrafficPolicy: Boolean!
-	spec: NetworkPolicySpecInput
+	yaml: String!
 }
 
-input NetworkPolicySpecInput {
-	egress: [NetworkPolicyEgressRuleInput!]
+enum NetworkPolicyKind {
+	NETWORK_POLICY
+	NETWORK_POLICY_MANAGED_BY_OTTERIZE
+	CILIUM_NETWORK_POLICY
+	CILIUM_CLUSTER_WIDE_NETWORK_POLICY
+}
+
+type NetworkPolicyMetadata {
+	isEgress: Boolean!
+	isIngress: Boolean!
+	hasIpBlocks: Boolean!
+}
+
+enum NetworkPolicyScope {
+	PRIMARY
+	EGRESS
+	INGRESS
+}
+
+type NetworkPolicyWorkload {
+	scope: NetworkPolicyScope!
+	service: Service!
+}
+
+"""Numeric filters"""
+enum NumericFilterOperators {
+	EQUAL
+	NOT_EQUAL
+	GREATER_THAN
+	GREATER_THAN_OR_EQUAL
+	LESS_THAN
+	LESS_THAN_OR_EQUAL
+}
+
+type NumericFilterValue {
+	value: Int!
+	operator: NumericFilterOperators!
 }
 
 type Organization {
@@ -2211,11 +2372,47 @@ type Organization {
 	created: Time!
 }
 
+type OrganizationMembership {
+	organizationId: ID!
+	role: AuthRole!
+	restrictions: OrganizationMembershipRestrictions
+	restrictionResources: OrganizationMembershipRestrictionResources
+}
+
+input OrganizationMembershipInput {
+	role: AuthRole!
+	restrictions: OrganizationMembershipRestrictionsInput
+}
+
+type OrganizationMembershipRestrictionResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+	environments: [Environment!]!
+}
+
+type OrganizationMembershipRestrictions {
+	clusterIds: IDFilterValue
+	serviceIds: IDFilterValue
+	namespaceIds: IDFilterValue
+	environmentIds: IDFilterValue
+}
+
+input OrganizationMembershipRestrictionsInput {
+	clusterIds: InputIDFilterValue
+	serviceIds: InputIDFilterValue
+	namespaceIds: InputIDFilterValue
+	environmentIds: InputIDFilterValue
+}
+
 type OrganizationSettings {
 	domains: [String!]
 	enforcedRegulations: [String!]
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [DefaultIntentsApprovalActionByEnv!]!
+	ignoreInternetIntents: Boolean
+	domainsDefaultRole: AuthRole!
+	defaultInviteMembership: OrganizationMembership!
 }
 
 input OrganizationSettingsInput {
@@ -2223,6 +2420,8 @@ input OrganizationSettingsInput {
 	enforcedRegulations: [String]
 	ignoredCloudDomains: [String!]
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
+	ignoreInternetIntents: Boolean
+	defaultInviteMembership: OrganizationMembershipInput
 }
 
 input PaginationInput {
@@ -2239,10 +2438,6 @@ enum PathType {
 	IMPLEMENTATION_SPECIFIC
 	PREFIX
 	EXACT
-}
-
-input PeerInput {
-	ipBlock: IpBlockInput!
 }
 
 input PortStatusInput {
@@ -2295,6 +2490,16 @@ type Query {
 		targetServiceId: ID!
 		lastSeenAfter: Time!
 	): [String!]!
+	edgeNetworkPolicies(
+		clientServiceId: ID!
+		serverServiceId: ID!
+	): [NetworkPolicy!]!
+""" Get edge connections count """
+	edgeConnectionsCount(
+		clientId: ID!
+		serverId: ID!
+		lastSeenAfter: Time!
+	): Int!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter
@@ -2420,6 +2625,13 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
+	networkPolicy(
+		id: ID!
+		filter: InputNetworkPolicyHitsFilter
+	): NetworkPolicy
+	networkPolicies(
+		filter: InputNetworkPolicyFilter
+	): [NetworkPolicy!]!
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2469,6 +2681,7 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
+	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
 		id: ID!
@@ -2508,6 +2721,9 @@ enum RegulationCode {
 	ZERO_TRUST_EGRESS_ACCESS_COVERED
 	ZERO_TRUST_EXTERNAL_INGRESS_TAGGED
 	ZERO_TRUST_ALL_INTRA_CLUSTER_ACCESS_COVERED
+	THREAT_INTELLIGENCE
+"""Detect known IOCs (IPs, domain names) against ingress and egress Internet traffic"""
+	THREAT_INTELLIGENCE_KNOWN_IOCS
 }
 
 enum RegulationStandard {
@@ -2515,6 +2731,7 @@ enum RegulationStandard {
 	PII
 	HIPAA
 	ZERO_TRUST
+	THREAT_INTELLIGENCE
 }
 
 input ReportServiceMetadataInput {
@@ -2537,6 +2754,44 @@ enum RowDiff {
 type RulesetsWithResources {
 	rulesets: [AccessApprovalRuleset!]!
 	resources: AccessApprovalRulesetResources!
+}
+
+type SIEMIntegrationTrigger {
+	isActive: Boolean!
+}
+
+input SIEMIntegrationTriggerInput {
+	isActive: Boolean!
+}
+
+type SIEMSettings {
+	isActive: Boolean!
+	syslogHostname: String!
+	syslogPort: Int!
+	syslogFacility: Int!
+	tlsConfiguration: TLSConfiguration
+	serviceTriggers: [SIEMTrigger!]!
+	findingTriggers: [SIEMTrigger!]!
+	integrationTriggers: SIEMIntegrationTrigger!
+}
+
+input SIEMSettingsInput {
+	isActive: Boolean!
+	syslogHostname: String!
+	syslogPort: Int!
+	syslogFacility: Int!
+	tlsConfiguration: TLSConfigurationInput
+	serviceTriggers: [SIEMTriggerInput!]!
+	findingTriggers: [SIEMTriggerInput!]!
+	integrationTriggers: SIEMIntegrationTriggerInput!
+}
+
+type SIEMTrigger {
+	filter: IntegrationAccessGraphFilter!
+}
+
+input SIEMTriggerInput {
+	filter: InputIntegrationAccessGraphFilter!
 }
 
 input SelectorKeyValueInput {
@@ -2622,6 +2877,7 @@ type Service {
 	aliases: [ServerAlias!]
 	namespace: Namespace
 	environment: Environment!
+	networkPolicies: [NetworkPolicy!]
 """If service is Kafka, its KafkaServerConfig."""
 	kafkaServerConfig: KafkaServerConfig
 	certificateInformation: CertificateInformation
@@ -2685,6 +2941,7 @@ input ServiceIdentityInput {
 	name: String!
 	namespace: String!
 	kind: String!
+	nameResolvedUsingAnnotation: Boolean
 }
 
 enum ServiceInternalTrafficPolicy {
@@ -2695,6 +2952,9 @@ enum ServiceInternalTrafficPolicy {
 input ServiceMetadataInput {
 	tags: [String!]
 	awsRoles: [String!]
+	labels: [LabelInput!]
+	podIps: [String!]
+	serviceIps: [String!]
 }
 
 enum ServiceType {
@@ -2786,6 +3046,17 @@ type StatusSummary {
 
 """The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
 scalar String
+
+type TLSConfiguration {
+	caCertificate: String
+	certificate: String
+}
+
+input TLSConfigurationInput {
+	caCertificate: String
+	certificate: String
+	key: String
+}
 
 enum TelemetryComponentType {
 	INTENTS_OPERATOR
@@ -2920,6 +3191,18 @@ enum UserErrorType {
 	CONFLICT
 	BAD_USER_INPUT
 	APPLIED_INTENTS_ERROR
+	TIMEOUT
+}
+
+input UserOrgMembershipInput {
+	userId: ID!
+	membership: OrganizationMembershipInput!
+}
+
+type UserOrganizationAssociation {
+	org: Organization!
+	user: User!
+	membership: OrganizationMembership!
 }
 
 type UserTutorial {


### PR DESCRIPTION
### Description
Added support for intents in strict mode. Webhook should enforce the following scenarios if strict mode is enabled:
* Internet intents should not allow wildcards
* Internet intents should not be allowed without port specified
* Only intents with type `Service` (or `kind: Service` in type `Kubernetes`) are allowed
 
### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
