### PR TITLE
[Prep for] Auto allow webhook traffic - support reporting AutomatedThirdPartyPolicyTypes to Otterize cloud for shadow mode support in cloud

### DIFF
--- a/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
+++ b/src/operator/controllers/webhook_traffic/custom_resource_definition_reconciler.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+//+kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 
 type CustomResourceDefinitionReconciler struct {
 	client.Client

--- a/src/shared/operator_cloud_client/status_report.go
+++ b/src/shared/operator_cloud_client/status_report.go
@@ -162,6 +162,11 @@ func uploadConfiguration(ctx context.Context, client CloudClient, mgr manager.Ma
 	})
 
 	configInput.AwsALBLoadBalancerExemptionEnabled = viper.GetBool(operatorconfig.IngressControllerALBExemptKey)
+	configInput.AutomatedThirdPartyPolicyTypes = []graphqlclient.AutomatedThirdPartyPolicyTypes{
+		graphqlclient.AutomatedThirdPartyPolicyTypesExternalTraffic,
+		graphqlclient.AutomatedThirdPartyPolicyTypesMetricsTraffic,
+		graphqlclient.AutomatedThirdPartyPolicyTypesWebhookTraffic,
+	}
 
 	client.ReportIntentsOperatorConfiguration(timeoutCtx, configInput)
 }

--- a/src/shared/otterizecloud/graphqlclient/generated.go
+++ b/src/shared/otterizecloud/graphqlclient/generated.go
@@ -26,6 +26,14 @@ const (
 	AutomateThirdPartyNetworkPolicyIfBlockedByOtterize AutomateThirdPartyNetworkPolicy = "IF_BLOCKED_BY_OTTERIZE"
 )
 
