### PR TITLE
[Prep for] Auto allow webhook traffic - restrict traffic from control plane IP based on configuration & support IPv6 for control plane

### DIFF
--- a/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
+++ b/src/operator/controllers/webhook_traffic/network_policy_handler_test.go
@@ -25,7 +25,7 @@ const (
 	TestNamespace      = "test-namespace"
 	TestWebhookName    = "test-webhook"
 	TestServicePodName = "test-service-pod"
-	TestControlPlaneIP = "111.222.333.4"
+	TestControlPlaneIP = "11.22.33.4"
 )
 
 var OtterizeIngressNetpols = []v1.NetworkPolicy{
@@ -499,7 +499,7 @@ func (s *NetworkPolicyHandlerTestSuite) mockGetControlPlaneIPs() {
 		gomock.Any(), gomock.Eq(types.NamespacedName{Name: "kubernetes", Namespace: "default"}), gomock.Eq(&corev1.Service{}),
 	).DoAndReturn(
 		func(_ any, _ any, svc *corev1.Service, _ ...any) error {
-			svc.Spec.ClusterIP = TestControlPlaneIP
+			svc.Spec.ClusterIPs = []string{TestControlPlaneIP}
 			svc.Name = "kubernetes"
 			svc.Namespace = "default"
 			return nil

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -52,7 +52,6 @@ import (
 	"github.com/otterize/intents-operator/src/shared/k8sconf"
 	"github.com/otterize/intents-operator/src/shared/operator_cloud_client"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig"
-	"github.com/otterize/intents-operator/src/shared/operatorconfig/automate_third_party_network_policy"
 	"github.com/otterize/intents-operator/src/shared/operatorconfig/enforcement"
 	"github.com/otterize/intents-operator/src/shared/reconcilergroup"
 	"github.com/otterize/intents-operator/src/shared/serviceidresolver"
@@ -240,8 +239,7 @@ func main() {
 
 	webhooksTrafficNetworkHandler := webhook_traffic.NewNetworkPolicyHandler(mgr.GetClient(),
 		scheme,
-		automate_third_party_network_policy.Off,
-		//enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
+		enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
 		viper.GetInt(operatorconfig.ControlPlaneIPv4CidrPrefixLength),
 		viper.GetBool(operatorconfig.WebhookTrafficAllowAllKey))
 	webhookTrafficReconcilerManager := webhook_traffic.NewWebhookTrafficReconcilerManager(mgr.GetClient(), webhooksTrafficNetworkHandler)

--- a/src/operator/main.go
+++ b/src/operator/main.go
@@ -242,7 +242,8 @@ func main() {
 		scheme,
 		automate_third_party_network_policy.Off,
 		//enforcementConfig.GetAutomateThirdPartyNetworkPolicy(),
-		viper.GetInt(operatorconfig.ControlPlaneIPv4CidrPrefixLength))
+		viper.GetInt(operatorconfig.ControlPlaneIPv4CidrPrefixLength),
+		viper.GetBool(operatorconfig.WebhookTrafficAllowAllKey))
 	webhookTrafficReconcilerManager := webhook_traffic.NewWebhookTrafficReconcilerManager(mgr.GetClient(), webhooksTrafficNetworkHandler)
 
 	if enforcementConfig.EnableLinkerdPolicies {

--- a/src/shared/operatorconfig/config.go
+++ b/src/shared/operatorconfig/config.go
@@ -68,6 +68,8 @@ const (
 	ExternallyManagedPolicyWorkloadsKey           = "externallyManagedPolicyWorkloads"
 	ControlPlaneIPv4CidrPrefixLength              = "control-plane-ipv4-cidr-prefix-length"
 	ControlPlaneIPv4CidrPrefixLengthDefault       = 32
+	WebhookTrafficAllowAllKey                     = "webhook-traffic-allow-all"
+	WebhookTrafficAllowAllDefault                 = true
 )
 
 func init() {
@@ -92,6 +94,7 @@ func init() {
 	viper.SetDefault(EnableGroupInternetIPsByCIDRKey, EnableGroupInternetIPsByCIDRDefault)
 	viper.SetDefault(EnableGroupInternetIPsByCIDRPeersLimitKey, EnableGroupInternetIPsByCIDRPeersLimitDefault)
 	viper.SetDefault(ControlPlaneIPv4CidrPrefixLength, ControlPlaneIPv4CidrPrefixLengthDefault)
+	viper.SetDefault(WebhookTrafficAllowAllKey, WebhookTrafficAllowAllDefault)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
### Description
Improvements for allow webhook traffic feature:
1. Support IPv6 for control plane
2. Get control plane CIDR prefix length from configuration
3. Determine whether to restrict the network policy traffic source to the control plane IP based on configuration (by default - allow all)

### Testing

Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
