### PR TITLE
[Prep for] Auto allow network traffic from control plane to webhook service

### DIFF
--- a/src/operator/api/v2alpha1/clientintents_types.go
+++ b/src/operator/api/v2alpha1/clientintents_types.go
@@ -64,6 +64,7 @@ const (
 	OtterizeNetworkPolicyExternalTraffic       = "intents.otterize.com/network-policy-external-traffic"
 	OtterizeNetPolMetricsCollectors            = "intents.otterize.com/network-policy-metrics-collectors"
 	OtterizeNetPolMetricsCollectorsLevel       = "intents.otterize.com/network-policy-metrics-collectors-level"
+	OtterizeNetworkPolicyWebhooks              = "intents.otterize.com/network-policy-webhooks"
 	ClientIntentsFinalizerName                 = "intents.otterize.com/client-intents-finalizer"
 	ProtectedServicesFinalizerName             = "intents.otterize.com/protected-services-finalizer"
 	OtterizeIstioClientAnnotationKeyDeprecated = "intents.otterize.com/istio-client"

--- a/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
@@ -41,7 +41,7 @@ func (r *CustomResourceDefinitionReconciler) InjectRecorder(recorder record.Even
 }
 
 func (r *CustomResourceDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
@@ -1,0 +1,50 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+type CustomResourceDefinitionReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewCustomResourceDefinitionReconciler(client client.Client, handler *NetworkPolicyHandler) *CustomResourceDefinitionReconciler {
+	return &CustomResourceDefinitionReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *CustomResourceDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiextensionsv1.CustomResourceDefinition{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *CustomResourceDefinitionReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *CustomResourceDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAll(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/endpoints_reconciler.go
@@ -1,0 +1,50 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=endpoints,verbs=get;list;watch
+
+type EndpointReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewEndpointReconciler(client client.Client, handler *NetworkPolicyHandler) *EndpointReconciler {
+	return &EndpointReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *EndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+	
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Endpoints{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *EndpointReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *EndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAll(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/endpoints_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/endpoints_reconciler.go
@@ -29,7 +29,7 @@ func NewEndpointReconciler(client client.Client, handler *NetworkPolicyHandler) 
 func (r *EndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	recorder := mgr.GetEventRecorderFor("intents-operator")
 	r.InjectRecorder(recorder)
-	
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Endpoints{}).
 		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
@@ -41,7 +41,7 @@ func (r *EndpointReconciler) InjectRecorder(recorder record.EventRecorder) {
 }
 
 func (r *EndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/mutating_webhooks_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/mutating_webhooks_reconciler.go
@@ -1,0 +1,50 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch
+
+type MutatingWebhookReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewMutatingWebhookReconciler(client client.Client, handler *NetworkPolicyHandler) *MutatingWebhookReconciler {
+	return &MutatingWebhookReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *MutatingWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&admissionv1.MutatingWebhookConfiguration{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *MutatingWebhookReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *MutatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAll(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/mutating_webhooks_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/mutating_webhooks_reconciler.go
@@ -41,7 +41,7 @@ func (r *MutatingWebhookReconciler) InjectRecorder(recorder record.EventRecorder
 }
 
 func (r *MutatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/network_policies_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/network_policies_reconciler.go
@@ -41,7 +41,7 @@ func (r *NetworkPoliciesReconciler) InjectRecorder(recorder record.EventRecorder
 }
 
 func (r *NetworkPoliciesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/network_policies_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/network_policies_reconciler.go
@@ -1,0 +1,50 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=networkpolicies,verbs=get;list;watch
+
+type NetworkPoliciesReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewNetworkPoliciesReconciler(client client.Client, handler *NetworkPolicyHandler) *NetworkPoliciesReconciler {
+	return &NetworkPoliciesReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *NetworkPoliciesReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.NetworkPolicy{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *NetworkPoliciesReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *NetworkPoliciesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAll(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/network_policy_handler.go
+++ b/src/operator/controllers/webhook_traffic/network_policy_handler.go
@@ -1,0 +1,373 @@
+package webhook_traffic
+
+import (
+	"context"
+	"fmt"
+	"github.com/otterize/intents-operator/src/operator/api/v2alpha1"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+const (
+	ReasonCreatingWebhookTrafficNetpol        = "CreatingNetworkPolicyForWebhook"
+	ReasonCreatingWebhookTrafficNetpolFailed  = "CreatingNetworkPolicyForWebhookFailed"
+	ReasonCreatingWebhookTrafficNetpolSuccess = "CreatingNetworkPolicyForWebhookSucceeded"
+	ReasonPatchingWebhookTrafficNetpol        = "PatchingNetworkPolicyForWebhook"
+	ReasonPatchingWebhookTrafficNetpolFailed  = "PatchingNetworkPolicyForWebhookFailed"
+	ReasonPatchingWebhookTrafficNetpolSuccess = "PatchingNetworkPolicyForWebhookSucceeded"
+)
+
+type WebhookClientConfigurationWithMeta struct {
+	clientConfiguration admissionv1.WebhookClientConfig
+	webhookName         string
+	webhook             runtime.Object
+}
+type NetworkPolicyWithMeta struct {
+	policy      *v1.NetworkPolicy
+	serviceName string
+	webhook     runtime.Object
+}
+type NetworkPolicyWithMetaByName map[string]*NetworkPolicyWithMeta
+type NetworkPolicyByName map[string]*v1.NetworkPolicy
+
+type NetworkPolicyHandler struct {
+	client client.Client
+	scheme *runtime.Scheme
+	injectablerecorder.InjectableRecorder
+	policy automate_third_party_network_policy.Enum
+}
+
+func NewNetworkPolicyHandler(
+	client client.Client,
+	scheme *runtime.Scheme,
+	policy automate_third_party_network_policy.Enum,
+) *NetworkPolicyHandler {
+	return &NetworkPolicyHandler{
+		client: client,
+		scheme: scheme,
+		policy: policy,
+	}
+}
+
+func (n *NetworkPolicyHandler) ReconcileAllValidatingWebhooksWebhooks(ctx context.Context) error {
+	validatingWebhookConfigurationList := &admissionv1.ValidatingWebhookConfigurationList{}
+	err := n.client.List(ctx, validatingWebhookConfigurationList)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	allClientConfigurations := make([]WebhookClientConfigurationWithMeta, 0)
+	for _, webhookConfiguration := range validatingWebhookConfigurationList.Items {
+		webhooksClientConfigurations := lo.Map(webhookConfiguration.Webhooks, func(webhook admissionv1.ValidatingWebhook, _ int) WebhookClientConfigurationWithMeta {
+			return WebhookClientConfigurationWithMeta{clientConfiguration: webhook.ClientConfig, webhookName: webhookConfiguration.Name, webhook: &webhookConfiguration}
+		})
+		allClientConfigurations = append(allClientConfigurations, webhooksClientConfigurations...)
+	}
+
+	err = n.reconcileWebhooks(ctx, allClientConfigurations)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (n *NetworkPolicyHandler) reconcileWebhooks(ctx context.Context, webhooksClientConfigs []WebhookClientConfigurationWithMeta) error {
+	reducedPolicies, err := n.reduceWebhooksNetpols(ctx, webhooksClientConfigs)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	existingPolicies, err := n.getExistingWebhooksNetpols(ctx)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	reducedPoliciesNames := lo.Keys(reducedPolicies)
+	currentNetworkPoliciesName := lo.Keys(existingPolicies)
+
+	policiesToAdd, policiesToDelete := lo.Difference(reducedPoliciesNames, currentNetworkPoliciesName)
+	policiesToUpdate := lo.Intersect(reducedPoliciesNames, currentNetworkPoliciesName)
+
+	err = n.handlePoliciesToAdd(ctx, policiesToAdd, reducedPolicies)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	err = n.handlePoliciesToDelete(ctx, policiesToDelete, existingPolicies)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	err = n.handlePoliciesToUpdate(ctx, policiesToUpdate, reducedPolicies)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+func (n *NetworkPolicyHandler) reduceWebhooksNetpols(ctx context.Context, webhooksClientConfigs []WebhookClientConfigurationWithMeta) (NetworkPolicyWithMetaByName, error) {
+	policiesByName := make(NetworkPolicyWithMetaByName)
+	
+	for _, webhookClientConfig := range webhooksClientConfigs {
+		if webhookClientConfig.clientConfiguration.Service != nil {
+			service, serviceFound, err := n.getWebhookService(ctx, webhookClientConfig.clientConfiguration.Service)
+			if err != nil {
+				return make(NetworkPolicyWithMetaByName), errors.Wrap(err)
+			}
+
+			if !serviceFound {
+				continue
+			}
+
+			// TODO: do we also need to create netpol for Otterize?
+			netpol, err := n.buildNetworkPolicy(ctx, webhookClientConfig.webhookName, webhookClientConfig.clientConfiguration.Service, service)
+			if err != nil {
+				return make(NetworkPolicyWithMetaByName), errors.Wrap(err)
+			}
+
+			existingNetpol, foundExistingNetpol := policiesByName[netpol.Name]
+			if foundExistingNetpol {
+				// merge existing netpol with the new one
+				netpol.Spec.Ingress[0].Ports = append(netpol.Spec.Ingress[0].Ports, existingNetpol.policy.Spec.Ingress[0].Ports...)
+			}
+
+			policiesByName[netpol.Name] = &NetworkPolicyWithMeta{serviceName: webhookClientConfig.clientConfiguration.Service.Name, policy: &netpol, webhook: webhookClientConfig.webhook}
+		}
+	}
+
+	// we want to make sure that the ports of the netpol will appear in the same order, for later policies comparison
+	n.dedupAndSortPorts(policiesByName)
+
+	return policiesByName, nil
+}
+
+func (n *NetworkPolicyHandler) dedupAndSortPorts(policiesByNames NetworkPolicyWithMetaByName) {
+	for _, netpol := range policiesByNames {
+		uniquePorts := lo.UniqBy(netpol.policy.Spec.Ingress[0].Ports, func(a v1.NetworkPolicyPort) string {
+			return a.Port.String()
+		})
+		slices.SortFunc(uniquePorts, func(a, b v1.NetworkPolicyPort) bool {
+			return a.Port.IntVal < b.Port.IntVal
+		})
+		netpol.policy.Spec.Ingress[0].Ports = uniquePorts
+	}
+}
+
+func (n *NetworkPolicyHandler) getWebhookService(ctx context.Context, webhookService *admissionv1.ServiceReference) (*corev1.Service, bool, error) {
+	service := &corev1.Service{}
+	err := n.client.Get(ctx, types.NamespacedName{Name: webhookService.Name, Namespace: webhookService.Namespace}, service)
+	if k8serrors.IsNotFound(err) {
+		// This is ok, the service might not exist yet, but the reconcile will be called when it does
+		return nil, false, nil
+	}
+
+	if err != nil {
+		return nil, false, errors.Wrap(err)
+	}
+
+	return service, true, nil
+}
+
+func (n *NetworkPolicyHandler) buildNetworkPolicy(ctx context.Context, webhookName string, webhookService *admissionv1.ServiceReference, service *corev1.Service) (v1.NetworkPolicy, error) {
+	policyName := fmt.Sprintf("webhook-%s-access-to-%s", strings.ToLower(webhookName), strings.ToLower(service.Name))
+
+	controlPLaneIP, err := n.getControlPlaneIPs(ctx)
+	if err != nil {
+		return v1.NetworkPolicy{}, errors.Wrap(err)
+	}
+
+	rule := v1.NetworkPolicyIngressRule{}
+
+	rule.From = append(rule.From, v1.NetworkPolicyPeer{
+		IPBlock: &v1.IPBlock{
+			// TODO: handle google cloud CIDR
+			CIDR: fmt.Sprintf("%s/32", controlPLaneIP),
+		},
+	})
+
+	newPolicy := v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: service.Namespace,
+			Labels: map[string]string{
+				v2alpha1.OtterizeNetworkPolicyWebhooks: webhookName,
+			},
+		},
+		Spec: v1.NetworkPolicySpec{
+			PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: service.Spec.Selector,
+			},
+			Ingress: []v1.NetworkPolicyIngressRule{
+				rule,
+			},
+		},
+	}
+
+	if webhookService.Port != nil {
+		newPolicy.Spec.Ingress[0].Ports = append(newPolicy.Spec.Ingress[0].Ports, v1.NetworkPolicyPort{
+			Port:     lo.ToPtr(intstr.IntOrString{IntVal: *webhookService.Port, Type: intstr.Int}),
+			Protocol: lo.ToPtr(corev1.ProtocolTCP),
+		})
+	}
+
+	return newPolicy, nil
+}
+
+func (n *NetworkPolicyHandler) getExistingWebhooksNetpols(ctx context.Context) (NetworkPolicyByName, error) {
+	otterizeWebhookNetpolSelector, err := metav1.LabelSelectorAsSelector(
+		&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      v2alpha1.OtterizeNetworkPolicyWebhooks,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+		})
+
+	if err != nil {
+		return make(NetworkPolicyByName), errors.Wrap(err)
+	}
+
+	networkPoliciesList := &v1.NetworkPolicyList{}
+	err = n.client.List(ctx, networkPoliciesList, client.MatchingLabelsSelector{Selector: otterizeWebhookNetpolSelector})
+	if err != nil {
+		return make(NetworkPolicyByName), errors.Wrap(err)
+	}
+
+	networkPolicies := make(NetworkPolicyByName)
+	for _, netpol := range networkPoliciesList.Items {
+		networkPolicies[netpol.Name] = &netpol
+	}
+
+	return networkPolicies, nil
+}
+
+func (n *NetworkPolicyHandler) getControlPlaneIPs(ctx context.Context) (string, error) {
+	var svc corev1.Service
+	err := n.client.Get(ctx, types.NamespacedName{Name: "kubernetes", Namespace: "default"}, &svc)
+	if err != nil {
+		return "", errors.Wrap(err)
+	}
+
+	// TODO: Do we also need to get the IPs of the service endpoints'?
+	return svc.Spec.ClusterIP, nil
+}
+
+func (n *NetworkPolicyHandler) policiesAreEqual(policy *v1.NetworkPolicy, otherPolicy *v1.NetworkPolicy) bool {
+	return reflect.DeepEqual(policy.Spec, otherPolicy.Spec) &&
+		reflect.DeepEqual(policy.Labels, otherPolicy.Labels) &&
+		reflect.DeepEqual(policy.Annotations, otherPolicy.Annotations)
+}
+
+func (n *NetworkPolicyHandler) handlePoliciesToAdd(ctx context.Context, policiesNamesToAdd []string, policiesByName NetworkPolicyWithMetaByName) error {
+	for _, policyName := range policiesNamesToAdd {
+		serviceName := policiesByName[policyName].serviceName
+		webhookRuntime := policiesByName[policyName].webhook
+		n.RecordNormalEventf(policiesByName[policyName].webhook, ReasonCreatingWebhookTrafficNetpol, "Creating network policy for serivice %s", serviceName)
+
+		err := n.client.Create(ctx, policiesByName[policyName].policy)
+		if err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				existingPolicy := &v1.NetworkPolicy{}
+				err = n.client.Get(ctx, types.NamespacedName{Name: policiesByName[policyName].policy.Name, Namespace: policiesByName[policyName].policy.Namespace}, existingPolicy)
+				if err != nil {
+					n.RecordWarningEventf(webhookRuntime, ReasonCreatingWebhookTrafficNetpolFailed, "Creating network policy for webhook for serivice %s failed with error: %s", serviceName, err.Error())
+					return errors.Wrap(err) // We could not add and update, so just give up
+				}
+				return n.updatePolicy(ctx, webhookRuntime, existingPolicy, policiesByName[policyName].policy)
+			}
+
+			n.RecordWarningEventf(webhookRuntime, ReasonCreatingWebhookTrafficNetpolFailed, "Creating network policy for webhook for serivice %s failed with error: %s", serviceName, err.Error())
+			return errors.Wrap(err)
+		}
+
+		n.RecordNormalEventf(webhookRuntime, ReasonCreatingWebhookTrafficNetpolSuccess, "Creating network policy for serivice %s succeed", serviceName)
+	}
+
+	return nil
+}
+
+func (n *NetworkPolicyHandler) handlePoliciesToDelete(ctx context.Context, policiesNamesToDelete []string, policiesByName NetworkPolicyByName) error {
+	for _, policyName := range policiesNamesToDelete {
+		err := n.client.Delete(ctx, policiesByName[policyName])
+		if k8serrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (n *NetworkPolicyHandler) handlePoliciesToUpdate(ctx context.Context, policiesNames []string, policiesByName NetworkPolicyWithMetaByName) error {
+	for _, policyName := range policiesNames {
+		webhookRuntime := policiesByName[policyName].webhook
+
+		existingPolicy := &v1.NetworkPolicy{}
+		err := n.client.Get(ctx, types.NamespacedName{Name: policyName, Namespace: policiesByName[policyName].policy.Namespace}, existingPolicy)
+
+		// No matching network policy found to update, try to create one
+		if k8serrors.IsNotFound(err) {
+			err = n.handlePoliciesToAdd(ctx, []string{policyName}, policiesByName)
+			if err != nil {
+				return errors.Wrap(err)
+			}
+			continue
+		}
+
+		if err != nil {
+			return errors.Wrap(err)
+		}
+
+		// Found existing matching policy, if it is identical to this one - do nothing
+		if n.policiesAreEqual(existingPolicy, policiesByName[policyName].policy) {
+			continue
+		}
+
+		err = n.updatePolicy(ctx, webhookRuntime, existingPolicy, policiesByName[policyName].policy)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (n *NetworkPolicyHandler) updatePolicy(ctx context.Context, webhookRuntime runtime.Object, existingPolicy *v1.NetworkPolicy, newPolicy *v1.NetworkPolicy) error {
+	policyCopy := existingPolicy.DeepCopy()
+	policyCopy.Labels = newPolicy.Labels
+	policyCopy.Annotations = newPolicy.Annotations
+	policyCopy.Spec = newPolicy.Spec
+
+	serviceName := policyCopy.Spec.PodSelector.MatchLabels["app"]
+	n.RecordNormalEventf(webhookRuntime, ReasonPatchingWebhookTrafficNetpol, "Patching network policy for webhook for serivce %s", serviceName)
+
+	err := n.client.Patch(ctx, policyCopy, client.MergeFrom(existingPolicy))
+	if err != nil {
+		n.RecordWarningEventf(webhookRuntime, ReasonPatchingWebhookTrafficNetpolFailed, "Patching network policy for webhook for serivce %s failed with error: %s", serviceName, err.Error())
+		return errors.Wrap(err)
+	}
+
+	n.RecordNormalEventf(webhookRuntime, ReasonPatchingWebhookTrafficNetpolSuccess, "Patching network policy for webhook for serivce %s succeed", serviceName)
+
+	return nil
+}

--- a/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
+++ b/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
@@ -1,0 +1,212 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/operator/api/v2alpha1"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
+	"github.com/otterize/intents-operator/src/shared/testbase"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+const (
+	TestServiceName    = "test-service"
+	TestServicePort    = 2345
+	TestNamespace      = "test-namespace"
+	TestWebhookName    = "test-webhook"
+	TestServicePodName = "test-service-pod"
+	TestControlPlaneIP = "111.222.333.4"
+)
+
+type NetworkPolicyHandlerTestSuite struct {
+	testbase.MocksSuiteBase
+	handler *NetworkPolicyHandler
+
+	validatingWebhook *admissionv1.ValidatingWebhookConfiguration
+	webhookService    *corev1.Service
+	serviceEndpoints  *corev1.Endpoints
+	servicePod        *corev1.Pod
+}
+
+func (s *NetworkPolicyHandlerTestSuite) SetupTest() {
+	s.MocksSuiteBase.SetupTest()
+	s.handler = NewNetworkPolicyHandler(s.Client, &runtime.Scheme{}, automate_third_party_network_policy.IfBlockedByOtterize)
+	s.handler.InjectRecorder(s.Recorder)
+
+	s.validatingWebhook = &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestWebhookName,
+		},
+		Webhooks: []admissionv1.ValidatingWebhook{
+			{
+				ClientConfig: admissionv1.WebhookClientConfig{
+					Service: &admissionv1.ServiceReference{
+						Name:      TestServiceName,
+						Namespace: TestNamespace,
+						Port:      lo.ToPtr(int32(TestServicePort)),
+					},
+				},
+			},
+		},
+	}
+
+	s.webhookService = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestServiceName,
+			Namespace: TestNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"Taylor": "Swift",
+			},
+		},
+	}
+
+	s.serviceEndpoints = &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						TargetRef: &corev1.ObjectReference{
+							Kind:      "Pod",
+							Name:      TestServicePodName,
+							Namespace: TestNamespace,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.servicePod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestServicePodName,
+			Namespace: TestNamespace,
+			Labels: map[string]string{
+				v2alpha1.OtterizeServiceLabelKey: TestServiceName,
+			},
+		},
+	}
+}
+
+func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlockedByOtterize_ServiceIsBlockedByOtterize_CreatingWebhookPolicy() {
+	s.mockForReturningValidatingWebhook()
+	s.mockReturningWebhookService()
+	s.mockServiceIsBlockedByOtterize()
+	s.mockGetControlPlaneIPs()
+	s.mockGetExistingOtterizeWebhooksNetpols([]v1.NetworkPolicy{})
+
+	netpolMatcher := NewNetworkPolicyMatcher()
+	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
+	err := s.handler.ReconcileAllValidatingWebhooksWebhooks(context.Background())
+	s.Require().NoError(err)
+	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
+	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
+}
+
+func (s *NetworkPolicyHandlerTestSuite) mockForReturningValidatingWebhook() {
+	s.Client.EXPECT().List(
+		gomock.Any(), gomock.Eq(&admissionv1.ValidatingWebhookConfigurationList{}),
+	).DoAndReturn(
+		func(_ any, list *admissionv1.ValidatingWebhookConfigurationList, _ ...any) error {
+			list.Items = []admissionv1.ValidatingWebhookConfiguration{*s.validatingWebhook}
+			return nil
+		},
+	)
+}
+
+func (s *NetworkPolicyHandlerTestSuite) mockReturningWebhookService() {
+	s.Client.EXPECT().Get(
+		gomock.Any(), gomock.Eq(types.NamespacedName{Name: TestServiceName, Namespace: TestNamespace}), gomock.Eq(&corev1.Service{}),
+	).DoAndReturn(
+		func(_ any, _ any, svc *corev1.Service, _ ...any) error {
+			s.webhookService.DeepCopyInto(svc)
+			return nil
+		},
+	)
+}
+
+func (s *NetworkPolicyHandlerTestSuite) mockServiceIsBlockedByOtterize() {
+	// Get service endpoints
+	s.Client.EXPECT().Get(
+		gomock.Any(), gomock.Eq(types.NamespacedName{Name: TestServiceName, Namespace: TestNamespace}), gomock.Eq(&corev1.Endpoints{}),
+	).DoAndReturn(
+		func(_ any, _ any, endpoints *corev1.Endpoints, _ ...any) error {
+			s.serviceEndpoints.DeepCopyInto(endpoints)
+			return nil
+		},
+	)
+
+	// Get endpoints pods
+	s.Client.EXPECT().Get(
+		gomock.Any(), gomock.Eq(types.NamespacedName{Name: TestServicePodName, Namespace: TestNamespace}), gomock.Eq(&corev1.Pod{}),
+	).DoAndReturn(
+		func(_ any, _ any, pod *corev1.Pod, _ ...any) error {
+			s.servicePod.DeepCopyInto(pod)
+			return nil
+		},
+	)
+
+	// Pod has network policy
+	s.Client.EXPECT().List(
+		gomock.Any(), gomock.Eq(&v1.NetworkPolicyList{}), gomock.Any(),
+	).DoAndReturn(
+		func(_ any, netpolList *v1.NetworkPolicyList, _ ...any) error {
+			netpolList.Items = []v1.NetworkPolicy{
+				{
+					Spec: v1.NetworkPolicySpec{
+						PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+					},
+				},
+			}
+			return nil
+		},
+	)
+	// Other 2 calls for network policies
+	s.Client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+}
+
+func (s *NetworkPolicyHandlerTestSuite) mockGetControlPlaneIPs() {
+	s.Client.EXPECT().Get(
+		gomock.Any(), gomock.Eq(types.NamespacedName{Name: "kubernetes", Namespace: "default"}), gomock.Eq(&corev1.Service{}),
+	).DoAndReturn(
+		func(_ any, _ any, svc *corev1.Service, _ ...any) error {
+			svc.Spec.ClusterIP = TestControlPlaneIP
+			return nil
+		},
+	)
+}
+
+func (s *NetworkPolicyHandlerTestSuite) mockGetExistingOtterizeWebhooksNetpols(netpols []v1.NetworkPolicy) {
+	otterizeWebhookNetpolSelector, err := metav1.LabelSelectorAsSelector(
+		&metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      v2alpha1.OtterizeNetworkPolicyWebhooks,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+		})
+	s.Require().NoError(err)
+
+	s.Client.EXPECT().List(
+		gomock.Any(), gomock.Eq(&v1.NetworkPolicyList{}), gomock.Eq(client.MatchingLabelsSelector{Selector: otterizeWebhookNetpolSelector}),
+	).DoAndReturn(
+		func(_ any, netpolList *v1.NetworkPolicyList, _ ...any) error {
+			netpolList.Items = netpols
+			return nil
+		},
+	)
+}
+
+func TestNetworkPolicyHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(NetworkPolicyHandlerTestSuite))
+}

--- a/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
+++ b/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
@@ -156,7 +156,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -191,7 +191,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -227,7 +227,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{secondPort, TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -243,7 +243,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	//netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	//s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -259,7 +259,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Patch(gomock.Any(), gomock.All(netpolMatcher), gomock.Any()).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonPatchingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonPatchingWebhookTrafficNetpolSuccess)
@@ -274,7 +274,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleIfBlocked
 
 	//netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	//s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -291,7 +291,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleOff_Servi
 
 	//netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	//s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -308,7 +308,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleOff_Servi
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Delete(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	//s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -326,7 +326,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_HandleAlways_Se
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -341,7 +341,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_MutatingWebhook
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)
@@ -356,7 +356,7 @@ func (s *NetworkPolicyHandlerTestSuite) TestNetworkPolicyHandler_CRDsWebhooks_Ha
 
 	netpolMatcher := NewNetworkPolicyMatcher([]int32{TestServicePort})
 	s.Client.EXPECT().Create(gomock.Any(), gomock.All(netpolMatcher)).Return(nil)
-	err := s.handler.ReconcileAll(context.Background())
+	err := s.handler.HandleAll(context.Background())
 	s.Require().NoError(err)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpol)
 	s.ExpectEvent(ReasonCreatingWebhookTrafficNetpolSuccess)

--- a/src/operator/controllers/webhook_traffic/network_policy_handler_utils_test.go
+++ b/src/operator/controllers/webhook_traffic/network_policy_handler_utils_test.go
@@ -1,0 +1,65 @@
+package webhook_traffic
+
+import (
+	"fmt"
+	"github.com/otterize/intents-operator/src/operator/api/v2alpha1"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+)
+
+var ExpectedNetpol = v1.NetworkPolicy{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: TestNamespace,
+		Name:      "webhook-test-webhook-access-to-test-service",
+		Labels:    map[string]string{v2alpha1.OtterizeNetworkPolicyWebhooks: TestWebhookName},
+	},
+	Spec: v1.NetworkPolicySpec{
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"Taylor": "Swift"},
+		},
+		Ingress: []v1.NetworkPolicyIngressRule{
+			{
+				Ports: []v1.NetworkPolicyPort{{
+					Protocol: lo.ToPtr(corev1.ProtocolTCP),
+					Port:     lo.ToPtr(intstr.IntOrString{Type: intstr.Int, IntVal: TestServicePort}),
+				}},
+				From: []v1.NetworkPolicyPeer{
+					{
+						IPBlock: &v1.IPBlock{
+							CIDR: fmt.Sprintf("%s/32", TestControlPlaneIP),
+						},
+					},
+				},
+			},
+		},
+		PolicyTypes: []v1.PolicyType{v1.PolicyTypeIngress},
+	},
+}
+
+type NetworkPolicyMatcher struct {
+}
+
+func NewNetworkPolicyMatcher() *NetworkPolicyMatcher {
+	return &NetworkPolicyMatcher{}
+}
+
+func (m *NetworkPolicyMatcher) String() string {
+	return fmt.Sprintf("%v", &ExpectedNetpol)
+}
+
+func (m *NetworkPolicyMatcher) Matches(other interface{}) bool {
+	otherAsNetpol, ok := other.(*v1.NetworkPolicy)
+	if !ok {
+		return false
+	}
+
+	return otherAsNetpol.Namespace == TestNamespace &&
+		otherAsNetpol.Name == ExpectedNetpol.Name &&
+		reflect.DeepEqual(otherAsNetpol.Labels, ExpectedNetpol.Labels) &&
+		reflect.DeepEqual(otherAsNetpol.Spec, ExpectedNetpol.Spec)
+}

--- a/src/operator/controllers/webhook_traffic/services_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/services_reconciler.go
@@ -41,7 +41,7 @@ func (r *ServicesReconciler) InjectRecorder(recorder record.EventRecorder) {
 }
 
 func (r *ServicesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/services_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/services_reconciler.go
@@ -1,0 +1,50 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=services,verbs=get;list;watch
+
+type ServicesReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewServicesReconciler(client client.Client, handler *NetworkPolicyHandler) *ServicesReconciler {
+	return &ServicesReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *ServicesReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *ServicesReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *ServicesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAll(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
@@ -42,7 +42,7 @@ func (r *ValidatingWebhookReconciler) InjectRecorder(recorder record.EventRecord
 }
 
 func (r *ValidatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAllValidatingWebhooksWebhooks(ctx)
+	err := r.handler.ReconcileAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
@@ -42,7 +42,7 @@ func (r *ValidatingWebhookReconciler) InjectRecorder(recorder record.EventRecord
 }
 
 func (r *ValidatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := r.handler.ReconcileAll(ctx)
+	err := r.handler.HandleAll(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/validating_webhooks_reconciler.go
@@ -1,0 +1,51 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"github.com/samber/lo"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch
+
+type ValidatingWebhookReconciler struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+}
+
+func NewValidatingWebhookReconciler(client client.Client, handler *NetworkPolicyHandler) *ValidatingWebhookReconciler {
+	return &ValidatingWebhookReconciler{
+		Client:  client,
+		handler: handler,
+	}
+}
+
+func (r *ValidatingWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+	r.handler.InjectRecorder(recorder)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&admissionv1.ValidatingWebhookConfiguration{}).
+		WithOptions(controller.Options{RecoverPanic: lo.ToPtr(true)}).
+		Complete(r)
+}
+
+func (r *ValidatingWebhookReconciler) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}
+
+func (r *ValidatingWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	err := r.handler.ReconcileAllValidatingWebhooksWebhooks(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/src/operator/controllers/webhook_traffic/webhook_traffic_reconciler_manager.go
+++ b/src/operator/controllers/webhook_traffic/webhook_traffic_reconciler_manager.go
@@ -1,0 +1,57 @@
+package webhook_traffic
+
+import (
+	"context"
+	"github.com/otterize/intents-operator/src/shared/errors"
+	"github.com/otterize/intents-operator/src/shared/injectablerecorder"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WebhookTrafficReconciler interface {
+	SetupWithManager(mgr ctrl.Manager) error
+	InjectRecorder(recorder record.EventRecorder)
+	Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
+}
+
+type WebhookTrafficReconcilerManager struct {
+	client.Client
+	injectablerecorder.InjectableRecorder
+	handler *NetworkPolicyHandler
+
+	reconcilers []WebhookTrafficReconciler
+}
+
+func NewWebhookTrafficReconcilerManager(client client.Client, handler *NetworkPolicyHandler) *WebhookTrafficReconcilerManager {
+	return &WebhookTrafficReconcilerManager{
+		Client:  client,
+		handler: handler,
+		reconcilers: []WebhookTrafficReconciler{
+			NewMutatingWebhookReconciler(client, handler),
+			NewValidatingWebhookReconciler(client, handler),
+			NewCustomResourceDefinitionReconciler(client, handler),
+			NewEndpointReconciler(client, handler),
+			NewServicesReconciler(client, handler),
+			NewNetworkPoliciesReconciler(client, handler),
+		},
+	}
+}
+
+func (r *WebhookTrafficReconcilerManager) SetupWithManager(mgr ctrl.Manager) error {
+	recorder := mgr.GetEventRecorderFor("intents-operator")
+	r.InjectRecorder(recorder)
+	r.handler.InjectRecorder(recorder)
+
+	for _, reconciler := range r.reconcilers {
+		if err := reconciler.SetupWithManager(mgr); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *WebhookTrafficReconcilerManager) InjectRecorder(recorder record.EventRecorder) {
+	r.Recorder = recorder
+}

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/otterize/intents-operator/src/shared/k8sconf"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig"
+	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -239,7 +240,8 @@ func main() {
 
 	webhooksTrafficNetworkHandler := webhook_traffic.NewNetworkPolicyHandler(mgr.GetClient(),
 		scheme,
-		enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
+		automate_third_party_network_policy.Off,
+		//enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
 		viper.GetInt(operatorconfig.ControlPlaneIPv4CidrPrefixLength))
 	webhookTrafficReconcilerManager := webhook_traffic.NewWebhookTrafficReconcilerManager(mgr.GetClient(), webhooksTrafficNetworkHandler)
 

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -237,7 +237,10 @@ func main() {
 			make([]networkpolicy.EgressRuleBuilder, 0))
 	epGroupReconciler := effectivepolicy.NewGroupReconciler(mgr.GetClient(), scheme, serviceIdResolver, epNetpolReconciler)
 
-	webhooksTrafficNetworkHandler := webhook_traffic.NewNetworkPolicyHandler(mgr.GetClient(), scheme, enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
+	webhooksTrafficNetworkHandler := webhook_traffic.NewNetworkPolicyHandler(mgr.GetClient(),
+		scheme,
+		enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
+		viper.GetInt(operatorconfig.ControlPlaneIPv4CidrPrefixLength))
 	webhookTrafficReconcilerManager := webhook_traffic.NewWebhookTrafficReconcilerManager(mgr.GetClient(), webhooksTrafficNetworkHandler)
 
 	if enforcementConfig.EnableLinkerdPolicies {

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -238,7 +238,7 @@ func main() {
 	epGroupReconciler := effectivepolicy.NewGroupReconciler(mgr.GetClient(), scheme, serviceIdResolver, epNetpolReconciler)
 
 	webhooksTrafficNetworkHandler := webhook_traffic.NewNetworkPolicyHandler(mgr.GetClient(), scheme, enforcementConfig.GetAutomateThirdPartyNetworkPolicy())
-	validatingWebhookTrafficReconciler := webhook_traffic.NewValidatingWebhookReconciler(mgr.GetClient(), webhooksTrafficNetworkHandler)
+	webhookTrafficReconcilerManager := webhook_traffic.NewWebhookTrafficReconcilerManager(mgr.GetClient(), webhooksTrafficNetworkHandler)
 
 	if enforcementConfig.EnableLinkerdPolicies {
 		epGroupReconciler.AddReconciler(intents_reconcilers.NewLinkerdReconciler(mgr.GetClient(), scheme, watchedNamespaces, enforcementConfig.EnforcementDefaultState))
@@ -452,7 +452,7 @@ func main() {
 		logrus.WithError(err).Panic("unable to create controller", "controller", "NetworkPolicy")
 	}
 
-	if err = validatingWebhookTrafficReconciler.SetupWithManager(mgr); err != nil {
+	if err = webhookTrafficReconcilerManager.SetupWithManager(mgr); err != nil {
 		logrus.WithError(err).Panic("unable to create controller", "controller", "Webhooks")
 	}
 

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -66,6 +66,8 @@ const (
 	SeparateNetpolsForIngressAndEgress            = "separate-netpols-for-ingress-and-egress"
 	SeparateNetpolsForIngressAndEgressDefault     = false
 	ExternallyManagedPolicyWorkloadsKey           = "externallyManagedPolicyWorkloads"
+	ControlPlaneIPv4CidrPrefixLength              = "control-plane-ipv4-cidr-prefix-length"
+	ControlPlaneIPv4CidrPrefixLengthDefault       = 32
 )
 
 func init() {
@@ -89,6 +91,7 @@ func init() {
 	viper.SetDefault(SeparateNetpolsForIngressAndEgress, SeparateNetpolsForIngressAndEgressDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRPeersLimitKey, EnableGroupInternetIPsByCIDRPeersLimitDefault)
+	viper.SetDefault(ControlPlaneIPv4CidrPrefixLength, ControlPlaneIPv4CidrPrefixLengthDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
### Description
Based on the `AutomateThirdPartyNetworkPolicy` configuration, we will create a network policy to allow communication from the control plane to a webhook service.
This kind of communication is important, because if blocked - it may cause a lot of damage in the cluster, such as pods not being able to start.

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