+type AutomatedThirdPartyPolicyTypes string
+
+const (
+	AutomatedThirdPartyPolicyTypesExternalTraffic AutomatedThirdPartyPolicyTypes = "EXTERNAL_TRAFFIC"
+	AutomatedThirdPartyPolicyTypesMetricsTraffic  AutomatedThirdPartyPolicyTypes = "METRICS_TRAFFIC"
+	AutomatedThirdPartyPolicyTypesWebhookTraffic  AutomatedThirdPartyPolicyTypes = "WEBHOOK_TRAFFIC"
+)
+
 type AzureKeyVaultPolicyInput struct {
 	CertificatePermissions []*string `json:"certificatePermissions"`
 	KeyPermissions         []*string `json:"keyPermissions"`
@@ -449,6 +457,7 @@ type IntentsOperatorConfigurationInput struct {
 	ExternallyManagedPolicyWorkloads      []ExternallyManagedPolicyWorkloadInput `json:"externallyManagedPolicyWorkloads"`
 	AutomateThirdPartyNetworkPolicies     AutomateThirdPartyNetworkPolicy        `json:"automateThirdPartyNetworkPolicies"`
 	PrometheusServerConfigs               []PrometheusServerConfigInput          `json:"prometheusServerConfigs"`
+	AutomatedThirdPartyPolicyTypes        []AutomatedThirdPartyPolicyTypes       `json:"automatedThirdPartyPolicyTypes"`
 }
 
 // GetGlobalEnforcementEnabled returns IntentsOperatorConfigurationInput.GlobalEnforcementEnabled, and is useful for accessing the field via an interface.
@@ -547,6 +556,11 @@ func (v *IntentsOperatorConfigurationInput) GetAutomateThirdPartyNetworkPolicies
 // GetPrometheusServerConfigs returns IntentsOperatorConfigurationInput.PrometheusServerConfigs, and is useful for accessing the field via an interface.
 func (v *IntentsOperatorConfigurationInput) GetPrometheusServerConfigs() []PrometheusServerConfigInput {
 	return v.PrometheusServerConfigs
+}
+
+// GetAutomatedThirdPartyPolicyTypes returns IntentsOperatorConfigurationInput.AutomatedThirdPartyPolicyTypes, and is useful for accessing the field via an interface.
+func (v *IntentsOperatorConfigurationInput) GetAutomatedThirdPartyPolicyTypes() []AutomatedThirdPartyPolicyTypes {
+	return v.AutomatedThirdPartyPolicyTypes
 }
 
 type InternetConfigInput struct {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -313,6 +313,12 @@ enum AutomateThirdPartyNetworkPolicy {
 	IF_BLOCKED_BY_OTTERIZE
 }
 
+enum AutomatedThirdPartyPolicyTypes {
+	EXTERNAL_TRAFFIC
+	METRICS_TRAFFIC
+	WEBHOOK_TRAFFIC
+}
+
 enum AwsIamStep {
 	CREATE_CLUSTER
 	CONNECT_CLUSTER
@@ -1600,6 +1606,7 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
+	automatedThirdPartyPolicyTypes: [AutomatedThirdPartyPolicyTypes!]
 }
 
 type IntentsOperatorState {
@@ -1791,6 +1798,14 @@ enum K8sServiceType {
 	NODE_PORT
 	LOAD_BALANCER
 	EXTERNAL_NAME
+}
+
+input K8sWebhookServiceInput {
+	otterizeName: String!
+	serviceName: String!
+	namespace: String!
+	webhookName: String!
+	webhookType: WebhookType!
 }
 
 type KafkaConfig {
@@ -2192,6 +2207,9 @@ type Mutation {
 		namespace: String!
 		reason: EligibleForMetricsCollectionReason!
 		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
+	reportK8sWebhookServices(
+		services: [K8sWebhookServiceInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
@@ -3275,6 +3293,12 @@ type ValidIDFilter {
 	namespaceIds: IDFilterValue
 	regulationIds: IDFilterValue
 	environmentIds: IDFilterValue
+}
+
+enum WebhookType {
+	VALIDATING_WEBHOOK
+	MUTATING_WEBHOOK
+	CONVERSION_WEBHOOK
 }
 
 type Workload {

--- a/src/shared/otterizecloud/graphqlclient/schema.graphql
+++ b/src/shared/otterizecloud/graphqlclient/schema.graphql
@@ -624,7 +624,7 @@ enum CustomConstraint {
 }
 
 input DNSIPPairInput {
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 }
 
@@ -1610,7 +1610,7 @@ type IntentsOperatorState {
 
 type InternetConfig {
 	appliedDomains: [String!]
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 	ports: [Int!]
 }

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -313,6 +313,12 @@ enum AutomateThirdPartyNetworkPolicy {
 	IF_BLOCKED_BY_OTTERIZE
 }
 
+enum AutomatedThirdPartyPolicyTypes {
+	EXTERNAL_TRAFFIC
+	METRICS_TRAFFIC
+	WEBHOOK_TRAFFIC
+}
+
 enum AwsIamStep {
 	CREATE_CLUSTER
 	CONNECT_CLUSTER
@@ -1600,6 +1606,7 @@ input IntentsOperatorConfigurationInput {
 	externallyManagedPolicyWorkloads: [ExternallyManagedPolicyWorkloadInput!]
 	automateThirdPartyNetworkPolicies: AutomateThirdPartyNetworkPolicy
 	prometheusServerConfigs: [PrometheusServerConfigInput!]
+	automatedThirdPartyPolicyTypes: [AutomatedThirdPartyPolicyTypes!]
 }
 
 type IntentsOperatorState {
@@ -1791,6 +1798,14 @@ enum K8sServiceType {
 	NODE_PORT
 	LOAD_BALANCER
 	EXTERNAL_NAME
+}
+
+input K8sWebhookServiceInput {
+	otterizeName: String!
+	serviceName: String!
+	namespace: String!
+	webhookName: String!
+	webhookType: WebhookType!
 }
 
 type KafkaConfig {
@@ -2192,6 +2207,9 @@ type Mutation {
 		namespace: String!
 		reason: EligibleForMetricsCollectionReason!
 		resources: [K8sResourceEligibleForMetricsCollectionInput!]!
+	): Boolean!
+	reportK8sWebhookServices(
+		services: [K8sWebhookServiceInput!]!
 	): Boolean!
 	reportKafkaServerConfigs(
 		namespace: String!
@@ -3275,6 +3293,12 @@ type ValidIDFilter {
 	namespaceIds: IDFilterValue
 	regulationIds: IDFilterValue
 	environmentIds: IDFilterValue
+}
+
+enum WebhookType {
+	VALIDATING_WEBHOOK
+	MUTATING_WEBHOOK
+	CONVERSION_WEBHOOK
 }
 
 type Workload {

--- a/src/shared/telemetries/telemetriesgql/schema.graphql
+++ b/src/shared/telemetries/telemetriesgql/schema.graphql
@@ -154,6 +154,7 @@ input AWSVisibilitySettingsInput {
 
 type AccessApprovalRuleset {
 	id: ID!
+	order: Int!
 	origin: AccessApprovalRulesetFilter!
 	target: AccessApprovalRulesetFilter!
 	action: AccessApprovalRulesetAction!
@@ -299,6 +300,11 @@ type AppliedIntentsRequestWithDetails {
 enum AuthRole {
 	ADMIN
 	VIEWER
+}
+
+type AutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
 }
 
 enum AutomateThirdPartyNetworkPolicy {
@@ -618,7 +624,7 @@ enum CustomConstraint {
 }
 
 input DNSIPPairInput {
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 }
 
@@ -884,6 +890,7 @@ type FeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 type Finding {
@@ -1004,12 +1011,14 @@ type GitHubRepoInfo {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 input GitHubRepoInfoInput {
 	repository: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitHubSettings {
@@ -1044,6 +1053,7 @@ input GitLabRepoInfoInput {
 	projectPath: String!
 	baseBranch: String!
 	intentsPath: String!
+	terraformPath: String
 }
 
 type GitLabSettings {
@@ -1117,6 +1127,7 @@ input IncomingTrafficIntentInput {
 	serverName: String!
 	namespace: String!
 	source: IncomingInternetSourceInput!
+	connectionsCount: ConnectionsCount
 }
 
 input IngressControllerConfigInput {
@@ -1129,6 +1140,8 @@ input IngressControllerConfigInput {
 input InputAccessApprovalRuleset {
 """Ruleset"""
 	id: ID!
+"""Ruleset"""
+	order: Int!
 """Ruleset"""
 	origin: InputAccessApprovalRulesetConfigFilter!
 """Ruleset"""
@@ -1208,6 +1221,11 @@ input InputAppliedIntentsRequestFilter {
 	approvalStatuses: InputIDFilterValue
 }
 
+input InputAutoApproveMoreRestrictiveIntentsByEnv {
+	environmentId: ID!
+	enabled: Boolean!
+}
+
 input InputDefaultIntentsApprovalActionByEnv {
 	environmentId: ID!
 	action: AccessApprovalRulesetAction!
@@ -1221,6 +1239,7 @@ input InputFeatureFlags {
 	useTypedIntentsCTE: Boolean
 	enableInternetIntentsSuggestions: Boolean
 	enableIAMIntentsSuggestions: Boolean
+	enableNetworkPoliciesInAccessGraph: Boolean
 }
 
 """ Findings filter """
@@ -1289,6 +1308,11 @@ input InputNumericFilterValue {
 	operator: NumericFilterOperators!
 }
 
+input InputOffsetPagination {
+	page: Int
+	size: Int
+}
+
 input InputResourceInventoryFilter {
 	serviceIds: InputIDFilterValue
 	environmentIds: InputIDFilterValue
@@ -1312,15 +1336,21 @@ input InputServiceFilter {
 	integrationIds: [ID!]
 }
 
+input InputTerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 input InputTerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 input InputTerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [InputTerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [InputTerraformAwsPolicyInfo!]
 }
 
@@ -1541,10 +1571,12 @@ type IntentsOperatorConfiguration {
 	gcpIAMPolicyEnforcementEnabled: Boolean!
 	azureIAMPolicyEnforcementEnabled: Boolean!
 	databaseEnforcementEnabled: Boolean!
+	strictModeEnabled: Boolean!
 	protectedServicesEnabled: Boolean!
 	protectedServices: [Service!]!
 	egressNetworkPolicyEnforcementEnabled: Boolean!
 	enforcedNamespaces: [String!]
+	excludedStrictModeNamespaces: [String!]
 }
 
 input IntentsOperatorConfigurationInput {
@@ -1559,6 +1591,8 @@ input IntentsOperatorConfigurationInput {
 	gcpIAMPolicyEnforcementEnabled: Boolean
 	azureIAMPolicyEnforcementEnabled: Boolean
 	databaseEnforcementEnabled: Boolean
+	strictModeEnabled: Boolean
+	excludedStrictModeNamespaces: [String!]
 	enforcedNamespaces: [String!]
 	ingressControllerConfig: [IngressControllerConfigInput!]
 	awsALBLoadBalancerExemptionEnabled: Boolean
@@ -1576,7 +1610,7 @@ type IntentsOperatorState {
 
 type InternetConfig {
 	appliedDomains: [String!]
-	dnsName: String!
+	dnsName: String
 	ips: [String!]
 	ports: [Int!]
 }
@@ -2287,6 +2321,11 @@ type NetworkMapperComponent {
 	status: ComponentStatus!
 }
 
+type NetworkPoliciesPage {
+	data: [NetworkPolicy!]!
+	meta: PaginationMeta
+}
+
 enum NetworkPoliciesStep {
 """Connect cluster"""
 	CREATE_CLUSTER
@@ -2413,6 +2452,7 @@ type OrganizationSettings {
 	ignoreInternetIntents: Boolean
 	domainsDefaultRole: AuthRole!
 	defaultInviteMembership: OrganizationMembership!
+	autoApproveMoreRestrictiveIntentsByEnv: [AutoApproveMoreRestrictiveIntentsByEnv!]!
 }
 
 input OrganizationSettingsInput {
@@ -2422,6 +2462,7 @@ input OrganizationSettingsInput {
 	defaultIntentsApprovalActionByEnv: [InputDefaultIntentsApprovalActionByEnv!]
 	ignoreInternetIntents: Boolean
 	defaultInviteMembership: OrganizationMembershipInput
+	autoApproveMoreRestrictiveIntentsByEnv: [InputAutoApproveMoreRestrictiveIntentsByEnv!]
 }
 
 input PaginationInput {
@@ -2631,7 +2672,8 @@ type Query {
 	): NetworkPolicy
 	networkPolicies(
 		filter: InputNetworkPolicyFilter
-	): [NetworkPolicy!]!
+		pagination: InputOffsetPagination
+	): NetworkPoliciesPage
 """List organizations"""
 	organizations: [Organization!]!
 """Get organization"""
@@ -2749,6 +2791,7 @@ type Resource {
 enum RowDiff {
 	ADDED
 	REMOVED
+	STRICT_MODE_WARNING
 }
 
 type RulesetsWithResources {
@@ -2971,6 +3014,7 @@ enum ServiceType {
 	KUBERNETES_LOAD_BALANCER
 	AWS_VISIBILITY_EKS
 	DETECTED_CLOUD_SERVER
+	CONTROL_PLANE
 }
 
 type ServicesResponse {
@@ -3078,21 +3122,28 @@ input TelemetryInput {
 	data: TelemetryData!
 }
 
+type TerraformAwsInlinePolicyInfo {
+	name: String!
+	policy: String!
+}
+
 type TerraformAwsPolicyInfo {
 	arn: String!
+	policy: String!
 	address: String!
 }
 
 type TerraformAwsRoleInfo {
 	arn: String!
 	address: String!
-	inlinePolicy: String!
+	inlinePolicy: [TerraformAwsInlinePolicyInfo!]
 	attachedPolicies: [TerraformAwsPolicyInfo!]
 }
 
 type TerraformResourceInfo {
 	modulePath: String!
-	gitOriginUrl: String!
+	gitPlatform: String!
+	gitOrigin: String!
 	gitCommitHash: String!
 	awsRoles: [TerraformAwsRoleInfo!]
 }


### PR DESCRIPTION
### Description
Report the AutomatedThirdPartyPolicyTypes to Otterize cloud, so Otterize cloud would be able to support auto-allow-webhook-traffic in shadow mode.

### References
- [Reporting webhook services to Otterize cloud](https://github.com/otterize/network-mapper/pull/303)

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
